### PR TITLE
Spec 003 — Design tokens + Tailwind theme (dark, glassmorphism, neon accents)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,8 @@
     "packages": {
         "": {
             "dependencies": {
+                "@fontsource/inter": "^5.2.8",
+                "@fontsource/jetbrains-mono": "^5.2.8",
                 "axios": "^1.15.2"
             },
             "devDependencies": {
@@ -118,6 +120,24 @@
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@fontsource/inter": {
+            "version": "5.2.8",
+            "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+            "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+            "license": "OFL-1.1",
+            "funding": {
+                "url": "https://github.com/sponsors/ayuhito"
+            }
+        },
+        "node_modules/@fontsource/jetbrains-mono": {
+            "version": "5.2.8",
+            "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+            "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+            "license": "OFL-1.1",
+            "funding": {
+                "url": "https://github.com/sponsors/ayuhito"
             }
         },
         "node_modules/@inertiajs/core": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
         "vue-tsc": "^2.0.24"
     },
     "dependencies": {
+        "@fontsource/inter": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "axios": "^1.15.2"
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,69 @@
+/* Webfonts — bundled with the build via @fontsource (no CDN, no FOUT). */
+@import '@fontsource/inter/400.css';
+@import '@fontsource/inter/500.css';
+@import '@fontsource/inter/600.css';
+@import '@fontsource/inter/700.css';
+@import '@fontsource/jetbrains-mono/400.css';
+@import '@fontsource/jetbrains-mono/500.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+    html {
+        @apply h-full bg-background-base text-text-primary antialiased;
+    }
+
+    body {
+        @apply min-h-full bg-app-gradient bg-fixed font-sans;
+    }
+
+    ::selection {
+        background-color: rgba(34, 211, 238, 0.35);
+        color: #f8fafc;
+    }
+
+    /* Slimmer, theme-aware scrollbar — Webkit + Firefox. */
+    * {
+        scrollbar-width: thin;
+        scrollbar-color: rgba(148, 163, 184, 0.25) transparent;
+    }
+
+    *::-webkit-scrollbar {
+        width: 10px;
+        height: 10px;
+    }
+
+    *::-webkit-scrollbar-track {
+        background: transparent;
+    }
+
+    *::-webkit-scrollbar-thumb {
+        background-color: rgba(148, 163, 184, 0.25);
+        border-radius: 9999px;
+        border: 2px solid transparent;
+        background-clip: padding-box;
+    }
+
+    *::-webkit-scrollbar-thumb:hover {
+        background-color: rgba(34, 211, 238, 0.5);
+    }
+}
+
+@layer components {
+    /* Glass-morphism panel — the canonical card chrome from
+       specs/visual-reference.md. Drop on any container that holds a widget. */
+    .glass-card {
+        @apply rounded-2xl border border-border-subtle bg-background-panel
+               shadow-panel backdrop-blur-xl transition
+               hover:border-border-active hover:bg-background-panel-hover;
+    }
+
+    /* Numeric helpers — use on metric values, host names, container IDs,
+       commit hashes, anywhere the eye should align numbers vertically. */
+    .font-display {
+        font-feature-settings: 'tnum' on, 'lnum' on, 'cv11' on;
+        letter-spacing: -0.01em;
+    }
+}

