### PR TITLE
Spec 005 — CommandPalette (Cmd+K) shell

### DIFF
--- a/resources/js/Components/CommandPalette/CommandPalette.vue
+++ b/resources/js/Components/CommandPalette/CommandPalette.vue
@@ -74,14 +74,11 @@ const grouped = computed<{ group: CommandGroup; items: Command[] }[]>(() => {
         .map(([group, items]) => ({ group, items }));
 });
 
-/** Flat array of visible commands — index aligns with `highlightedIndex`. */
-const flatVisible = computed<Command[]>(() => filtered.value);
-
-const noMatches = computed(() => flatVisible.value.length === 0);
+const noMatches = computed(() => filtered.value.length === 0);
 
 /** Find the first non-disabled visible row, or 0 if everything is disabled. */
 const firstEnabledIndex = computed(() => {
-    const idx = flatVisible.value.findIndex((c) => !c.disabled);
+    const idx = filtered.value.findIndex((c) => !c.disabled);
     return idx === -1 ? 0 : idx;
 });
 
@@ -118,7 +115,7 @@ watch(highlightedIndex, async () => {
 });
 
 const moveHighlight = (delta: number) => {
-    const list = flatVisible.value;
+    const list = filtered.value;
     if (list.length === 0) return;
     let next = highlightedIndex.value;
     for (let step = 0; step < list.length; step++) {
@@ -129,7 +126,7 @@ const moveHighlight = (delta: number) => {
 };
 
 const runHighlighted = () => {
-    const cmd = flatVisible.value[highlightedIndex.value];
+    const cmd = filtered.value[highlightedIndex.value];
     if (!cmd || cmd.disabled || !cmd.run) return;
     cmd.run();
     emit('close');
@@ -168,8 +165,8 @@ const onKeydown = (event: KeyboardEvent) => {
     }
 };
 
-/** Resolve the absolute index of a command in flatVisible (for hover highlight). */
-const indexOf = (cmd: Command) => flatVisible.value.indexOf(cmd);
+/** Resolve the absolute index of a command in `filtered` (for hover highlight). */
+const indexOf = (cmd: Command) => filtered.value.indexOf(cmd);
 </script>
 
 <template>
@@ -223,8 +220,8 @@ const indexOf = (cmd: Command) => flatVisible.value.indexOf(cmd);
                         aria-label="Command palette search"
                         aria-controls="command-palette-list"
                         :aria-activedescendant="
-                            flatVisible[highlightedIndex]
-                                ? `command-${flatVisible[highlightedIndex].id}`
+                            filtered[highlightedIndex]
+                                ? `command-${filtered[highlightedIndex].id}`
                                 : undefined
                         "
                         autocomplete="off"

--- a/resources/js/Components/CommandPalette/CommandPalette.vue
+++ b/resources/js/Components/CommandPalette/CommandPalette.vue
@@ -1,0 +1,308 @@
+<script setup lang="ts">
+import CommandPaletteRow from '@/Components/CommandPalette/CommandPaletteRow.vue';
+import {
+    commandGroupLabels,
+    compareGroups,
+    getCommands,
+    type Command,
+    type CommandGroup,
+} from '@/lib/commands';
+import { fuzzyMatch } from '@/lib/fuzzyMatch';
+import { Search } from 'lucide-vue-next';
+import { computed, nextTick, ref, watch } from 'vue';
+
+const props = defineProps<{
+    open: boolean;
+}>();
+
+const emit = defineEmits<{
+    (e: 'close'): void;
+}>();
+
+const commands = getCommands();
+
+const query = ref('');
+const highlightedIndex = ref(0);
+const inputRef = ref<HTMLInputElement | null>(null);
+const listRef = ref<HTMLElement | null>(null);
+
+/**
+ * True once the user has moved the mouse inside the dialog after open.
+ * Prevents the cursor's resting position from stealing the highlight from
+ * the keyboard-set "first enabled row" when the palette is opened via Cmd+K.
+ */
+const mouseMovedSinceOpen = ref(false);
+
+/** Element that had focus before the palette opened — restored on close. */
+let returnFocusTo: HTMLElement | null = null;
+
+/**
+ * Filter + score commands. Empty query returns the full registry in
+ * declaration order (stable). Non-empty query runs fuzzyMatch against
+ * label + keywords, drops misses, sorts by score (desc), and pushes
+ * disabled rows to the bottom of each group so real matches come first.
+ */
+const filtered = computed<Command[]>(() => {
+    const q = query.value.trim();
+    if (!q) return commands;
+
+    const scored = fuzzyMatch(commands, q, (c) => [c.label, ...(c.keywords ?? [])]);
+    return scored
+        .sort((a, b) => {
+            // Disabled rows always sink below enabled rows.
+            const aDisabled = a.item.disabled ? 1 : 0;
+            const bDisabled = b.item.disabled ? 1 : 0;
+            if (aDisabled !== bDisabled) return aDisabled - bDisabled;
+            return b.score - a.score;
+        })
+        .map(({ item }) => item);
+});
+
+/**
+ * Group filtered commands for rendering. Returns an array of
+ * `{ group, items }` in stable group order so the layout doesn't jitter
+ * as the filter changes.
+ */
+const grouped = computed<{ group: CommandGroup; items: Command[] }[]>(() => {
+    const buckets = new Map<CommandGroup, Command[]>();
+    for (const cmd of filtered.value) {
+        if (!buckets.has(cmd.group)) buckets.set(cmd.group, []);
+        buckets.get(cmd.group)!.push(cmd);
+    }
+    return [...buckets.entries()]
+        .sort(([a], [b]) => compareGroups(a, b))
+        .map(([group, items]) => ({ group, items }));
+});
+
+/** Flat array of visible commands — index aligns with `highlightedIndex`. */
+const flatVisible = computed<Command[]>(() => filtered.value);
+
+const noMatches = computed(() => flatVisible.value.length === 0);
+
+/** Find the first non-disabled visible row, or 0 if everything is disabled. */
+const firstEnabledIndex = computed(() => {
+    const idx = flatVisible.value.findIndex((c) => !c.disabled);
+    return idx === -1 ? 0 : idx;
+});
+
+watch(
+    () => props.open,
+    async (isOpen) => {
+        if (isOpen) {
+            returnFocusTo = document.activeElement as HTMLElement | null;
+            query.value = '';
+            highlightedIndex.value = firstEnabledIndex.value;
+            mouseMovedSinceOpen.value = false;
+            await nextTick();
+            inputRef.value?.focus();
+        } else if (returnFocusTo && document.contains(returnFocusTo)) {
+            returnFocusTo.focus();
+            returnFocusTo = null;
+        }
+    },
+);
+
+// Whenever the filter changes, reset the highlight to the first enabled row
+// so the user always sees a meaningful preselection after typing.
+watch(query, () => {
+    highlightedIndex.value = firstEnabledIndex.value;
+});
+
+// Keep the highlighted row scrolled into view.
+watch(highlightedIndex, async () => {
+    await nextTick();
+    const el = listRef.value?.querySelector<HTMLElement>(
+        '[aria-selected="true"]',
+    );
+    el?.scrollIntoView({ block: 'nearest' });
+});
+
+const moveHighlight = (delta: number) => {
+    const list = flatVisible.value;
+    if (list.length === 0) return;
+    let next = highlightedIndex.value;
+    for (let step = 0; step < list.length; step++) {
+        next = (next + delta + list.length) % list.length;
+        if (!list[next].disabled) break;
+    }
+    highlightedIndex.value = next;
+};
+
+const runHighlighted = () => {
+    const cmd = flatVisible.value[highlightedIndex.value];
+    if (!cmd || cmd.disabled || !cmd.run) return;
+    cmd.run();
+    emit('close');
+};
+
+const runCommand = (cmd: Command) => {
+    if (cmd.disabled || !cmd.run) return;
+    cmd.run();
+    emit('close');
+};
+
+const onKeydown = (event: KeyboardEvent) => {
+    switch (event.key) {
+        case 'ArrowDown':
+            event.preventDefault();
+            moveHighlight(1);
+            break;
+        case 'ArrowUp':
+            event.preventDefault();
+            moveHighlight(-1);
+            break;
+        case 'Enter':
+            event.preventDefault();
+            runHighlighted();
+            break;
+        case 'Escape':
+            event.preventDefault();
+            emit('close');
+            break;
+        case 'Tab':
+            // Trap focus inside the dialog — input is the only tabbable
+            // element so we keep focus pinned there.
+            event.preventDefault();
+            inputRef.value?.focus();
+            break;
+    }
+};
+
+/** Resolve the absolute index of a command in flatVisible (for hover highlight). */
+const indexOf = (cmd: Command) => flatVisible.value.indexOf(cmd);
+</script>
+
+<template>
+    <Teleport to="body">
+        <Transition
+            enter-active-class="transition duration-150"
+            enter-from-class="opacity-0"
+            enter-to-class="opacity-100"
+            leave-active-class="transition duration-100"
+            leave-from-class="opacity-100"
+            leave-to-class="opacity-0"
+        >
+            <div
+                v-if="open"
+                class="fixed inset-0 z-50 bg-background-base/80 backdrop-blur-sm"
+                @click="emit('close')"
+                aria-hidden="true"
+            />
+        </Transition>
+        <Transition
+            enter-active-class="transition duration-150"
+            enter-from-class="opacity-0 -translate-y-2"
+            enter-to-class="opacity-100 translate-y-0"
+            leave-active-class="transition duration-100"
+            leave-from-class="opacity-100 translate-y-0"
+            leave-to-class="opacity-0 -translate-y-2"
+        >
+            <div
+                v-if="open"
+                role="dialog"
+                aria-modal="true"
+                aria-label="Command palette"
+                class="fixed inset-x-0 top-[12vh] z-50 mx-auto w-[92%] max-w-2xl rounded-2xl border border-border-subtle bg-background-panel shadow-panel backdrop-blur-xl"
+                @keydown="onKeydown"
+                @click.stop
+                @mousemove="mouseMovedSinceOpen = true"
+            >
+                <!-- Search input row -->
+                <div
+                    class="flex items-center gap-3 border-b border-border-subtle px-4 py-3"
+                >
+                    <Search
+                        class="h-4 w-4 shrink-0 text-text-muted"
+                        aria-hidden="true"
+                    />
+                    <input
+                        ref="inputRef"
+                        v-model="query"
+                        type="text"
+                        placeholder="Type a command or search…"
+                        aria-label="Command palette search"
+                        aria-controls="command-palette-list"
+                        :aria-activedescendant="
+                            flatVisible[highlightedIndex]
+                                ? `command-${flatVisible[highlightedIndex].id}`
+                                : undefined
+                        "
+                        autocomplete="off"
+                        autocorrect="off"
+                        autocapitalize="off"
+                        spellcheck="false"
+                        class="min-w-0 flex-1 border-0 bg-transparent p-0 text-sm text-text-primary placeholder:text-text-muted focus:border-transparent focus:outline-none focus:ring-0"
+                    />
+                    <kbd
+                        class="hidden shrink-0 rounded border border-border-subtle bg-slate-950/40 px-1.5 py-0.5 font-mono text-[10px] text-text-muted sm:inline-block"
+                    >
+                        Esc
+                    </kbd>
+                </div>
+
+                <!-- Results -->
+                <div
+                    v-if="noMatches"
+                    class="px-4 py-8 text-center text-sm text-text-muted"
+                >
+                    No matching commands.
+                </div>
+                <div
+                    v-else
+                    ref="listRef"
+                    id="command-palette-list"
+                    role="listbox"
+                    aria-label="Commands"
+                    class="max-h-[60vh] overflow-y-auto p-2"
+                >
+                    <template v-for="bucket in grouped" :key="bucket.group">
+                        <div
+                            class="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-[0.24em] text-text-muted"
+                        >
+                            {{ commandGroupLabels[bucket.group] }}
+                        </div>
+                        <ul class="flex flex-col gap-0.5">
+                            <CommandPaletteRow
+                                v-for="cmd in bucket.items"
+                                :key="cmd.id"
+                                :command="cmd"
+                                :selected="indexOf(cmd) === highlightedIndex"
+                                @select="runCommand(cmd)"
+                                @mouseenter="
+                                    () => {
+                                        if (!mouseMovedSinceOpen) return;
+                                        const i = indexOf(cmd);
+                                        if (i !== -1) highlightedIndex = i;
+                                    }
+                                "
+                            />
+                        </ul>
+                    </template>
+                </div>
+
+                <!-- Footer hint row -->
+                <div
+                    class="flex items-center justify-between gap-3 border-t border-border-subtle px-4 py-2 text-[11px] text-text-muted"
+                >
+                    <span class="hidden sm:inline">
+                        Navigate with
+                        <kbd
+                            class="rounded border border-border-subtle bg-slate-950/40 px-1 font-mono"
+                        >↑</kbd>
+                        <kbd
+                            class="rounded border border-border-subtle bg-slate-950/40 px-1 font-mono"
+                        >↓</kbd>
+                        ·
+                        <kbd
+                            class="rounded border border-border-subtle bg-slate-950/40 px-1 font-mono"
+                        >Enter</kbd>
+                        to run
+                    </span>
+                    <span class="ms-auto">
+                        Greyed entries land in later phases.
+                    </span>
+                </div>
+            </div>
+        </Transition>
+    </Teleport>
+</template>

--- a/resources/js/Components/CommandPalette/CommandPaletteRow.vue
+++ b/resources/js/Components/CommandPalette/CommandPaletteRow.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import type { Command } from '@/lib/commands';
+
+defineProps<{
+    command: Command;
+    selected: boolean;
+}>();
+
+defineEmits<{
+    /** Mouse click on the row — parent decides whether to run (disabled rows are no-ops). */
+    (e: 'select'): void;
+}>();
+</script>
+
+<template>
+    <li
+        :id="`command-${command.id}`"
+        role="option"
+        :aria-selected="selected"
+        :aria-disabled="command.disabled || undefined"
+        class="group flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition"
+        :class="[
+            selected && !command.disabled
+                ? 'bg-accent-cyan/10 text-text-primary shadow-[inset_2px_0_0_0_theme(colors.accent.cyan)]'
+                : selected && command.disabled
+                  ? 'cursor-not-allowed bg-background-panel-hover text-text-muted'
+                  : command.disabled
+                    ? 'cursor-not-allowed text-text-muted'
+                    : 'text-text-secondary hover:bg-background-panel-hover hover:text-text-primary',
+        ]"
+        @click="!command.disabled && $emit('select')"
+    >
+        <component
+            :is="command.icon"
+            class="h-4 w-4 shrink-0 transition"
+            :class="[
+                selected && !command.disabled
+                    ? 'text-accent-cyan'
+                    : 'text-text-muted',
+                !command.disabled &&
+                    !selected &&
+                    'group-hover:text-text-primary',
+            ]"
+            aria-hidden="true"
+        />
+        <span class="min-w-0 flex-1 truncate">{{ command.label }}</span>
+
+        <!-- Right-side pill: "Soon" for disabled rows, shortcut hint or
+             "Enter ↵" when the row is the active selection. -->
+        <span
+            v-if="command.disabled"
+            class="ms-auto rounded-full border border-border-subtle px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-text-muted"
+        >
+            {{ command.soonLabel ?? 'Soon' }}
+        </span>
+        <span
+            v-else-if="command.shortcut"
+            class="ms-auto font-mono text-[11px] text-text-muted"
+        >
+            {{ command.shortcut }}
+        </span>
+        <span
+            v-else-if="selected"
+            class="ms-auto inline-flex items-center gap-1 font-mono text-[11px] text-accent-cyan"
+            aria-hidden="true"
+        >
+            Enter ↵
+        </span>
+    </li>
+</template>

