### PR TITLE
Spec 002 — Auth scaffolding (login / register / verified email)

### DIFF
--- a/.claude/skills/nexus-spec-workflow/SKILL.md
+++ b/.claude/skills/nexus-spec-workflow/SKILL.md
@@ -38,10 +38,7 @@ If the user is just exploring the codebase, debugging, or making a one-off fix t
    The slug must match the spec file's slug (e.g. `spec/002-auth-scaffolding`).
 4. **Update the spec frontmatter:** `status: in-progress`, bump `updated:` to today's date, add a dated entry in **Work log** noting the branch + issue number.
 5. **Do the work.** Use TaskCreate for the task list inside the spec. Update the spec's `Files touched` as you go.
-6. **Commit incrementally.** One topical commit per logical change is fine; many small commits are fine. Commit messages follow the existing repo style (see `git log`). Always include the trailer:
-   ```
-   Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
-   ```
+6. **Commit incrementally.** One topical commit per logical change is fine; many small commits are fine. Commit messages follow the existing repo style (see `git log`). **Do not add a Co-Authored-By trailer** — the repo owner does not want Claude/Anthropic co-author trailers on commits.
 7. **Self-review pass before opening the PR.** Invoke the `superpowers:code-reviewer` agent on the diff (`git diff main...HEAD`). Capture its findings. Address anything material (real bugs, security issues, missed acceptance criteria) before the PR; surface stylistic suggestions to the user in the PR body but don't necessarily fix them.
 8. **Open the PR** when acceptance criteria are met:
    - Title: `Spec NNN — <spec title>`
@@ -75,7 +72,7 @@ If the user is just exploring the codebase, debugging, or making a one-off fix t
 - Branch: `spec/<NNN>-<slug>` (slug matches spec filename slug)
 - Issue title: `Spec <NNN> — <title>`
 - PR title: `Spec <NNN> — <title>`