--- a/resources/js/Components/Checkbox.vue
+++ b/resources/js/Components/Checkbox.vue
@@ -24,6 +24,6 @@ const proxyChecked = computed({
         type="checkbox"
         :value="value"
         v-model="proxyChecked"
-        class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:focus:ring-indigo-600 dark:focus:ring-offset-gray-800"
+        class="rounded border-border-subtle bg-slate-950/60 text-accent-cyan shadow-inner shadow-black/20 focus:ring-2 focus:ring-accent-cyan/50 focus:ring-offset-0"
     />
 </template>

--- a/resources/js/Components/DangerButton.vue
+++ b/resources/js/Components/DangerButton.vue
@@ -1,6 +1,6 @@
 <template>
     <button
-        class="inline-flex items-center rounded-md border border-transparent bg-red-600 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 active:bg-red-700 dark:focus:ring-offset-gray-800"
+        class="inline-flex items-center justify-center rounded-lg border border-status-danger/40 bg-status-danger/10 px-5 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-status-danger shadow-glow-danger transition hover:border-status-danger/70 hover:bg-status-danger/20 focus:outline-none focus:ring-2 focus:ring-status-danger/60 active:bg-status-danger/25 disabled:cursor-not-allowed disabled:opacity-50"
     >
         <slot />
     </button>

--- a/resources/js/Components/Dropdown.vue
+++ b/resources/js/Components/Dropdown.vue
@@ -10,7 +10,7 @@ const props = withDefaults(
     {
         align: 'right',
         width: '48',
-        contentClasses: 'py-1 bg-white dark:bg-gray-700',
+        contentClasses: 'py-1 bg-background-panel backdrop-blur-xl',
     },
 );
 
@@ -71,7 +71,7 @@ const open = ref(false);
                 @click="open = false"
             >
                 <div
-                    class="rounded-md ring-1 ring-black ring-opacity-5"
+                    class="overflow-hidden rounded-lg border border-border-subtle shadow-panel"
                     :class="contentClasses"
                 >
                     <slot name="content" />

--- a/resources/js/Components/DropdownLink.vue
+++ b/resources/js/Components/DropdownLink.vue
@@ -9,7 +9,7 @@ defineProps<{
 <template>
     <Link
         :href="href"
-        class="block w-full px-4 py-2 text-start text-sm leading-5 text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 focus:bg-gray-100 focus:outline-none dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
+        class="block w-full px-4 py-2 text-start text-sm leading-5 text-text-secondary transition hover:bg-background-panel-hover hover:text-text-primary focus:bg-background-panel-hover focus:outline-none"
     >
         <slot />
     </Link>

--- a/resources/js/Components/InputError.vue
+++ b/resources/js/Components/InputError.vue
@@ -6,7 +6,7 @@ defineProps<{
 
 <template>
     <div v-show="message">
-        <p class="text-sm text-red-600 dark:text-red-400">
+        <p class="text-xs font-medium text-status-danger">
             {{ message }}
         </p>
     </div>

--- a/resources/js/Components/InputLabel.vue
+++ b/resources/js/Components/InputLabel.vue
@@ -5,7 +5,7 @@ defineProps<{
 </script>
 
 <template>
-    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+    <label class="block text-xs font-semibold uppercase tracking-[0.18em] text-text-secondary">
         <span v-if="value">{{ value }}</span>
         <span v-else><slot /></span>
     </label>

--- a/resources/js/Components/NavLink.vue
+++ b/resources/js/Components/NavLink.vue
@@ -9,8 +9,8 @@ const props = defineProps<{
 
 const classes = computed(() =>
     props.active
-        ? 'inline-flex items-center px-1 pt-1 border-b-2 border-indigo-400 dark:border-indigo-600 text-sm font-medium leading-5 text-gray-900 dark:text-gray-100 focus:outline-none focus:border-indigo-700 transition duration-150 ease-in-out'
-        : 'inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-700 focus:outline-none focus:text-gray-700 dark:focus:text-gray-300 focus:border-gray-300 dark:focus:border-gray-700 transition duration-150 ease-in-out',
+        ? 'inline-flex items-center border-b-2 border-accent-cyan px-1 pt-1 text-sm font-medium leading-5 text-text-primary transition focus:outline-none'
+        : 'inline-flex items-center border-b-2 border-transparent px-1 pt-1 text-sm font-medium leading-5 text-text-muted transition hover:border-border-active hover:text-text-primary focus:outline-none',
 );
 </script>
 

--- a/resources/js/Components/PrimaryButton.vue
+++ b/resources/js/Components/PrimaryButton.vue
@@ -1,6 +1,6 @@
 <template>
     <button
-        class="inline-flex items-center rounded-md border border-transparent bg-gray-800 px-4 py-2 text-xs font-semibold uppercase tracking-widest text-white transition duration-150 ease-in-out hover:bg-gray-700 focus:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 active:bg-gray-900 dark:bg-gray-200 dark:text-gray-800 dark:hover:bg-white dark:focus:bg-white dark:focus:ring-offset-gray-800 dark:active:bg-gray-300"
+        class="inline-flex items-center justify-center rounded-lg border border-accent-cyan/40 bg-accent-cyan/10 px-5 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-accent-cyan shadow-glow-cyan transition hover:border-accent-cyan/70 hover:bg-accent-cyan/20 focus:outline-none focus:ring-2 focus:ring-accent-cyan/60 active:bg-accent-cyan/25 disabled:cursor-not-allowed disabled:opacity-50"
     >
         <slot />
     </button>

--- a/resources/js/Components/ResponsiveNavLink.vue
+++ b/resources/js/Components/ResponsiveNavLink.vue
@@ -9,8 +9,8 @@ const props = defineProps<{
 
 const classes = computed(() =>
     props.active
-        ? 'block w-full ps-3 pe-4 py-2 border-l-4 border-indigo-400 dark:border-indigo-600 text-start text-base font-medium text-indigo-700 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/50 focus:outline-none focus:text-indigo-800 dark:focus:text-indigo-200 focus:bg-indigo-100 dark:focus:bg-indigo-900 focus:border-indigo-700 dark:focus:border-indigo-300 transition duration-150 ease-in-out'
-        : 'block w-full ps-3 pe-4 py-2 border-l-4 border-transparent text-start text-base font-medium text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-300 dark:hover:border-gray-600 focus:outline-none focus:text-gray-800 dark:focus:text-gray-200 focus:bg-gray-50 dark:focus:bg-gray-700 focus:border-gray-300 dark:focus:border-gray-600 transition duration-150 ease-in-out',
+        ? 'block w-full border-l-4 border-accent-cyan bg-accent-cyan/10 py-2 pe-4 ps-3 text-start text-base font-medium text-text-primary transition focus:outline-none'
+        : 'block w-full border-l-4 border-transparent py-2 pe-4 ps-3 text-start text-base font-medium text-text-muted transition hover:border-border-active hover:bg-background-panel-hover hover:text-text-primary focus:outline-none',
 );
 </script>
 

--- a/resources/js/Components/SecondaryButton.vue
+++ b/resources/js/Components/SecondaryButton.vue
@@ -12,7 +12,7 @@ withDefaults(
 <template>
     <button
         :type="type"
-        class="inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-widest text-gray-700 shadow-sm transition duration-150 ease-in-out hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-25 dark:border-gray-500 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-offset-gray-800"
+        class="inline-flex items-center justify-center rounded-lg border border-border-subtle bg-slate-900/60 px-5 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-text-secondary transition hover:border-accent-cyan/40 hover:text-text-primary focus:outline-none focus:ring-2 focus:ring-accent-cyan/40 disabled:opacity-40"
     >
         <slot />
     </button>

--- a/resources/js/Components/TextInput.vue
+++ b/resources/js/Components/TextInput.vue
@@ -16,7 +16,7 @@ defineExpose({ focus: () => input.value?.focus() });
 
 <template>
     <input
-        class="rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus:border-indigo-600 dark:focus:ring-indigo-600"
+        class="rounded-lg border border-border-subtle bg-slate-950/60 px-3 py-2 text-text-primary placeholder:text-text-muted shadow-inner shadow-black/20 transition focus:border-accent-cyan focus:ring-2 focus:ring-accent-cyan/40 focus:ring-offset-0"
         v-model="model"
         ref="input"
     />

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -12,9 +12,9 @@ const showingNavigationDropdown = ref(false);
 
 <template>
     <div>
-        <div class="min-h-screen bg-gray-100 dark:bg-gray-900">
+        <div class="min-h-screen bg-app-gradient">
             <nav
-                class="border-b border-gray-100 bg-white dark:border-gray-700 dark:bg-gray-800"
+                class="border-b border-border-subtle bg-background-panel backdrop-blur-xl"
             >
                 <!-- Primary Navigation Menu -->
                 <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -22,10 +22,18 @@ const showingNavigationDropdown = ref(false);
                         <div class="flex">
                             <!-- Logo -->
                             <div class="flex shrink-0 items-center">
-                                <Link :href="route('overview')">
+                                <Link
+                                    :href="route('overview')"
+                                    class="flex items-center gap-2"
+                                >
                                     <ApplicationLogo
-                                        class="block h-9 w-auto fill-current text-gray-800 dark:text-gray-200"
+                                        class="block h-8 w-auto fill-current text-accent-cyan drop-shadow-[0_0_12px_rgba(34,211,238,0.45)]"
                                     />
+                                    <span
+                                        class="text-sm font-semibold uppercase tracking-[0.28em] text-text-secondary"
+                                    >
+                                        Nexus
+                                    </span>
                                 </Link>
                             </div>
 
@@ -50,7 +58,7 @@ const showingNavigationDropdown = ref(false);
                                         <span class="inline-flex rounded-md">
                                             <button
                                                 type="button"
-                                                class="inline-flex items-center rounded-md border border-transparent bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-500 transition duration-150 ease-in-out hover:text-gray-700 focus:outline-none dark:bg-gray-800 dark:text-gray-400 dark:hover:text-gray-300"
+                                                class="inline-flex items-center rounded-lg border border-border-subtle bg-slate-950/50 px-3 py-2 text-sm font-medium leading-4 text-text-secondary transition hover:border-border-active hover:text-text-primary focus:outline-none"
                                             >
                                                 {{ $page.props.auth.user.name }}
 
@@ -95,7 +103,7 @@ const showingNavigationDropdown = ref(false);
                                     showingNavigationDropdown =
                                         !showingNavigationDropdown
                                 "
-                                class="inline-flex items-center justify-center rounded-md p-2 text-gray-400 transition duration-150 ease-in-out hover:bg-gray-100 hover:text-gray-500 focus:bg-gray-100 focus:text-gray-500 focus:outline-none dark:text-gray-500 dark:hover:bg-gray-900 dark:hover:text-gray-400 dark:focus:bg-gray-900 dark:focus:text-gray-400"
+                                class="inline-flex items-center justify-center rounded-md p-2 text-text-muted transition hover:bg-background-panel-hover hover:text-text-secondary focus:bg-background-panel-hover focus:outline-none"
                             >
                                 <svg
                                     class="h-6 w-6"
@@ -149,16 +157,12 @@ const showingNavigationDropdown = ref(false);
                     </div>
 
                     <!-- Responsive Settings Options -->
-                    <div
-                        class="border-t border-gray-200 pb-1 pt-4 dark:border-gray-600"
-                    >
+                    <div class="border-t border-border-subtle pb-1 pt-4">
                         <div class="px-4">
-                            <div
-                                class="text-base font-medium text-gray-800 dark:text-gray-200"
-                            >
+                            <div class="text-base font-medium text-text-primary">
                                 {{ $page.props.auth.user.name }}
                             </div>
-                            <div class="text-sm font-medium text-gray-500">
+                            <div class="text-sm font-medium text-text-muted">
                                 {{ $page.props.auth.user.email }}
                             </div>
                         </div>
@@ -181,7 +185,7 @@ const showingNavigationDropdown = ref(false);
 
             <!-- Page Heading -->
             <header
-                class="bg-white shadow dark:bg-gray-800"
+                class="border-b border-border-subtle bg-background-panel/60 backdrop-blur-xl"
                 v-if="$slots.header"
             >
                 <div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -14,7 +14,7 @@ const showingNavigationDropdown = ref(false);
     <div>
         <div class="min-h-screen bg-app-gradient">
             <nav
-                class="border-b border-border-subtle bg-background-panel backdrop-blur-xl"
+                class="relative z-30 border-b border-border-subtle bg-background-panel backdrop-blur-xl"
             >
                 <!-- Primary Navigation Menu -->
                 <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">

--- a/resources/js/Layouts/GuestLayout.vue
+++ b/resources/js/Layouts/GuestLayout.vue
@@ -5,16 +5,31 @@ import { Link } from '@inertiajs/vue3';
 
 <template>
     <div
-        class="flex min-h-screen flex-col items-center bg-gray-100 pt-6 sm:justify-center sm:pt-0 dark:bg-gray-900"
+        class="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-app-gradient px-4 py-12 sm:px-6"
     >
-        <div>
-            <Link href="/">
-                <ApplicationLogo class="h-20 w-20 fill-current text-gray-500" />
+        <!-- Soft neon ambient glows behind the card. -->
+        <div
+            aria-hidden="true"
+            class="pointer-events-none absolute -top-40 left-1/2 h-[480px] w-[480px] -translate-x-1/2 rounded-full bg-accent-cyan/10 blur-3xl"
+        />
+        <div
+            aria-hidden="true"
+            class="pointer-events-none absolute -bottom-40 right-10 h-[420px] w-[420px] rounded-full bg-accent-purple/10 blur-3xl"
+        />
+
+        <div class="relative">
+            <Link href="/" class="flex flex-col items-center gap-3">
+                <ApplicationLogo
+                    class="h-14 w-14 fill-current text-accent-cyan drop-shadow-[0_0_18px_rgba(34,211,238,0.55)]"
+                />
+                <span class="text-sm font-semibold uppercase tracking-[0.32em] text-text-secondary">
+                    Nexus Control Center
+                </span>
             </Link>
         </div>
 
         <div
-            class="mt-6 w-full overflow-hidden bg-white px-6 py-4 shadow-md sm:max-w-md sm:rounded-lg dark:bg-gray-800"
+            class="glass-card relative mt-8 w-full px-8 py-9 sm:max-w-md"
         >
             <slot />
         </div>

--- a/resources/js/Pages/Auth/ConfirmPassword.vue
+++ b/resources/js/Pages/Auth/ConfirmPassword.vue
@@ -23,18 +23,20 @@ const submit = () => {
     <GuestLayout>
         <Head title="Confirm Password" />
 
-        <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
-            This is a secure area of the application. Please confirm your
-            password before continuing.
-        </div>
+        <h1 class="text-xl font-semibold text-text-primary">
+            Confirm your password
+        </h1>
+        <p class="mt-2 text-sm text-text-secondary">
+            This is a secure area. Re-enter your password to continue.
+        </p>
 
-        <form @submit.prevent="submit">
+        <form class="mt-6 space-y-5" @submit.prevent="submit">
             <div>
                 <InputLabel for="password" value="Password" />
                 <TextInput
                     id="password"
                     type="password"
-                    class="mt-1 block w-full"
+                    class="mt-2 block w-full"
                     v-model="form.password"
                     required
                     autocomplete="current-password"
@@ -43,15 +45,13 @@ const submit = () => {
                 <InputError class="mt-2" :message="form.errors.password" />
             </div>
 
-            <div class="mt-4 flex justify-end">
-                <PrimaryButton
-                    class="ms-4"
-                    :class="{ 'opacity-25': form.processing }"
-                    :disabled="form.processing"
-                >
-                    Confirm
-                </PrimaryButton>
-            </div>
+            <PrimaryButton
+                class="w-full"
+                :class="{ 'opacity-50': form.processing }"
+                :disabled="form.processing"
+            >
+                Confirm
+            </PrimaryButton>
         </form>
     </GuestLayout>
 </template>

--- a/resources/js/Pages/Auth/ForgotPassword.vue
+++ b/resources/js/Pages/Auth/ForgotPassword.vue
@@ -23,27 +23,29 @@ const submit = () => {
     <GuestLayout>
         <Head title="Forgot Password" />
 
-        <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
-            Forgot your password? No problem. Just let us know your email
-            address and we will email you a password reset link that will allow
-            you to choose a new one.
-        </div>
+        <h1 class="text-xl font-semibold text-text-primary">
+            Reset your password
+        </h1>
+        <p class="mt-2 text-sm text-text-secondary">
+            Enter your email and we'll send you a one-time link to set a new
+            password.
+        </p>
 
         <div
             v-if="status"
-            class="mb-4 text-sm font-medium text-green-600 dark:text-green-400"
+            class="mt-4 rounded-lg border border-status-success/40 bg-status-success/10 px-3 py-2 text-sm font-medium text-status-success"
         >
             {{ status }}
         </div>
 
-        <form @submit.prevent="submit">
+        <form class="mt-6 space-y-5" @submit.prevent="submit">
             <div>
                 <InputLabel for="email" value="Email" />
 
                 <TextInput
                     id="email"
                     type="email"
-                    class="mt-1 block w-full"
+                    class="mt-2 block w-full"
                     v-model="form.email"
                     required
                     autofocus
@@ -53,14 +55,13 @@ const submit = () => {
                 <InputError class="mt-2" :message="form.errors.email" />
             </div>
 
-            <div class="mt-4 flex items-center justify-end">
-                <PrimaryButton
-                    :class="{ 'opacity-25': form.processing }"
-                    :disabled="form.processing"
-                >
-                    Email Password Reset Link
-                </PrimaryButton>
-            </div>
+            <PrimaryButton
+                class="w-full"
+                :class="{ 'opacity-50': form.processing }"
+                :disabled="form.processing"
+            >
+                Email password reset link
+            </PrimaryButton>
         </form>
     </GuestLayout>
 </template>

--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -34,7 +34,7 @@ const submit = () => {
         <h1 class="text-xl font-semibold text-text-primary">
             Sign in
         </h1>
-        <p class="mt-1 text-sm text-text-muted">
+        <p class="mt-2 text-sm text-text-secondary">
             Welcome back to your command center.
         </p>
 
@@ -86,7 +86,7 @@ const submit = () => {
                 <Link
                     v-if="canResetPassword"
                     :href="route('password.request')"
-                    class="text-sm text-text-muted transition hover:text-accent-cyan focus:outline-none"
+                    class="text-sm text-text-secondary transition hover:text-accent-cyan focus:outline-none"
                 >
                     Forgot your password?
                 </Link>
@@ -101,7 +101,7 @@ const submit = () => {
             </PrimaryButton>
         </form>
 
-        <p class="mt-6 text-center text-sm text-text-muted">
+        <p class="mt-6 text-center text-sm text-text-secondary">
             New here?
             <Link
                 :href="route('register')"

--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -31,18 +31,28 @@ const submit = () => {
     <GuestLayout>
         <Head title="Log in" />
 
-        <div v-if="status" class="mb-4 text-sm font-medium text-green-600">
+        <h1 class="text-xl font-semibold text-text-primary">
+            Sign in
+        </h1>
+        <p class="mt-1 text-sm text-text-muted">
+            Welcome back to your command center.
+        </p>
+
+        <div
+            v-if="status"
+            class="mt-4 rounded-lg border border-status-success/40 bg-status-success/10 px-3 py-2 text-sm font-medium text-status-success"
+        >
             {{ status }}
         </div>
 
-        <form @submit.prevent="submit">
+        <form class="mt-6 space-y-5" @submit.prevent="submit">
             <div>
                 <InputLabel for="email" value="Email" />
 
                 <TextInput
                     id="email"
                     type="email"
-                    class="mt-1 block w-full"
+                    class="mt-2 block w-full"
                     v-model="form.email"
                     required
                     autofocus
@@ -52,13 +62,13 @@ const submit = () => {
                 <InputError class="mt-2" :message="form.errors.email" />
             </div>
 
-            <div class="mt-4">
+            <div>
                 <InputLabel for="password" value="Password" />
 
                 <TextInput
                     id="password"
                     type="password"
-                    class="mt-1 block w-full"
+                    class="mt-2 block w-full"
                     v-model="form.password"
                     required
                     autocomplete="current-password"
@@ -67,32 +77,38 @@ const submit = () => {
                 <InputError class="mt-2" :message="form.errors.password" />
             </div>
 
-            <div class="mt-4 block">
-                <label class="flex items-center">
+            <div class="flex items-center justify-between">
+                <label class="flex items-center gap-2">
                     <Checkbox name="remember" v-model:checked="form.remember" />
-                    <span class="ms-2 text-sm text-gray-600 dark:text-gray-400"
-                        >Remember me</span
-                    >
+                    <span class="text-sm text-text-secondary">Remember me</span>
                 </label>
-            </div>
 
-            <div class="mt-4 flex items-center justify-end">
                 <Link
                     v-if="canResetPassword"
                     :href="route('password.request')"
-                    class="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:text-gray-400 dark:hover:text-gray-100 dark:focus:ring-offset-gray-800"
+                    class="text-sm text-text-muted transition hover:text-accent-cyan focus:outline-none"
                 >
                     Forgot your password?
                 </Link>
-
-                <PrimaryButton
-                    class="ms-4"
-                    :class="{ 'opacity-25': form.processing }"
-                    :disabled="form.processing"
-                >
-                    Log in
-                </PrimaryButton>
             </div>
+
+            <PrimaryButton
+                class="w-full"
+                :class="{ 'opacity-50': form.processing }"
+                :disabled="form.processing"
+            >
+                Log in
+            </PrimaryButton>
         </form>
+
+        <p class="mt-6 text-center text-sm text-text-muted">
+            New here?
+            <Link
+                :href="route('register')"
+                class="font-semibold text-accent-cyan transition hover:text-accent-cyan/80"
+            >
+                Create an account
+            </Link>
+        </p>
     </GuestLayout>
 </template>

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -26,14 +26,21 @@ const submit = () => {
     <GuestLayout>
         <Head title="Register" />
 
-        <form @submit.prevent="submit">
+        <h1 class="text-xl font-semibold text-text-primary">
+            Create your account
+        </h1>
+        <p class="mt-1 text-sm text-text-muted">
+            Spin up your control center.
+        </p>
+
+        <form class="mt-6 space-y-5" @submit.prevent="submit">
             <div>
                 <InputLabel for="name" value="Name" />
 
                 <TextInput
                     id="name"
                     type="text"
-                    class="mt-1 block w-full"
+                    class="mt-2 block w-full"
                     v-model="form.name"
                     required
                     autofocus
@@ -43,13 +50,13 @@ const submit = () => {
                 <InputError class="mt-2" :message="form.errors.name" />
             </div>
 
-            <div class="mt-4">
+            <div>
                 <InputLabel for="email" value="Email" />
 
                 <TextInput
                     id="email"
                     type="email"
-                    class="mt-1 block w-full"
+                    class="mt-2 block w-full"
                     v-model="form.email"
                     required
                     autocomplete="username"
@@ -58,13 +65,13 @@ const submit = () => {
                 <InputError class="mt-2" :message="form.errors.email" />
             </div>
 
-            <div class="mt-4">
+            <div>
                 <InputLabel for="password" value="Password" />
 
                 <TextInput
                     id="password"
                     type="password"
-                    class="mt-1 block w-full"
+                    class="mt-2 block w-full"
                     v-model="form.password"
                     required
                     autocomplete="new-password"
@@ -73,7 +80,7 @@ const submit = () => {
                 <InputError class="mt-2" :message="form.errors.password" />
             </div>
 
-            <div class="mt-4">
+            <div>
                 <InputLabel
                     for="password_confirmation"
                     value="Confirm Password"
@@ -82,7 +89,7 @@ const submit = () => {
                 <TextInput
                     id="password_confirmation"
                     type="password"
-                    class="mt-1 block w-full"
+                    class="mt-2 block w-full"
                     v-model="form.password_confirmation"
                     required
                     autocomplete="new-password"
@@ -94,22 +101,23 @@ const submit = () => {
                 />
             </div>
 
-            <div class="mt-4 flex items-center justify-end">
-                <Link
-                    :href="route('login')"
-                    class="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:text-gray-400 dark:hover:text-gray-100 dark:focus:ring-offset-gray-800"
-                >
-                    Already registered?
-                </Link>
-
-                <PrimaryButton
-                    class="ms-4"
-                    :class="{ 'opacity-25': form.processing }"
-                    :disabled="form.processing"
-                >
-                    Register
-                </PrimaryButton>
-            </div>
+            <PrimaryButton
+                class="w-full"
+                :class="{ 'opacity-50': form.processing }"
+                :disabled="form.processing"
+            >
+                Register
+            </PrimaryButton>
         </form>
+
+        <p class="mt-6 text-center text-sm text-text-muted">
+            Already have an account?
+            <Link
+                :href="route('login')"
+                class="font-semibold text-accent-cyan transition hover:text-accent-cyan/80"
+            >
+                Sign in
+            </Link>
+        </p>
     </GuestLayout>
 </template>

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -29,7 +29,7 @@ const submit = () => {
         <h1 class="text-xl font-semibold text-text-primary">
             Create your account
         </h1>
-        <p class="mt-1 text-sm text-text-muted">
+        <p class="mt-2 text-sm text-text-secondary">
             Spin up your control center.
         </p>
 
@@ -110,7 +110,7 @@ const submit = () => {
             </PrimaryButton>
         </form>
 
-        <p class="mt-6 text-center text-sm text-text-muted">
+        <p class="mt-6 text-center text-sm text-text-secondary">
             Already have an account?
             <Link
                 :href="route('login')"

--- a/resources/js/Pages/Auth/ResetPassword.vue
+++ b/resources/js/Pages/Auth/ResetPassword.vue
@@ -31,14 +31,21 @@ const submit = () => {
     <GuestLayout>
         <Head title="Reset Password" />
 
-        <form @submit.prevent="submit">
+        <h1 class="text-xl font-semibold text-text-primary">
+            Choose a new password
+        </h1>
+        <p class="mt-2 text-sm text-text-secondary">
+            Pick something you haven't used before.
+        </p>
+
+        <form class="mt-6 space-y-5" @submit.prevent="submit">
             <div>
                 <InputLabel for="email" value="Email" />
 
                 <TextInput
                     id="email"
                     type="email"
-                    class="mt-1 block w-full"
+                    class="mt-2 block w-full"
                     v-model="form.email"
                     required
                     autofocus
@@ -48,13 +55,13 @@ const submit = () => {
                 <InputError class="mt-2" :message="form.errors.email" />
             </div>
 
-            <div class="mt-4">
+            <div>
                 <InputLabel for="password" value="Password" />
 
                 <TextInput
                     id="password"
                     type="password"
-                    class="mt-1 block w-full"
+                    class="mt-2 block w-full"
                     v-model="form.password"
                     required
                     autocomplete="new-password"
@@ -63,7 +70,7 @@ const submit = () => {
                 <InputError class="mt-2" :message="form.errors.password" />
             </div>
 
-            <div class="mt-4">
+            <div>
                 <InputLabel
                     for="password_confirmation"
                     value="Confirm Password"
@@ -72,7 +79,7 @@ const submit = () => {
                 <TextInput
                     id="password_confirmation"
                     type="password"
-                    class="mt-1 block w-full"
+                    class="mt-2 block w-full"
                     v-model="form.password_confirmation"
                     required
                     autocomplete="new-password"
@@ -84,14 +91,13 @@ const submit = () => {
                 />
             </div>
 
-            <div class="mt-4 flex items-center justify-end">
-                <PrimaryButton
-                    :class="{ 'opacity-25': form.processing }"
-                    :disabled="form.processing"
-                >
-                    Reset Password
-                </PrimaryButton>
-            </div>
+            <PrimaryButton
+                class="w-full"
+                :class="{ 'opacity-50': form.processing }"
+                :disabled="form.processing"
+            >
+                Reset password
+            </PrimaryButton>
         </form>
     </GuestLayout>
 </template>

--- a/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/resources/js/Pages/Auth/VerifyEmail.vue
@@ -23,37 +23,37 @@ const verificationLinkSent = computed(
     <GuestLayout>
         <Head title="Email Verification" />
 
-        <div class="mb-4 text-sm text-gray-600 dark:text-gray-400">
-            Thanks for signing up! Before getting started, could you verify your
-            email address by clicking on the link we just emailed to you? If you
-            didn't receive the email, we will gladly send you another.
-        </div>
+        <h1 class="text-xl font-semibold text-text-primary">
+            Verify your email
+        </h1>
+        <p class="mt-2 text-sm text-text-secondary">
+            We just sent a verification link to your inbox. Click it to finish
+            setting up your account. Didn't get it? We'll happily resend.
+        </p>
 
         <div
-            class="mb-4 text-sm font-medium text-green-600 dark:text-green-400"
             v-if="verificationLinkSent"
+            class="mt-4 rounded-lg border border-status-success/40 bg-status-success/10 px-3 py-2 text-sm font-medium text-status-success"
         >
-            A new verification link has been sent to the email address you
-            provided during registration.
+            A new verification link has been sent.
         </div>
 
-        <form @submit.prevent="submit">
-            <div class="mt-4 flex items-center justify-between">
-                <PrimaryButton
-                    :class="{ 'opacity-25': form.processing }"
-                    :disabled="form.processing"
-                >
-                    Resend Verification Email
-                </PrimaryButton>
+        <form class="mt-6 space-y-3" @submit.prevent="submit">
+            <PrimaryButton
+                class="w-full"
+                :class="{ 'opacity-50': form.processing }"
+                :disabled="form.processing"
+            >
+                Resend verification email
+            </PrimaryButton>
 
-                <Link
-                    :href="route('logout')"
-                    method="post"
-                    as="button"
-                    class="rounded-md text-sm text-gray-600 underline hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:text-gray-400 dark:hover:text-gray-100 dark:focus:ring-offset-gray-800"
-                    >Log Out</Link
-                >
-            </div>
+            <Link
+                :href="route('logout')"
+                method="post"
+                as="button"
+                class="block w-full text-center text-sm text-text-muted transition hover:text-accent-cyan focus:outline-none"
+                >Log out</Link
+            >
         </form>
     </GuestLayout>
 </template>

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -8,22 +8,16 @@ import { Head } from '@inertiajs/vue3';
 
     <AuthenticatedLayout>
         <template #header>
-            <h2
-                class="text-xl font-semibold leading-tight text-gray-800 dark:text-gray-200"
-            >
+            <h2 class="text-xl font-semibold leading-tight text-text-primary">
                 Overview
             </h2>
         </template>
 
         <div class="py-12">
             <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
-                <div
-                    class="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800"
-                >
-                    <div class="p-6 text-gray-900 dark:text-gray-100">
-                        You're logged in. The futuristic Nexus dashboard
-                        lands here in spec 006.
-                    </div>
+                <div class="glass-card p-8 text-text-secondary">
+                    You're logged in. The futuristic Nexus dashboard lands
+                    here in spec 006.
                 </div>
             </div>
         </div>

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -11,7 +11,7 @@
         @vite(['resources/js/app.ts', "resources/js/Pages/{$page['component']}.vue"])
         @inertiaHead
     </head>
-    <body class="min-h-screen bg-background-base font-sans text-text-primary antialiased">
+    <body class="min-h-screen font-sans text-text-primary antialiased">
         @inertia
     </body>
 </html>

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,21 +1,17 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <title inertia>{{ config('app.name', 'Laravel') }}</title>
 
-        <!-- Fonts -->
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
-
         <!-- Scripts -->
         @routes
         @vite(['resources/js/app.ts', "resources/js/Pages/{$page['component']}.vue"])
         @inertiaHead
     </head>
-    <body class="font-sans antialiased">
+    <body class="min-h-screen bg-background-base font-sans text-text-primary antialiased">
         @inertia
     </body>
 </html>

--- a/specs/phase-0-foundation/003-design-tokens.md
+++ b/specs/phase-0-foundation/003-design-tokens.md
@@ -1,0 +1,103 @@
+---
+spec: design-tokens
+phase: 0-foundation
+status: done
+owner: yoany
+created: 2026-04-27
+updated: 2026-04-27
+issue: https://github.com/Copxer/nexus/issues/4
+branch: spec/003-design-tokens
+---
+
+# 003 — Design tokens + Tailwind theme (dark, glassmorphism, neon accents)
+
+## Goal
+Translate the locked visual reference (`specs/visual-reference.md`, sourced from `nexus-dashboard.png`) into concrete Tailwind theme extensions and base CSS. After this spec, **any new component should be able to drop in `bg-panel`, `text-accent-cyan`, `font-mono`, `shadow-glow-cyan`, etc., and look correct without further design decisions.**
+
+Roadmap reference: §7 UX Direction, §22 Visual Design Specification.
+
+## Scope
+**In scope:**
+- Extend `tailwind.config.js` with the locked color tokens, font family stack, and a small set of utilities for glow/blur/shadow.
+- Replace `resources/css/app.css` with the project's base styles: dark background, custom scrollbar, font-face declarations, default selection color.
+- Add **Inter** (sans) and **JetBrains Mono** (mono) via the `@fontsource/*` npm packages so the fonts ship with the build, not via CDN (faster, offline-friendly, no FOUT).
+- Add a small reusable component CSS layer for `.glass-card` and the typographic helpers (`.tabular-nums`, `.font-display`).
+- Apply the tokens to **Login**, **Register**, and **AuthenticatedLayout** as a smoke test. The visual feel of those pages should change visibly: navy background, cyan-accented buttons, glass card chrome.
+- Add `darkMode: 'class'` and set `<html class="dark">` by default in `app.blade.php` (the dashboard target is dark-first, light mode is a phase-9 nice-to-have).
+- Update Pint + tests still pass; add a visual smoke screenshot if practical.
+
+**Out of scope:**
+- Building the actual sidebar, top bar, command palette, or overview page (spec 004+).
+- Light-mode parity. Dark-first; light mode is deferred.
+- Tailwind v4 upgrade. Breeze installed v3.2; we stay on v3 to minimize risk in this spec. v4 can be a separate `chore/upgrade-tailwind` PR later.
+- Animations/motion. Spec 003 is static tokens only; animation utilities land in spec 004 alongside the layout that uses them.
+
+## Plan
+1. Draft the token list against `visual-reference.md`. Map every color, font, blur, and shadow to a Tailwind extension key.
+2. Install fonts: `npm i @fontsource/inter @fontsource/jetbrains-mono`. Import the weights we'll actually use (400/500/600/700 for Inter, 400/500 for JetBrains Mono).
+3. Update `tailwind.config.js` with `extend.colors`, `extend.fontFamily`, `extend.boxShadow`, `extend.backdropBlur`, `extend.backgroundImage` (for the navy gradient).
+4. Rewrite `resources/css/app.css`:
+    - `@import` the font CSS files
+    - `@tailwind base; @tailwind components; @tailwind utilities;` (preserve current order)
+    - `@layer base` block: `:root`, `html.dark`, `body`, `::selection`, scrollbar
+    - `@layer components` block: `.glass-card`, optional `.glow-*`
+5. Force dark mode at the layout level (`<html class="dark">` in `resources/views/app.blade.php`).
+6. Repaint:
+    - `Login.vue` background + button + input
+    - `Register.vue` (same components — Breeze uses `GuestLayout`)
+    - `GuestLayout.vue` if needed
+    - `AuthenticatedLayout.vue` top bar + page background
+7. Run `php artisan test` (must stay green), `npm run build` (must compile), `vendor/bin/pint --test` (must pass).
+8. Run `composer run dev`, eyeball each page, capture a smoke screenshot for the work log.
+9. Open PR.
+
+## Acceptance criteria
+- [x] Tailwind config exposes named color tokens matching `visual-reference.md` (background.{base,panel,panel-hover}, border.{subtle,active}, text.{primary,secondary,muted}, accent.{blue,cyan,purple,magenta}, status.{success,warning,danger,info}).
+- [x] Tailwind config exposes `fontFamily.sans = Inter`, `fontFamily.mono = JetBrains Mono`, with system fallbacks from `defaultTheme`.
+- [x] `npm run build` produces a CSS bundle bundling Inter + JetBrains Mono webfonts (verified — passes locally).
+- [x] `app.blade.php` renders with `<html class="dark">` and a navy gradient background (`bg-app-gradient`).
+- [x] `.glass-card` utility added under `@layer components`: `rounded-2xl`, semi-transparent slate panel, subtle border, backdrop-blur, hover-glow border.
+- [x] Login + Register repainted: dark gradient background with cyan/purple ambient blobs, glass card chrome, neon-cyan primary button, monospace-friendly inputs, "Nexus Control Center" wordmark.
+- [x] AuthenticatedLayout repainted: glass top bar with the cyan-glow logo, dark dropdown trigger, dark mobile menu, navy gradient page background, dark page-heading bar.
+- [x] All Breeze components (TextInput, InputLabel, PrimaryButton, SecondaryButton, DangerButton, InputError, Checkbox, NavLink, ResponsiveNavLink) use the new tokens — no leftover `gray-*` / `indigo-*` classes.
+- [x] All existing tests still pass (25/25).
+- [x] Pint clean.
+- [ ] CI green on the PR (will verify after push).
+
+## Files touched
+- `tailwind.config.js` — added `darkMode: 'class'`, locked color tokens, font stacks (Inter / JetBrains Mono with fallbacks), `app-gradient` backgroundImage, glow box-shadows, `panel` shadow, `xs` backdropBlur.
+- `resources/css/app.css` — webfont imports (`@fontsource/inter` 400/500/600/700, `@fontsource/jetbrains-mono` 400/500), `@layer base` with html/body/selection/scrollbar styling, `@layer components` with `.glass-card` and `.font-display`.
+- `resources/views/app.blade.php` — `<html class="dark">`, removed Bunny Fonts CDN link (replaced by bundled webfonts), body uses `bg-background-base font-sans text-text-primary`.
+- `resources/js/Layouts/GuestLayout.vue` — dark gradient backdrop, ambient cyan/purple glow blobs, cyan-glow logo, "Nexus Control Center" wordmark, `glass-card` form container.
+- `resources/js/Layouts/AuthenticatedLayout.vue` — `bg-app-gradient` page background, glass top bar with backdrop blur, cyan-glow logo + "Nexus" wordmark, dark dropdown trigger, dark mobile menu, dark page-heading bar.
+- `resources/js/Pages/Auth/Login.vue` — heading + subhead, status pill, spaced fields, full-width primary button, "Create an account" link, neon-cyan accents.
+- `resources/js/Pages/Auth/Register.vue` — same treatment.
+- `resources/js/Pages/Overview.vue` — placeholder card now uses `glass-card`.
+- `resources/js/Components/TextInput.vue` — dark input chrome, cyan focus ring.
+- `resources/js/Components/InputLabel.vue` — uppercase tracked label in `text-secondary`.
+- `resources/js/Components/PrimaryButton.vue` — neon-cyan filled, glow shadow.
+- `resources/js/Components/SecondaryButton.vue` — dark slate, cyan hover.
+- `resources/js/Components/DangerButton.vue` — neon-danger filled, danger glow.
+- `resources/js/Components/InputError.vue` — `text-status-danger`.
+- `resources/js/Components/Checkbox.vue` — dark + cyan accent.
+- `resources/js/Components/NavLink.vue` — cyan underline when active.
+- `resources/js/Components/ResponsiveNavLink.vue` — cyan left border + tinted bg when active.
+- `package.json` / `package-lock.json` — added `@fontsource/inter`, `@fontsource/jetbrains-mono`.
+
+## Work log
+
+### 2026-04-27
+- Spec drafted. Verified current Tailwind setup is v3.2 with Breeze defaults.
+- Opened tracking issue #4 and created branch `spec/003-design-tokens`.
+- Installed `@fontsource/inter` (400/500/600/700) and `@fontsource/jetbrains-mono` (400/500). 50 packages added.
+- Extended `tailwind.config.js` per the locked tokens. Reserved glow shadows for active/critical/online states only.
+- Rewrote `app.css` with webfont imports, base layer (scrollbar + selection + body/html), and components layer (`.glass-card`, `.font-display`).
+- Forced `<html class="dark">` in `app.blade.php`. Removed the Figtree CDN link.
+- Repainted the entire Breeze component library (8 components) so any new page automatically gets the right look.
+- Repainted Login, Register, GuestLayout, AuthenticatedLayout, and the Overview placeholder.
+- `vendor/bin/pint --test` ✅, `npm run build` ✅, `php artisan test` 25/25 ✅.
+- Visual smoke test deferred to PR review (the user will verify via `composer run dev`).
+
+## Open questions / blockers
+- Whether to alias both `accent-cyan` and `accent-cyan-500`-style scales. Decision: just the named flat tokens for now (`accent-cyan`, `accent-purple`, etc.). Scales can be added later if a component genuinely needs them.
+- Whether to use `@apply` inside `.vue` `<style>` blocks or keep all style in Tailwind class strings. Decision: prefer Tailwind class strings; use `@layer components` for actual reuse (cards, buttons), not page-specific styling.

--- a/specs/phase-0-foundation/003-design-tokens.md
+++ b/specs/phase-0-foundation/003-design-tokens.md
@@ -82,6 +82,12 @@ Roadmap reference: §7 UX Direction, §22 Visual Design Specification.
 - `resources/js/Components/Checkbox.vue` — dark + cyan accent.
 - `resources/js/Components/NavLink.vue` — cyan underline when active.
 - `resources/js/Components/ResponsiveNavLink.vue` — cyan left border + tinted bg when active.
+- `resources/js/Components/Dropdown.vue` — glass-style content panel (post-review fix).
+- `resources/js/Components/DropdownLink.vue` — token-driven hover (post-review fix).
+- `resources/js/Pages/Auth/ForgotPassword.vue` — repainted with the new heading/subhead pattern (post-review fix).
+- `resources/js/Pages/Auth/ResetPassword.vue` — same.
+- `resources/js/Pages/Auth/VerifyEmail.vue` — same.
+- `resources/js/Pages/Auth/ConfirmPassword.vue` — same.
 - `package.json` / `package-lock.json` — added `@fontsource/inter`, `@fontsource/jetbrains-mono`.
 
 ## Work log
@@ -96,6 +102,12 @@ Roadmap reference: §7 UX Direction, §22 Visual Design Specification.
 - Repainted the entire Breeze component library (8 components) so any new page automatically gets the right look.
 - Repainted Login, Register, GuestLayout, AuthenticatedLayout, and the Overview placeholder.
 - `vendor/bin/pint --test` ✅, `npm run build` ✅, `php artisan test` 25/25 ✅.
+- Ran `superpowers:code-reviewer` self-review on the diff. Findings (no blockers):
+  - **[material]** `Dropdown.vue` and `DropdownLink.vue` still carried `bg-white dark:bg-gray-700` / `text-gray-700 dark:text-gray-300 dark:hover:bg-gray-800`. They open from the repainted `AuthenticatedLayout` user menu, so the half-painted effect was visible. **Fixed:** repainted both with `bg-background-panel`, `border-border-subtle`, `shadow-panel`, and `text-text-secondary` hover-on-`bg-background-panel-hover`.
+  - **[material]** Secondary auth pages (`ForgotPassword`, `ResetPassword`, `VerifyEmail`, `ConfirmPassword`) still carried Breeze grays — they sit inside `GuestLayout`'s glass card so looked half-painted. **Fixed:** repainted all four with the same heading/subhead/spacing pattern as Login/Register, removed `text-gray-600`/`text-green-600`/`text-indigo-500`.
+  - **[material]** `text-text-muted` (#64748B) on `bg-background-panel` is ~3.5:1 — fails WCAG AA for body copy. Used on Login/Register subheads and the "Forgot your password?" / "New here?" / "Already have an account?" text. **Fixed:** bumped to `text-text-secondary` (#CBD5E1) on those non-metadata strings.
+  - **[nit]** `app.blade.php` body had `bg-background-base` while `app.css` `@layer base` set `bg-app-gradient bg-fixed` on `body` — the inline class won, so the gradient never appeared on body. **Fixed:** removed `bg-background-base` from the blade body so `app.css`'s gradient is the single source.
+- Re-verified Pint + build + 25/25 tests after the review fixes. All green.
 - Visual smoke test deferred to PR review (the user will verify via `composer run dev`).
 
 ## Open questions / blockers

--- a/specs/phase-0-foundation/README.md
+++ b/specs/phase-0-foundation/README.md
@@ -12,7 +12,7 @@ Stand up a Laravel 12 + Vue 3 + Inertia + Tailwind project with authentication, 
 |---|------|--------|
 | 001 | Laravel 13 + Inertia + Vue 3 + TS scaffold | 🟢 |
 | 002 | Auth scaffolding (login / register / verified email) | 🟢 |
-| 003 | Design tokens + Tailwind theme (dark, glassmorphism, neon accents) | ⬜ |
+| 003 | Design tokens + Tailwind theme (dark, glassmorphism, neon accents) | 🟢 |
 | 004 | AppLayout + Sidebar + TopBar + RightActivityRail | ⬜ |
 | 005 | CommandPalette (Cmd+K) shell | ⬜ |
 | 006 | Overview page with mock KPI cards, sparklines, status badges | ⬜ |

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,8 @@ import forms from '@tailwindcss/forms';
 
 /** @type {import('tailwindcss').Config} */
 export default {
+    darkMode: 'class',
+
     content: [
         './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
         './storage/framework/views/*.php',
@@ -12,8 +14,58 @@ export default {
 
     theme: {
         extend: {
+            // Tokens locked from specs/visual-reference.md (sourced from nexus-dashboard.png).
+            colors: {
+                background: {
+                    base: '#020617',
+                    panel: 'rgba(15, 23, 42, 0.72)',
+                    'panel-hover': 'rgba(30, 41, 59, 0.85)',
+                },
+                border: {
+                    subtle: 'rgba(148, 163, 184, 0.16)',
+                    active: 'rgba(56, 189, 248, 0.5)',
+                },
+                text: {
+                    primary: '#F8FAFC',
+                    secondary: '#CBD5E1',
+                    muted: '#64748B',
+                },
+                accent: {
+                    blue: '#38BDF8',
+                    cyan: '#22D3EE',
+                    purple: '#8B5CF6',
+                    magenta: '#D946EF',
+                },
+                status: {
+                    success: '#22C55E',
+                    warning: '#F59E0B',
+                    danger: '#EF4444',
+                    info: '#3B82F6',
+                },
+            },
+
             fontFamily: {
-                sans: ['Figtree', ...defaultTheme.fontFamily.sans],
+                sans: ['Inter', ...defaultTheme.fontFamily.sans],
+                mono: ['"JetBrains Mono"', ...defaultTheme.fontFamily.mono],
+            },
+
+            backgroundImage: {
+                'app-gradient':
+                    'linear-gradient(135deg, #020617 0%, #0B1220 100%)',
+            },
+
+            backdropBlur: {
+                xs: '2px',
+            },
+
+            boxShadow: {
+                // Reserved for active/hovered/critical states only — never neutral.
+                'glow-cyan': '0 0 24px rgba(34, 211, 238, 0.45)',
+                'glow-purple': '0 0 24px rgba(139, 92, 246, 0.45)',
+                'glow-magenta': '0 0 24px rgba(217, 70, 239, 0.45)',
+                'glow-success': '0 0 24px rgba(34, 197, 94, 0.45)',
+                'glow-danger': '0 0 24px rgba(239, 68, 68, 0.55)',
+                panel: '0 25px 50px -12px rgba(0, 0, 0, 0.55)',
             },
         },
     },


### PR DESCRIPTION
Closes #4

Spec: [`specs/phase-0-foundation/003-design-tokens.md`](specs/phase-0-foundation/003-design-tokens.md)

## Summary
- Lock the visual-reference color palette + typography in `tailwind.config.js`. Any new component can drop in `bg-background-panel`, `text-accent-cyan`, `font-mono`, `shadow-glow-cyan`, `.glass-card` and look correct without further design decisions.
- Bundle Inter + JetBrains Mono via `@fontsource` so webfonts ship with the build (no FOUT, no CDN).
- Force `<html class="dark">` + the navy-gradient background. Add a `.glass-card` component utility in `@layer components`.
- Repaint the entire Breeze component library + both layouts + every auth page + the Overview placeholder so the new look propagates everywhere it's reachable.

## Test plan
- [x] `vendor/bin/pint --test` clean
- [x] `npm run build` green; `@fontsource` webfonts emitted in `public/build/assets/`
- [x] `php artisan test` 25/25 green
- [ ] Visual smoke (reviewer to verify via `composer run dev`):
    - `/login`, `/register`, `/forgot-password`, `/reset-password`, `/verify-email`, `/confirm-password` all render with the dark glass-card chrome, cyan-glow logo, and neon-cyan primary button. No leftover Breeze gray-on-white look.
    - `/overview` (after login) shows the dark gradient page bg + glass-card placeholder + dark top bar with cyan-glow Nexus wordmark.
    - User dropdown menu in the top bar opens with the dark glass panel (post-review fix).

## Self-review notes
Ran `superpowers:code-reviewer` on the diff. No blockers. Three material findings + one nit, all addressed in commit `03eae75`:
- **Dropdown / DropdownLink** — still on Breeze grays even though they open from the repainted user menu. Repainted with `bg-background-panel`, `shadow-panel`, token-driven hover.
- **Secondary auth pages** (`ForgotPassword`, `ResetPassword`, `VerifyEmail`, `ConfirmPassword`) — still on gray-* / green-* / indigo-* and rendered inside the glass card → half-painted look. Repainted with the same heading/subhead pattern as Login/Register.
- **Contrast** — `text-text-muted` (#64748B) on `bg-background-panel` is ~3.5:1, fails WCAG AA for body copy. Bumped non-metadata copy on Login/Register to `text-text-secondary` (#CBD5E1).
- **Body bg layering** — `app.blade.php` body's `bg-background-base` was overriding `bg-app-gradient bg-fixed` from `app.css`. Dropped the inline utility so the gradient is the single source.

## Out of scope (deferred to future specs)
- `Welcome.vue` (Laravel landing) and `Pages/Profile/**` still carry Breeze grays. They live behind separate flows and the spec did not include them. Filing as a follow-up if the user wants them repainted.
- `Modal.vue` carries gray-* but is currently only used by the profile delete-account flow. Will be repainted when that flow gets touched.
- Sidebar / TopBar / Right activity rail — spec 004.
- Command palette — spec 005.
- Motion / animation utilities — alongside spec 004.