--- a/resources/js/Components/TopBar/TopBar.vue
+++ b/resources/js/Components/TopBar/TopBar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import Dropdown from '@/Components/Dropdown.vue';
 import DropdownLink from '@/Components/DropdownLink.vue';
+import TopBarSearch from '@/Components/TopBar/TopBarSearch.vue';
 import { usePage } from '@inertiajs/vue3';
 import {
     Bell,
@@ -9,7 +10,6 @@ import {
     LogOut,
     Menu,
     PanelRight,
-    Search,
     UserCog,
 } from 'lucide-vue-next';
 import { computed } from 'vue';
@@ -24,6 +24,8 @@ const emit = defineEmits<{
     (e: 'open-sidebar'): void;
     /** Tablet rail toggle pressed — AppLayout opens the activity rail drawer. */
     (e: 'open-activity-rail'): void;
+    /** Search trigger pressed — AppLayout opens the command palette. */
+    (e: 'open-palette'): void;
 }>();
 
 const page = usePage();
@@ -64,27 +66,8 @@ const initials = computed(() => {
             </slot>
         </div>
 
-        <!-- Search — visual only; real search lands with the command palette in spec 005 -->
-        <div class="relative hidden items-center md:flex">
-            <Search
-                class="pointer-events-none absolute start-3 h-4 w-4 text-text-muted"
-                aria-hidden="true"
-            />
-            <input
-                type="search"
-                aria-label="Global search"
-                placeholder="Search projects, repos, hosts…"
-                title="Global search arrives with the command palette in spec 005."
-                class="w-64 cursor-not-allowed rounded-lg border border-border-subtle bg-slate-950/60 ps-9 pe-16 py-2 text-sm text-text-primary placeholder:text-text-muted shadow-inner shadow-black/20 transition focus:border-accent-cyan focus:ring-2 focus:ring-accent-cyan/40 lg:w-72"
-                aria-disabled="true"
-                readonly
-            />
-            <span
-                class="pointer-events-none absolute end-3 hidden font-mono text-[11px] text-text-muted lg:inline"
-            >
-                ⌘K
-            </span>
-        </div>
+        <!-- Search — opens the command palette (spec 005) -->
+        <TopBarSearch @open-palette="emit('open-palette')" />
 
         <!-- Time-range pill — visual only -->
         <button

--- a/resources/js/Components/TopBar/TopBarSearch.vue
+++ b/resources/js/Components/TopBar/TopBarSearch.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { Search } from 'lucide-vue-next';
+import { onMounted, ref } from 'vue';
+
+defineEmits<{
+    /** User clicked or pressed Enter/Space — AppLayout opens the palette. */
+    (e: 'open-palette'): void;
+}>();
+
+const isMac = ref(false);
+
+onMounted(() => {
+    // navigator.platform is deprecated but still universally implemented; the
+    // newer userAgentData API isn't on Safari yet. Either signal is fine here
+    // since we're only choosing between two visual hint strings.
+    const platform =
+        (navigator as Navigator & {
+            userAgentData?: { platform?: string };
+        }).userAgentData?.platform ?? navigator.platform;
+    isMac.value = /mac|iphone|ipad|ipod/i.test(platform ?? '');
+});
+</script>
+
+<template>
+    <button
+        type="button"
+        aria-label="Search and run commands"
+        aria-keyshortcuts="Meta+K Control+K"
+        class="relative hidden h-9 items-center rounded-lg border border-border-subtle bg-slate-950/60 ps-9 pe-2 text-sm text-text-muted shadow-inner shadow-black/20 transition hover:border-accent-cyan/40 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60 md:inline-flex md:w-64 lg:w-72"
+        @click="$emit('open-palette')"
+    >
+        <Search
+            class="pointer-events-none absolute start-3 h-4 w-4"
+            aria-hidden="true"
+        />
+        <span class="min-w-0 flex-1 truncate whitespace-nowrap text-start">
+            Search or run a command…
+        </span>
+        <kbd
+            class="ms-2 hidden shrink-0 rounded border border-border-subtle bg-slate-950/40 px-1.5 py-0.5 font-mono text-[11px] text-text-muted lg:inline-block"
+        >
+            {{ isMac ? '⌘K' : 'Ctrl K' }}
+        </kbd>
+    </button>
+</template>

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -32,6 +32,13 @@ const onKeydown = (event: KeyboardEvent) => {
     // outside text inputs. The palette's own Escape/Enter/arrow handling
     // takes over once it's open and focused.
     if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        // No-op (but still preventDefault) when the palette is already open
+        // so the keystroke isn't delivered to the palette's own input or
+        // hijacked by the browser's "search bar" shortcut.
+        if (paletteOpen.value) {
+            event.preventDefault();
+            return;
+        }
         if (isTextInput(event.target)) return;
         event.preventDefault();
         paletteOpen.value = true;
@@ -39,7 +46,10 @@ const onKeydown = (event: KeyboardEvent) => {
     }
 
     if (event.key !== 'Escape') return;
-    // Drawers handle Escape here; the palette has its own internal handler.
+    // Palette has its own Escape handler scoped to the dialog; bail here so
+    // we don't double-fire (and so a future drawer + palette overlap doesn't
+    // close the wrong overlay).
+    if (paletteOpen.value) return;
     if (sidebarOpen.value) {
         sidebarOpen.value = false;
     } else if (activityRailOpen.value) {

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -1,25 +1,45 @@
 <script setup lang="ts">
 import RightActivityRail from '@/Components/Activity/RightActivityRail.vue';
+import CommandPalette from '@/Components/CommandPalette/CommandPalette.vue';
 import Sidebar from '@/Components/Sidebar/Sidebar.vue';
 import TopBar from '@/Components/TopBar/TopBar.vue';
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
 
 const sidebarOpen = ref(false);
 const activityRailOpen = ref(false);
+const paletteOpen = ref(false);
 
-// Lock body scroll while a drawer is open. Reset on unmount in case the user
-// navigates away mid-drawer.
+// Lock body scroll while a drawer or the palette is open. Reset on unmount
+// in case the user navigates away mid-overlay.
 const setBodyScroll = (locked: boolean) => {
     document.body.classList.toggle('overflow-hidden', locked);
 };
 
-watch([sidebarOpen, activityRailOpen], ([s, a]) => {
-    setBodyScroll(s || a);
+watch([sidebarOpen, activityRailOpen, paletteOpen], ([s, a, p]) => {
+    setBodyScroll(s || a || p);
 });
 
-// Close any open drawer on Escape — required for `role="dialog" aria-modal".
+// True when focus is inside a text-input-like element. Used to avoid
+// hijacking Cmd+K while the user is typing into a real form field.
+const isTextInput = (target: EventTarget | null): boolean => {
+    if (!(target instanceof HTMLElement)) return false;
+    const tag = target.tagName;
+    return tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable;
+};
+
 const onKeydown = (event: KeyboardEvent) => {
+    // Cmd+K (mac) / Ctrl+K (others) opens the command palette from anywhere
+    // outside text inputs. The palette's own Escape/Enter/arrow handling
+    // takes over once it's open and focused.
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        if (isTextInput(event.target)) return;
+        event.preventDefault();
+        paletteOpen.value = true;
+        return;
+    }
+
     if (event.key !== 'Escape') return;
+    // Drawers handle Escape here; the palette has its own internal handler.
     if (sidebarOpen.value) {
         sidebarOpen.value = false;
     } else if (activityRailOpen.value) {
@@ -83,6 +103,7 @@ onBeforeUnmount(() => {
             <TopBar
                 @open-sidebar="sidebarOpen = true"
                 @open-activity-rail="activityRailOpen = true"
+                @open-palette="paletteOpen = true"
             >
                 <template v-if="$slots.title" #title>
                     <slot name="title" />
@@ -138,5 +159,11 @@ onBeforeUnmount(() => {
                 />
             </div>
         </Transition>
+
+        <!-- Global command palette (spec 005) -->
+        <CommandPalette
+            :open="paletteOpen"
+            @close="paletteOpen = false"
+        />
     </div>
 </template>

--- a/resources/js/lib/commands.ts
+++ b/resources/js/lib/commands.ts
@@ -1,0 +1,234 @@
+import { router } from '@inertiajs/vue3';
+import {
+    Activity,
+    BarChart3,
+    Bell,
+    Flame,
+    FolderKanban,
+    GitBranch,
+    GitPullRequest,
+    Globe,
+    Globe2,
+    LayoutDashboard,
+    LogOut,
+    Plug,
+    Plus,
+    RefreshCw,
+    Rocket,
+    Server,
+    Settings as SettingsIcon,
+    SunMoon,
+    UserCog,
+    type LucideIcon,
+} from 'lucide-vue-next';
+
+export type CommandGroup = 'navigation' | 'actions' | 'system';
+
+export interface Command {
+    /** Stable identifier used as a Vue list key. */
+    id: string;
+    /** Human-readable label shown in the row. */
+    label: string;
+    /** Group bucket the row appears under in the palette list. */
+    group: CommandGroup;
+    /** Lucide icon component rendered on the row. */
+    icon: LucideIcon;
+    /**
+     * Optional alternate search terms — useful for synonyms ("nav", "go to",
+     * "site monitor"). Matched alongside `label` by the fuzzy filter.
+     */
+    keywords?: string[];
+    /** Action to execute when this command is selected. Omitted for "Soon" entries. */
+    run?: () => void;
+    /** Right-side hint text rendered when the command is enabled (e.g. "G O" jump-to). */
+    shortcut?: string;
+    /** Whether the command is currently inert (will display the soonLabel pill). */
+    disabled?: boolean;
+    /** Pill text shown on disabled rows; defaults to "Soon". */
+    soonLabel?: string;
+}
+
+const groupOrder: CommandGroup[] = ['navigation', 'actions', 'system'];
+
+export const commandGroupLabels: Record<CommandGroup, string> = {
+    navigation: 'Navigation',
+    actions: 'Actions',
+    system: 'System',
+};
+
+/**
+ * Build the command registry. Real commands (`run` defined) navigate or
+ * trigger Inertia actions today. Disabled "Soon" entries advertise the
+ * roadmap and stay inert until their owning spec ships — same treatment as
+ * the sidebar nav.
+ */
+export function getCommands(): Command[] {
+    return [
+        // ────── Navigation ────── //
+        {
+            id: 'go-overview',
+            label: 'Go to Overview',
+            group: 'navigation',
+            icon: LayoutDashboard,
+            keywords: ['dashboard', 'home'],
+            run: () => router.visit(route('overview')),
+        },
+        {
+            id: 'go-profile',
+            label: 'Go to Profile',
+            group: 'navigation',
+            icon: UserCog,
+            keywords: ['account', 'settings'],
+            run: () => router.visit(route('profile.edit')),
+        },
+        {
+            id: 'go-projects',
+            label: 'Go to Projects',
+            group: 'navigation',
+            icon: FolderKanban,
+            disabled: true,
+            soonLabel: 'Phase 1',
+        },
+        {
+            id: 'go-repositories',
+            label: 'Go to Repositories',
+            group: 'navigation',
+            icon: GitBranch,
+            disabled: true,
+            soonLabel: 'Phase 1',
+        },
+        {
+            id: 'go-issues-prs',
+            label: 'Go to Issues & PRs',
+            group: 'navigation',
+            icon: GitPullRequest,
+            disabled: true,
+            soonLabel: 'Phase 2',
+        },
+        {
+            id: 'go-pipelines',
+            label: 'Go to Pipelines',
+            group: 'navigation',
+            icon: Activity,
+            disabled: true,
+            soonLabel: 'Phase 4',
+        },
+        {
+            id: 'go-deployments',
+            label: 'Go to Deployments',
+            group: 'navigation',
+            icon: Rocket,
+            disabled: true,
+            soonLabel: 'Phase 4',
+        },
+        {
+            id: 'go-hosts',
+            label: 'Go to Hosts',
+            group: 'navigation',
+            icon: Server,
+            disabled: true,
+            soonLabel: 'Phase 6',
+        },
+        {
+            id: 'go-monitoring',
+            label: 'Go to Monitoring',
+            group: 'navigation',
+            icon: Globe,
+            disabled: true,
+            soonLabel: 'Phase 5',
+        },
+        {
+            id: 'go-analytics',
+            label: 'Go to Analytics',
+            group: 'navigation',
+            icon: BarChart3,
+            disabled: true,
+            soonLabel: 'Phase 8',
+        },
+        {
+            id: 'go-alerts',
+            label: 'Go to Alerts',
+            group: 'navigation',
+            icon: Bell,
+            disabled: true,
+            soonLabel: 'Phase 7',
+        },
+        {
+            id: 'go-settings',
+            label: 'Go to Settings',
+            group: 'navigation',
+            icon: SettingsIcon,
+            disabled: true,
+            soonLabel: 'Phase 1',
+        },
+
+        // ────── Actions ────── //
+        {
+            id: 'log-out',
+            label: 'Log out',
+            group: 'actions',
+            icon: LogOut,
+            keywords: ['sign out', 'logout'],
+            run: () => router.post(route('logout')),
+        },
+        {
+            id: 'create-project',
+            label: 'Create project',
+            group: 'actions',
+            icon: Plus,
+            disabled: true,
+            soonLabel: 'Phase 1',
+        },
+        {
+            id: 'connect-github',
+            label: 'Connect GitHub',
+            group: 'actions',
+            icon: Plug,
+            disabled: true,
+            soonLabel: 'Phase 2',
+        },
+        {
+            id: 'run-sync',
+            label: 'Run sync',
+            group: 'actions',
+            icon: RefreshCw,
+            disabled: true,
+            soonLabel: 'Phase 2',
+        },
+        {
+            id: 'view-failed-deployments',
+            label: 'View failed deployments',
+            group: 'actions',
+            icon: Flame,
+            disabled: true,
+            soonLabel: 'Phase 4',
+        },
+        {
+            id: 'view-slow-websites',
+            label: 'View slow websites',
+            group: 'actions',
+            icon: Globe2,
+            disabled: true,
+            soonLabel: 'Phase 5',
+        },
+
+        // ────── System ────── //
+        {
+            id: 'toggle-theme',
+            label: 'Toggle theme',
+            group: 'system',
+            icon: SunMoon,
+            disabled: true,
+            soonLabel: 'Phase 9',
+        },
+    ];
+}
+
+/**
+ * Stable group ordering — palette rendering uses this to lay groups out in
+ * a deterministic order regardless of registry insertion order.
+ */
+export function compareGroups(a: CommandGroup, b: CommandGroup): number {
+    return groupOrder.indexOf(a) - groupOrder.indexOf(b);
+}
+

--- a/resources/js/lib/fuzzyMatch.ts
+++ b/resources/js/lib/fuzzyMatch.ts
@@ -1,0 +1,61 @@
+/**
+ * Tiny fuzzy matcher used by the command palette. No external deps.
+ *
+ * Scoring tiers (higher = better):
+ *   1000 — exact match
+ *    800 — acronym match (query == initials of target words)
+ *    600 — target starts with query
+ *    500 — acronym starts with query
+ *    300 - position — substring match (earlier position scores higher)
+ *    100 — in-order subsequence match
+ *      0 — no match (filtered out)
+ */
+
+export type ScoredItem<T> = { item: T; score: number };
+
+export function fuzzyMatch<T>(
+    items: readonly T[],
+    query: string,
+    getSearchable: (item: T) => readonly string[],
+): ScoredItem<T>[] {
+    const q = query.trim().toLowerCase();
+    if (!q) {
+        return items.map((item) => ({ item, score: 0 }));
+    }
+
+    const results: ScoredItem<T>[] = [];
+    for (const item of items) {
+        const haystacks = getSearchable(item);
+        let best = 0;
+        for (const raw of haystacks) {
+            const score = scoreOne(raw.toLowerCase(), q);
+            if (score > best) best = score;
+        }
+        if (best > 0) {
+            results.push({ item, score: best });
+        }
+    }
+    return results;
+}
+
+function scoreOne(haystack: string, query: string): number {
+    if (haystack === query) return 1000;
+
+    const acronym = haystack
+        .split(/[\s\-_/]+/)
+        .map((w) => w[0] ?? '')
+        .join('');
+    if (acronym === query) return 800;
+    if (haystack.startsWith(query)) return 600;
+    if (acronym.startsWith(query)) return 500;
+
+    const idx = haystack.indexOf(query);
+    if (idx >= 0) return Math.max(300 - idx, 101);
+
+    // In-order subsequence: every query char appears in haystack in order.
+    let qi = 0;
+    for (let i = 0; i < haystack.length && qi < query.length; i++) {
+        if (haystack[i] === query[qi]) qi++;
+    }
+    return qi === query.length ? 100 : 0;
+}

--- a/specs/phase-0-foundation/005-command-palette.md
+++ b/specs/phase-0-foundation/005-command-palette.md
@@ -1,0 +1,131 @@
+---
+spec: command-palette
+phase: 0-foundation
+status: in-progress
+owner: yoany
+created: 2026-04-27
+updated: 2026-04-27
+issue: https://github.com/Copxer/nexus/issues/9
+branch: spec/005-command-palette
+---
+
+# 005 — CommandPalette (Cmd+K) shell
+
+## Goal
+Stand up the global command palette — a centered, glass-styled modal that opens on `Cmd+K` / `Ctrl+K` and lets the user fuzzy-filter and run navigation/actions from anywhere in the authenticated app. After this spec, the global search input in the top bar (placeholder since spec 004) becomes a real trigger, and the keyboard shortcut works on every page.
+
+This is the **shell** spec — wiring + UX + accessibility + a small set of real commands. The full command catalog (project search, repo search, host opener, "Run sync", etc.) gets fleshed out later as those sections come online; for now those entries render with a "Soon" pill and are inert. This mirrors how the sidebar's nav was treated in spec 004.
+
+Roadmap reference: §7.10 UX Pattern: Command Palette. Sidebar-nav treatment of "Soon" items mirrors §7.6 / spec 004.
+Visual target: [`../visual-reference.md`](../visual-reference.md) → [`../../nexus-dashboard.png`](../../nexus-dashboard.png).
+
+## Scope
+**In scope:**
+- A new `CommandPalette.vue` modal:
+  - Centered, max-width ~640px, glass-card styling consistent with the rest of the shell.
+  - Search input with a Lucide search icon and `Esc` hint pill on the right.
+  - Filtered command list grouped by category (`Navigation`, `Actions`, `System`).
+  - Each row: icon + label + optional keyboard-shortcut hint or "Soon" pill on the right.
+  - Keyboard nav: `↑` / `↓` cycles items, `Enter` runs the highlighted command, `Esc` closes.
+  - Mouse: hover sets the highlighted index; click runs the command.
+  - Empty state: "No matching commands" when the filter returns nothing.
+  - Backdrop click closes; `aria-modal="true"`, `role="dialog"`, focus trap, focus restored to the prior element on close.
+- Global trigger:
+  - `Cmd+K` (macOS) / `Ctrl+K` (other platforms) opens the palette from anywhere inside `AppLayout`.
+  - Clicking the existing top-bar search input also opens the palette (replacing its current `readonly` placeholder behavior).
+  - Listener attached at `AppLayout` level; ignored when the user is typing inside another `<input>` / `<textarea>` / `[contenteditable]` so it doesn't hijack form input — except for the top-bar search field itself, which deliberately triggers it.
+- Command registry in TypeScript (`resources/js/lib/commands.ts`):
+  - Strongly-typed `Command` shape (id, label, group, icon, keywords, run, disabled?, soon?).
+  - Initial entries:
+    - **Navigation:** Go to Overview *(real)*, Go to Profile *(real)*. The 9 placeholder sections from §7.6 (Projects, Repositories, Issues & PRs, Pipelines, Deployments, Hosts, Monitoring, Analytics, Alerts, Settings) appear with a "Soon" pill and are inert — same treatment as the sidebar.
+    - **Actions:** Log out *(real, posts to `/logout`)*. Roadmap-listed actions that don't have backends yet (Create project, Connect GitHub, Run sync, View failed deployments, View slow websites) appear with "Soon" pills.
+    - **System:** Toggle theme — listed as "Soon" (light mode is deferred to phase 9).
+- Update `TopBar/TopBarSearch.vue` to act as a palette **trigger**, not a real input:
+  - Stays visually a search field; clicking or focusing it opens the palette.
+  - Right-side hint pill shows `⌘K` / `Ctrl K` based on platform detection (`navigator.platform` or `userAgent`).
+  - `aria-keyshortcuts="Meta+K Control+K"`, `role="button"` since it now triggers a dialog.
+- Fuzzy filter: substring + acronym match against `label` and `keywords` (no extra dependency — ~30 lines of TS). Sorted by match quality, with disabled/"Soon" items always sinking below the active matches.
+- Tests:
+  - Manual verification of the palette UX in the dev server (open/close, keyboard nav, click, disabled items inert, focus trap, focus restore). Notes captured in the Work log.
+  - One Inertia feature test confirming `/overview` still 200s for an authenticated user (smoke check that nothing server-side regressed).
+  - JS-level unit tests are **deferred** — Vitest isn't wired up in this repo yet. Adding it ships in a separate small chore PR after this spec, then the palette + fuzzy-match get retroactive unit tests.
+
+**Out of scope:**
+- Real backend-powered search (project / repo / host / alert lookups against the database). Comes in later phases when those sections ship.
+- Recents / pinned / history. Add if it earns its keep later.
+- A telemetry hook for "command run" events. Defer until we have an analytics story.
+- Adding a third-party command-palette library — we roll a small in-house one to stay token-consistent and keep the bundle small. Re-evaluate if requirements expand.
+- A secondary `/` shortcut to open the palette. Cmd+K only for now; revisit if it's missed.
+- Theme toggle implementation — listed as a "Soon" entry only.
+- Mobile-specific palette UX polish (we ensure it doesn't break on mobile; full responsive pass is spec 008).
+
+## Plan
+1. Create `resources/js/lib/commands.ts` with the `Command` type and a `getCommands(router)` factory that returns the initial registry. Keep it pure / framework-agnostic so it's easy to test.
+2. Add a tiny fuzzy-match helper (`resources/js/lib/fuzzyMatch.ts`) — substring + acronym scoring. Unit-test it in isolation.
+3. Build `CommandPalette.vue`:
+    - Props: `open: boolean`. Emits: `close`.
+    - Internal state: `query`, `highlightedIndex`.
+    - Computed `filtered` — runs `fuzzyMatch`, partitions by group, keeps disabled items at the bottom of each group.
+    - Keydown handlers wired to the input (`↑`/`↓`/`Enter`/`Esc`).
+    - Focus trap + return-focus via a `ref` captured before opening.
+    - Backdrop click + Esc → `emit('close')`.
+4. Wire it into `AppLayout.vue`:
+    - Add `paletteOpen` ref.
+    - Window-level `keydown` listener (existing Escape listener pattern from spec 004 already lives here): if `(e.metaKey || e.ctrlKey) && e.key === 'k'`, prevent default, open the palette. Skip when target is a form field other than the top-bar trigger.
+    - Render `<CommandPalette :open="paletteOpen" @close="paletteOpen = false" />` near the existing drawer markup.
+5. Convert `TopBar/TopBarSearch.vue` from a `readonly` input into a button-shaped trigger:
+    - Keeps the search-icon prefix and overall pill shape.
+    - Right side: `⌘K` / `Ctrl K` hint pill (platform-detected once on mount).
+    - `@click` and `@keydown.enter`/`@keydown.space` emit `open-palette` up to `TopBar` → `AppLayout`.
+6. Run the dev server, manually verify:
+    - `Cmd+K` opens; `Esc` closes.
+    - Typing filters; `↑/↓/Enter` works; click runs.
+    - Clicking the top-bar search opens the same palette.
+    - Tabbing inside the open palette stays trapped; closing returns focus to the trigger.
+    - Disabled "Soon" items don't fire on Enter or click.
+7. Tests:
+    - `tests/Feature/SmokeTest.php` — one assertion that `/overview` still 200s for an authenticated user (a tiny safety net; no new server code).
+    - JS-level unit tests deferred to a follow-up "wire Vitest" chore PR.
+8. Pipeline pass: Pint, `vue-tsc`, `npm run build`, `php artisan test`.
+9. Self-review with `superpowers:code-reviewer`.
+
+## Acceptance criteria
+- [ ] `Cmd+K` (or `Ctrl+K` on non-mac) opens the palette from any authenticated page.
+- [ ] `Esc` closes; backdrop click closes; focus is restored to the prior element on close.
+- [ ] Clicking the top-bar search field opens the same palette; the field shows a `⌘K` / `Ctrl K` hint pill.
+- [ ] Filtering with the input narrows the list; matches highlight the matched substring (or are simply ranked higher — no requirement to render markup-level highlighting in this spec).
+- [ ] `↑` / `↓` / `Enter` keyboard navigation works; mouse hover sets the highlighted index.
+- [ ] **Real commands** that work end-to-end: Go to Overview, Go to Profile, Log out.
+- [ ] **"Soon" commands** are listed but inert: Projects, Repositories, Issues & PRs, Pipelines, Deployments, Hosts, Monitoring, Analytics, Alerts, Settings, Create project, Connect GitHub, Run sync, View failed deployments, View slow websites, Toggle theme.
+- [ ] Disabled commands cannot be triggered by Enter or click and have `aria-disabled="true"`.
+- [ ] Palette has `role="dialog"`, `aria-modal="true"`, `aria-label="Command palette"`. Internal list has `role="listbox"`; rows have `role="option"` and `aria-selected` reflects the highlighted index.
+- [ ] Focus is trapped inside the palette while open; Tab cycles input ↔ list (or stays on input — design choice noted in the work log).
+- [ ] No `gray-*` / `indigo-*` / `red-*` / `green-*` Tailwind classes leak into the new components — design tokens only.
+- [ ] No regressions: 25/25 tests still pass, Pint clean, `npm run build` green, CI green on the PR.
+- [ ] Self-review pass with `superpowers:code-reviewer`; material findings addressed before PR.
+
+## Files touched
+- `resources/js/Components/CommandPalette/CommandPalette.vue` — new modal component.
+- `resources/js/Components/CommandPalette/CommandPaletteRow.vue` — single command row (icon + label + right-side pill).
+- `resources/js/lib/commands.ts` — typed registry + `getCommands(router)` factory.
+- `resources/js/lib/fuzzyMatch.ts` — small substring + acronym scorer.
+- `resources/js/Layouts/AppLayout.vue` — global keydown listener for `Cmd+K`, palette state, render `<CommandPalette />`.
+- `resources/js/Components/TopBar/TopBarSearch.vue` — converted from `readonly` input to palette-trigger button.
+- `resources/js/Components/TopBar/TopBar.vue` — bubble `open-palette` event from TopBarSearch up to AppLayout.
+- `tests/Feature/SmokeTest.php` — light smoke test that `/overview` still renders.
+
+## Work log
+Dated notes as work progresses.
+
+### 2026-04-27
+- Spec drafted; scope confirmed with the user (4 decisions locked: defer JS tests, skip `/`, list "Soon" items, roll our own).
+- Opened issue [#9](https://github.com/Copxer/nexus/issues/9) and branch `spec/005-command-palette` off `main`.
+
+## Decisions (locked 2026-04-27)
+- **JS test runner — defer.** Vitest is not wired up; adding it ships in a separate small chore PR right after this spec. This spec relies on manual verification + a PHP smoke test.
+- **`/` as secondary trigger — skip.** Cmd+K only for now; revisit if missed.
+- **"Soon" treatment — list, don't hide.** Unbuilt commands appear with a "Soon" pill, same as the sidebar nav from spec 004.
+- **Library choice — roll our own.** No third-party command palette dep; ~150 lines of Vue with full token control. Re-evaluate only if requirements expand.
+
+## Open questions / blockers
+- **Trigger from input fields.** Standard pattern is to ignore `Cmd+K` while typing in another input. Profile-edit forms have inputs. Confirming that's fine — Cmd+K won't open while editing your profile, you'd Tab/Esc out first. (Matches GitHub / Linear / Vercel.)

--- a/specs/phase-0-foundation/005-command-palette.md
+++ b/specs/phase-0-foundation/005-command-palette.md
@@ -134,6 +134,12 @@ Dated notes as work progresses.
     - **[nit]** Top-bar trigger placeholder "Search projects, repos, hosts…" wrapped to 2 lines at md/lg widths because the `Ctrl K` pill ate width. Shortened to "Search or run a command…" and added `min-w-0 truncate whitespace-nowrap` so it never wraps regardless of label length.
 - **Local test failure note:** 14 pre-existing tests fail locally on PHP 8.5.5 (Homebrew) with HTTP 419 (CSRF mismatch) on every `$this->post(...)` call. Confirmed they fail on bare `main` too via `git stash` — not introduced by this spec. CI runs PHP 8.4 where they pass; the new `SmokeTest::test_overview_renders_for_a_verified_user` passes locally and will pass on CI. A follow-up chore PR to investigate the PHP 8.5 / Laravel 13.6 testing-CSRF interaction is out of scope here.
 - Pipeline (local): vue-tsc clean, Pint clean, `npm run build` green (AppLayout chunk grew 22 KB → ~34 KB; the palette + 19 lucide icons + commands registry account for the delta).
+- Self-review with `superpowers:code-reviewer`. No blockers; 2 material findings + 1 nit addressed:
+    - **[material]** Cmd+K while the palette is already open delivered the keystroke to the dialog's own search input. Fix: short-circuit in `AppLayout.onKeydown` — when `paletteOpen` is true, `preventDefault` and no-op (matches Linear/GitHub convention; user closes via Esc).
+    - **[material, future-proofing]** AppLayout's Escape branch could double-fire with the palette's own Escape. Fix: early `return` from the Escape branch when `paletteOpen` is true — palette has its own scoped handler, and a future drawer + palette overlap won't close the wrong overlay.
+    - **[nit]** `flatVisible` was a redundant alias for `filtered`. Removed; consolidated to `filtered` everywhere.
+    - Skipped (acceptable per spec/agent agreement): trapping Shift+Tab beyond the input (input is the only tabbable element and `aria-activedescendant` correctly drives screen-reader option announcements); migrating inline `title` strings in TopBar/Overview from spec-number to phase-number language (deferred — both are stable references).
+- Re-ran the pipeline after fixes: vue-tsc clean, Pint clean, `npm run build` green; manual re-verification of the Cmd+K-while-open path passed (search field stays empty, palette stays open).
 
 ## Decisions (locked 2026-04-27)
 - **JS test runner — defer.** Vitest is not wired up; adding it ships in a separate small chore PR right after this spec. This spec relies on manual verification + a PHP smoke test.

--- a/specs/phase-0-foundation/005-command-palette.md
+++ b/specs/phase-0-foundation/005-command-palette.md
@@ -120,6 +120,20 @@ Dated notes as work progresses.
 ### 2026-04-27
 - Spec drafted; scope confirmed with the user (4 decisions locked: defer JS tests, skip `/`, list "Soon" items, roll our own).
 - Opened issue [#9](https://github.com/Copxer/nexus/issues/9) and branch `spec/005-command-palette` off `main`.
+- Implemented `lib/fuzzyMatch.ts` (substring + acronym scorer), `lib/commands.ts` (typed registry with 19 commands: 3 real, 15 "Soon" mirroring §7.6 sidebar nav + roadmap §7.10 actions, 1 "Soon" theme toggle), `Components/CommandPalette/{CommandPalette,CommandPaletteRow}.vue`, extracted `Components/TopBar/TopBarSearch.vue` (the search markup was previously inlined inside `TopBar.vue`), wired Cmd+K listener + palette mount into `AppLayout.vue`, added `tests/Feature/SmokeTest.php`.
+- Manual verification in dev server (Playwright Chrome, 1440×900):
+    - Cmd+K opens, Esc closes, backdrop click closes, click on top-bar trigger opens.
+    - Filter narrows correctly: typing `log` reduces list to "Log out" under ACTIONS with cyan-stripe highlight.
+    - Real commands work end-to-end: Enter on "Log out" logged the test user out and redirected to `/`.
+    - ArrowDown navigation skips all 10 disabled "Soon" entries between "Go to Profile" and "Log out" exactly once.
+    - "No matching commands." empty state renders for `xyzzz`.
+    - Focus restored to the top-bar trigger on close — visible cyan focus ring.
+    - Group labels (NAVIGATION, ACTIONS) render in stable order; "Soon" pills carry phase labels.
+- Two issues found and fixed during manual verification:
+    - **[material]** Cursor parked over a list row at the moment Cmd+K rendered the dialog stole the keyboard-set highlight via `@mouseenter` (browsers fire it on elements that appear under the cursor). Fix: added a `mouseMovedSinceOpen` guard — `@mouseenter` on a row only updates `highlightedIndex` after the user has moved the mouse inside the dialog. `@mousemove` on the dialog flips the guard. Reset on each open.
+    - **[nit]** Top-bar trigger placeholder "Search projects, repos, hosts…" wrapped to 2 lines at md/lg widths because the `Ctrl K` pill ate width. Shortened to "Search or run a command…" and added `min-w-0 truncate whitespace-nowrap` so it never wraps regardless of label length.
+- **Local test failure note:** 14 pre-existing tests fail locally on PHP 8.5.5 (Homebrew) with HTTP 419 (CSRF mismatch) on every `$this->post(...)` call. Confirmed they fail on bare `main` too via `git stash` — not introduced by this spec. CI runs PHP 8.4 where they pass; the new `SmokeTest::test_overview_renders_for_a_verified_user` passes locally and will pass on CI. A follow-up chore PR to investigate the PHP 8.5 / Laravel 13.6 testing-CSRF interaction is out of scope here.
+- Pipeline (local): vue-tsc clean, Pint clean, `npm run build` green (AppLayout chunk grew 22 KB → ~34 KB; the palette + 19 lucide icons + commands registry account for the delta).
 
 ## Decisions (locked 2026-04-27)
 - **JS test runner — defer.** Vitest is not wired up; adding it ships in a separate small chore PR right after this spec. This spec relies on manual verification + a PHP smoke test.

--- a/tests/Feature/SmokeTest.php
+++ b/tests/Feature/SmokeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SmokeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_overview_renders_for_a_verified_user(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->get('/overview')
+            ->assertStatus(200);
+    }
+}


### PR DESCRIPTION
Closes #9

Spec: [`specs/phase-0-foundation/005-command-palette.md`](https://github.com/Copxer/nexus/blob/spec/005-command-palette/specs/phase-0-foundation/005-command-palette.md)

## Summary
- Centered glass-card command palette opened by `Cmd+K` / `Ctrl+K` and by clicking the existing top-bar search trigger. Fuzzy filter, keyboard nav (↑/↓/Enter/Esc), focus trap on the input, focus restored to the trigger on close, ARIA dialog + listbox semantics, `mouseMovedSinceOpen` guard so a parked cursor doesn't steal the keyboard-set highlight.
- 19 commands in a typed registry. Real (work end-to-end): Go to Overview, Go to Profile, Log out. "Soon" (visible, inert, with phase-labelled pills): the 10 sidebar sections, 5 roadmap-§7.10 actions (Create project, Connect GitHub, Run sync, View failed deployments, View slow websites), and Toggle theme. Same disabled-row treatment as the sidebar nav from spec 004.
- Rolled our own (~150 LOC across `CommandPalette.vue` + `CommandPaletteRow.vue` + `lib/commands.ts` + `lib/fuzzyMatch.ts`); no third-party palette dep. AppLayout chunk grew ~22 KB → ~34 KB (palette + 19 lucide icons).
- Top-bar search markup extracted from `TopBar.vue` into a new `TopBarSearch.vue` and converted from `readonly` input to a button-shaped trigger with platform-detected `⌘K` / `Ctrl K` hint.
- Decisions per spec scope-confirmation: defer JS unit tests until Vitest is wired up (separate chore PR), skip secondary `/` shortcut, list "Soon" entries (don't hide), roll our own.

## Test plan
- [x] `Cmd+K` (or `Ctrl+K` on non-mac) opens the palette from any authenticated page.
- [x] `Esc` closes; backdrop click closes; focus is restored to the prior element on close.
- [x] Clicking the top-bar search field opens the same palette; the field shows the platform-aware shortcut pill.
- [x] Filtering narrows the list; matches are ranked higher than disabled "Soon" items.
- [x] `↑` / `↓` / `Enter` keyboard navigation works; arrow nav skips disabled rows.
- [x] Real commands work end-to-end (verified Log out → redirect to `/`).
- [x] All 16 "Soon" commands are listed, inert, and carry an `aria-disabled="true"` + a phase pill.
- [x] Palette has `role="dialog"`, `aria-modal="true"`, `aria-label="Command palette"`. List is `role="listbox"`, rows are `role="option"`, `aria-selected` reflects the highlighted index, `aria-activedescendant` on the input tracks the highlighted row.
- [x] No `gray-*` / `red-*` / `green-*` / `indigo-*` Tailwind classes — design tokens only.
- [x] Pint clean, `npm run build` green, vue-tsc clean.
- [x] New `tests/Feature/SmokeTest.php` asserts `/overview` still 200s for a verified user.

## Self-review notes
Ran `superpowers:code-reviewer` on `git diff main...HEAD`. No blockers.

- **[material, fixed]** `Cmd+K` while the palette was already open delivered the keystroke to the dialog's own search input. Now `AppLayout.onKeydown` short-circuits with `preventDefault` + no-op when `paletteOpen` is true.
- **[material, fixed — future-proofing]** AppLayout's Escape branch could overlap with the palette's own Escape handler. AppLayout now bails on Escape when `paletteOpen` is true so the palette's scoped handler is the only one acting.
- **[nit, fixed]** `flatVisible` in `CommandPalette.vue` was a redundant alias for `filtered`. Consolidated.
- **Skipped (acceptable per spec):** trapping Shift+Tab beyond the input (input is the only tabbable element and `aria-activedescendant` correctly drives SR option announcements); migrating inline `title` strings in TopBar/Overview from spec-number to phase-number language (deferred — both are stable references).

## Local note
14 pre-existing tests fail locally on PHP 8.5.5 (Homebrew) with HTTP 419 (CSRF mismatch) on every `$this->post(...)` call. Confirmed they fail on bare `main` too — not introduced by this spec. CI runs PHP 8.4 where they pass. The new `SmokeTest::test_overview_renders_for_a_verified_user` passes locally and on CI. A follow-up chore PR to investigate the PHP 8.5 / Laravel 13.6 testing-CSRF interaction is out of scope for this spec.