-- Commit messages: free-form, but one trailer required: `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+- Commit messages: free-form. **No Co-Authored-By trailer.**
 
 ## Anti-patterns (do not do)
 

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -33,7 +33,7 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
-        return redirect()->intended(route('dashboard', absolute: false));
+        return redirect()->intended(route('overview', absolute: false));
     }
 
     /**

--- a/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -36,6 +36,6 @@ class ConfirmablePasswordController extends Controller
 
         $request->session()->put('auth.password_confirmed_at', time());
 
-        return redirect()->intended(route('dashboard', absolute: false));
+        return redirect()->intended(route('overview', absolute: false));
     }
 }

--- a/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -14,7 +14,7 @@ class EmailVerificationNotificationController extends Controller
     public function store(Request $request): RedirectResponse
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(route('dashboard', absolute: false));
+            return redirect()->intended(route('overview', absolute: false));
         }
 
         $request->user()->sendEmailVerificationNotification();

--- a/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -16,7 +16,7 @@ class EmailVerificationPromptController extends Controller
     public function __invoke(Request $request): RedirectResponse|Response
     {
         return $request->user()->hasVerifiedEmail()
-                    ? redirect()->intended(route('dashboard', absolute: false))
+                    ? redirect()->intended(route('overview', absolute: false))
                     : Inertia::render('Auth/VerifyEmail', ['status' => session('status')]);
     }
 }

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -47,6 +47,6 @@ class RegisteredUserController extends Controller
 
         Auth::login($user);
 
-        return redirect(route('dashboard', absolute: false));
+        return redirect(route('overview', absolute: false));
     }
 }

--- a/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -15,13 +15,13 @@ class VerifyEmailController extends Controller
     public function __invoke(EmailVerificationRequest $request): RedirectResponse
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+            return redirect()->intended(route('overview', absolute: false).'?verified=1');
         }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 
-        return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+        return redirect()->intended(route('overview', absolute: false).'?verified=1');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Database\Factories\UserFactory;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -12,7 +12,7 @@ use Illuminate\Notifications\Notifiable;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, Notifiable;

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -22,7 +22,7 @@ const showingNavigationDropdown = ref(false);
                         <div class="flex">
                             <!-- Logo -->
                             <div class="flex shrink-0 items-center">
-                                <Link :href="route('dashboard')">
+                                <Link :href="route('overview')">
                                     <ApplicationLogo
                                         class="block h-9 w-auto fill-current text-gray-800 dark:text-gray-200"
                                     />
@@ -34,10 +34,10 @@ const showingNavigationDropdown = ref(false);
                                 class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex"
                             >
                                 <NavLink
-                                    :href="route('dashboard')"
-                                    :active="route().current('dashboard')"
+                                    :href="route('overview')"
+                                    :active="route().current('overview')"
                                 >
-                                    Dashboard
+                                    Overview
                                 </NavLink>
                             </div>
                         </div>
@@ -141,10 +141,10 @@ const showingNavigationDropdown = ref(false);
                 >
                     <div class="space-y-1 pb-3 pt-2">
                         <ResponsiveNavLink
-                            :href="route('dashboard')"
-                            :active="route().current('dashboard')"
+                            :href="route('overview')"
+                            :active="route().current('overview')"
                         >
-                            Dashboard
+                            Overview
                         </ResponsiveNavLink>
                     </div>
 

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -4,14 +4,14 @@ import { Head } from '@inertiajs/vue3';
 </script>
 
 <template>
-    <Head title="Dashboard" />
+    <Head title="Overview" />
 
     <AuthenticatedLayout>
         <template #header>
             <h2
                 class="text-xl font-semibold leading-tight text-gray-800 dark:text-gray-200"
             >
-                Dashboard
+                Overview
             </h2>
         </template>
 
@@ -21,7 +21,8 @@ import { Head } from '@inertiajs/vue3';
                     class="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800"
                 >
                     <div class="p-6 text-gray-900 dark:text-gray-100">
-                        You're logged in!
+                        You're logged in. The futuristic Nexus dashboard
+                        lands here in spec 006.
                     </div>
                 </div>
             </div>

--- a/resources/js/Pages/Welcome.vue
+++ b/resources/js/Pages/Welcome.vue
@@ -47,10 +47,10 @@ function handleImageError() {
                     <nav v-if="canLogin" class="-mx-3 flex flex-1 justify-end">
                         <Link
                             v-if="$page.props.auth.user"
-                            :href="route('dashboard')"
+                            :href="route('overview')"
                             class="rounded-md px-3 py-2 text-black ring-1 ring-transparent transition hover:text-black/70 focus:outline-none focus-visible:ring-[#FF2D20] dark:text-white dark:hover:text-white/80 dark:focus-visible:ring-white"
                         >
-                            Dashboard
+                            Overview
                         </Link>
 
                         <template v-else>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,9 +14,9 @@ Route::get('/', function () {
     ]);
 });
 
-Route::get('/dashboard', function () {
-    return Inertia::render('Dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+Route::get('/overview', function () {
+    return Inertia::render('Overview');
+})->middleware(['auth', 'verified'])->name('overview');
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');

--- a/specs/phase-0-foundation/002-auth-scaffolding.md
+++ b/specs/phase-0-foundation/002-auth-scaffolding.md
@@ -1,10 +1,12 @@
 ---
 spec: auth-scaffolding
 phase: 0-foundation
-status: not-started
+status: done
 owner: yoany
 created: 2026-04-27
 updated: 2026-04-27
+issue: https://github.com/Copxer/nexus/issues/1
+branch: spec/002-auth-scaffolding
 ---
 
 # 002 — Auth scaffolding (login / register / verified email)
@@ -39,22 +41,48 @@ Roadmap reference: §16.1 Authentication, §21 Step 1.
 7. Commit.
 
 ## Acceptance criteria
-- [ ] `php artisan test` is fully green (Breeze auth suite + example tests)
-- [ ] Visiting `/login` and `/register` renders Breeze's default forms
-- [ ] Registering a user creates a row in `users` and writes a verification mail to `storage/logs/laravel.log`
-- [ ] Clicking the verification link sets `users.email_verified_at`
-- [ ] After login, the user lands on `/overview` (placeholder page is OK for now)
-- [ ] Hitting `/overview` while unauthenticated redirects to `/login`
-- [ ] Hitting `/overview` while authenticated-but-unverified redirects to `/verify-email`
-- [ ] Logging out returns to `/`
+- [x] `php artisan test` is fully green (Breeze auth suite + example tests) — 25/25 passed
+- [x] Visiting `/login` and `/register` renders Breeze's default forms
+- [x] Registering a user creates a row in `users` and dispatches a verification mail (delivered via Mailtrap SMTP — log driver replaced by user mid-flight)
+- [x] Clicking the verification link sets `users.email_verified_at` (covered by `EmailVerificationTest`)
+- [x] After login, the user lands on `/overview` (placeholder page renders inside `AuthenticatedLayout`)
+- [x] Hitting `/overview` while unauthenticated redirects to `/login`
+- [x] Hitting `/overview` while authenticated-but-unverified redirects to `/verify-email` (required adding `MustVerifyEmail` to `User`)
+- [x] Logging out returns to `/`
 
 ## Files touched
-- (filled in as work progresses)
+- `routes/web.php` — renamed `/dashboard` route to `/overview`, route name `dashboard` → `overview`, render `Overview` component
+- `app/Models/User.php` — implements `Illuminate\Contracts\Auth\MustVerifyEmail` so the `verified` middleware actually enforces verification
+- `app/Http/Controllers/Auth/AuthenticatedSessionController.php` — `route('dashboard')` → `route('overview')`
+- `app/Http/Controllers/Auth/RegisteredUserController.php` — same
+- `app/Http/Controllers/Auth/ConfirmablePasswordController.php` — same
+- `app/Http/Controllers/Auth/VerifyEmailController.php` — same
+- `app/Http/Controllers/Auth/EmailVerificationPromptController.php` — same
+- `app/Http/Controllers/Auth/EmailVerificationNotificationController.php` — same
+- `resources/js/Pages/Overview.vue` — renamed from `Dashboard.vue`, header text + placeholder copy updated
+- `resources/js/Pages/Welcome.vue` — `route('dashboard')` → `route('overview')`, link text "Dashboard" → "Overview"
+- `resources/js/Layouts/AuthenticatedLayout.vue` — same; both desktop nav and responsive nav updated
+- `tests/Feature/Auth/AuthenticationTest.php` — `route('dashboard')` → `route('overview')`
+- `tests/Feature/Auth/RegistrationTest.php` — same
+- `tests/Feature/Auth/EmailVerificationTest.php` — same
 
 ## Work log
 
 ### 2026-04-27
 - Spec drafted.
+- Workflow skill `nexus-spec-workflow` codified; user requested no Co-Authored-By trailer (saved to feedback memory).
+- Opened tracking issue #1 and created branch `spec/002-auth-scaffolding`.
+- Renamed `/dashboard` → `/overview` (route URL + route name) so the rest of Phase 0 can build the real Overview page on this URL. Updated all 6 auth controllers, 3 Breeze tests, the Inertia layout, the Welcome page, and renamed `Dashboard.vue` → `Overview.vue`.
+- Initial test run failed with 23/25 red — root cause was a stale route cache. `php artisan optimize:clear` fixed it.
+- Manual smoke test (curl + cookie jar) showed the `verified` middleware was a no-op even when `email_verified_at` was NULL. Root cause: the `User` model had `MustVerifyEmail` import commented out and didn't implement the interface. Fixed by adding the interface and uncommenting the import.
+- Re-ran tests: 25/25 green. Re-ran smoke test:
+    - unauthenticated `/overview` → 302 → `/login` ✅
+    - register → user row, `email_verified_at = NULL` ✅
+    - authenticated-but-unverified `/overview` → 302 → `/verify-email` ✅
+    - manually verified user → `/overview` returns 200 ✅
+    - logout → 302 → `/` ✅
+    - login again → 302 → `/overview` ✅
+- User configured Mailtrap SMTP mid-flight (replaced `MAIL_MAILER=log`); registration email is now delivered to their Mailtrap inbox.
 
 ## Open questions / blockers
 - None yet.

--- a/specs/phase-0-foundation/README.md
+++ b/specs/phase-0-foundation/README.md
@@ -11,7 +11,7 @@ Stand up a Laravel 12 + Vue 3 + Inertia + Tailwind project with authentication, 
 | # | Task | Status |
 |---|------|--------|
 | 001 | Laravel 13 + Inertia + Vue 3 + TS scaffold | 🟢 |
-| 002 | Auth scaffolding (login / register / verified email) | ⬜ |
+| 002 | Auth scaffolding (login / register / verified email) | 🟢 |
 | 003 | Design tokens + Tailwind theme (dark, glassmorphism, neon accents) | ⬜ |
 | 004 | AppLayout + Sidebar + TopBar + RightActivityRail | ⬜ |
 | 005 | CommandPalette (Cmd+K) shell | ⬜ |

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -27,7 +27,7 @@ class AuthenticationTest extends TestCase
         ]);
 
         $this->assertAuthenticated();
-        $response->assertRedirect(route('dashboard', absolute: false));
+        $response->assertRedirect(route('overview', absolute: false));
     }
 
     public function test_users_can_not_authenticate_with_invalid_password(): void

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -38,7 +38,7 @@ class EmailVerificationTest extends TestCase
 
         Event::assertDispatched(Verified::class);
         $this->assertTrue($user->fresh()->hasVerifiedEmail());
-        $response->assertRedirect(route('dashboard', absolute: false).'?verified=1');
+        $response->assertRedirect(route('overview', absolute: false).'?verified=1');
     }
 
     public function test_email_is_not_verified_with_invalid_hash(): void

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -26,6 +26,6 @@ class RegistrationTest extends TestCase
         ]);
 
         $this->assertAuthenticated();
-        $response->assertRedirect(route('dashboard', absolute: false));
+        $response->assertRedirect(route('overview', absolute: false));
     }
 }


### PR DESCRIPTION
Closes #1

Spec: [`specs/phase-0-foundation/002-auth-scaffolding.md`](specs/phase-0-foundation/002-auth-scaffolding.md)

## Summary
- Renamed `/dashboard` route (URL + name) to `/overview` so the futuristic dashboard from the roadmap can land on the URL that matches the sidebar nav. Renamed `Dashboard.vue` → `Overview.vue`.
- Made the `User` model implement `MustVerifyEmail` (Breeze ships it commented out) so the `verified` middleware actually enforces email verification on protected routes.
- Updated all 6 Breeze auth controllers, the Inertia layout, the Welcome page, and the 3 affected auth tests for the new route name.
- Tightened the workflow skill to drop the Co-Authored-By trailer per project preference.

## Test plan
- [x] `php artisan test` is fully green (25/25)
- [x] Visiting `/login` and `/register` renders Breeze's default forms
- [x] Registering a user creates a row in `users` and dispatches a verification mail (delivered via Mailtrap SMTP)
- [x] Clicking the verification link sets `users.email_verified_at` (`EmailVerificationTest`)
- [x] After login, the user lands on `/overview`
- [x] Hitting `/overview` while unauthenticated redirects to `/login`
- [x] Hitting `/overview` while authenticated-but-unverified redirects to `/verify-email`
- [x] Logging out returns to `/`

## Notes
Visual restyling of auth pages is **out of scope** here — they still use Breeze's default styling and will be themed in spec 003 (design tokens) and spec 004 (layout).