### PR TITLE
chore(workflow): require all commits go through a PR

### DIFF
--- a/.claude/skills/nexus-spec-workflow/SKILL.md
+++ b/.claude/skills/nexus-spec-workflow/SKILL.md
@@ -69,15 +69,16 @@ If the user is just exploring the codebase, debugging, or making a one-off fix t
 ## Naming conventions (locked)
 
 - Spec file: `specs/phase-<N>-<phase-slug>/<NNN>-<slug>.md`
-- Branch: `spec/<NNN>-<slug>` (slug matches spec filename slug)
-- Issue title: `Spec <NNN> — <title>`
-- PR title: `Spec <NNN> — <title>`
+- Spec branch: `spec/<NNN>-<slug>` (slug matches spec filename slug)
+- Spec issue title: `Spec <NNN> — <title>`
+- Spec PR title: `Spec <NNN> — <title>`
+- Non-spec branches (tooling, CI tweaks, docs, hotfixes, etc.): `<type>/<slug>` where `<type>` matches the conventional-commit prefix — `chore/`, `fix/`, `docs/`, `refactor/`, `ci/`. PR title uses the same prefix in conventional-commit form (e.g. `chore(workflow): drop trailer requirement`). Non-spec PRs do not need a backing GitHub issue unless the work warrants one.
 - Commit messages: free-form. **No Co-Authored-By trailer.**
 
 ## Anti-patterns (do not do)
 
 - Opening a separate GitHub issue per task within a spec — the spec markdown's checklist is the single source of truth for sub-task progress.
-- Working directly on `main` (spec 001 was committed to main as a one-time bootstrap exception; small workflow/tooling commits like CI changes or skill updates may go on main directly with a `chore:` prefix, but never spec implementation work).
+- Working directly on `main`. Every change — spec, chore, fix, doc — goes through a branch and a PR. Spec 001 was the one-time bootstrap exception. The "Protect main" ruleset rejects any push to `main` that doesn't have a green `ci` check, so direct-push attempts will be rejected even if attempted.
 - Pushing `--force` to `main` or any shared branch.
 - Auto-merging the PR. Always pause for review unless the user explicitly says "merge it" or has put the auto-merge instruction in CLAUDE.md.
 - Skipping the self-review pass. Even when the change is small, running `superpowers:code-reviewer` is cheap and catches things.

--- a/specs/README.md
+++ b/specs/README.md
@@ -72,9 +72,10 @@ Every spec is shipped as a GitHub issue + branch + PR. The detailed flow lives i
 7. **CI must be green.** `.github/workflows/ci.yml` runs Pint, `php artisan test`, and `npm run build`. Branch protection on `main` requires it.
 8. **Wait for the user.** No auto-merge. After explicit go-ahead, squash-merge with `gh pr merge --squash --delete-branch`.
 9. **Verify the issue closed as completed** (`gh issue view <n> --json state,stateReason`). Manual fallback: `gh issue close <n> --reason completed`.
-10. **Bookkeeping commit on `main`:** flip spec frontmatter to `done`, update tracker tables in this file and the phase README.
+10. **Spec & tracker bookkeeping** ride inside the same spec PR — flip spec frontmatter to `done` and update tracker tables before opening the PR, so when it merges, `main` is consistent in one shot.
 
 ### Notes
-- Spec 001 (initial scaffold) was committed directly to `main` to bootstrap the repo. From spec 002 onward we use the issue → branch → PR flow.
+- Spec 001 (initial scaffold) was committed directly to `main` to bootstrap the repo. From spec 002 onward every change flows through a PR.
 - Tasks *within* a spec are tracked as a checklist in the spec file (and in the local `TaskCreate` list during the active session). They do **not** get their own GitHub issues — that would be too noisy.
-- Tooling/workflow changes (CI tweaks, skill updates, etc.) may go on `main` directly with a `chore:` prefix. Spec implementation never goes to `main` directly.
+- Non-spec changes (tooling, CI tweaks, skill updates, hotfixes, doc-only edits) also go through a PR. Branch naming: `<type>/<slug>` matching the conventional-commit prefix (`chore/`, `fix/`, `docs/`, `refactor/`, `ci/`). PR title uses the same prefix.
+- The "Protect main" ruleset enforces this: pushes to `main` are rejected unless they carry a green `ci` check, which only PRs can produce.


### PR DESCRIPTION
The new "Protect main" ruleset rejects direct pushes to `main` without a green `ci` check, which only PRs can produce. Update the workflow skill and `specs/README.md` so the docs match what's actually enforced.

Also adds a branch-naming convention for non-spec changes: `<type>/<slug>` matching the conventional-commit prefix (`chore/`, `fix/`, `docs/`, `refactor/`, `ci/`).

## Test plan
- [x] CI green
- [x] Skill no longer says "small chore commits may go on main directly"
- [x] specs/README.md mirrors the same rule

## Self-review notes
- Pure docs change. No runtime effect.