### PR TITLE
chore(specs): mark spec 005 done; update trackers

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -35,7 +35,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 
 | # | Phase | Status | Notes |
 |---|-------|--------|-------|
-| 0 | Foundation (auth, layout, static overview) | ⬜ | — |
+| 0 | Foundation (auth, layout, static overview) | 🟡 | 5/9 specs done (001–005). Next: 006 Overview KPI cards. |
 | 1 | Projects & Repositories | ⬜ | — |
 | 2 | GitHub Integration MVP | ⬜ | — |
 | 3 | GitHub Webhooks & Activity Feed | ⬜ | — |

--- a/specs/phase-0-foundation/005-command-palette.md
+++ b/specs/phase-0-foundation/005-command-palette.md
@@ -1,12 +1,13 @@
 ---
 spec: command-palette
 phase: 0-foundation
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-27
 updated: 2026-04-27
 issue: https://github.com/Copxer/nexus/issues/9
 branch: spec/005-command-palette
+pr: https://github.com/Copxer/nexus/pull/10
 ---
 
 # 005 — CommandPalette (Cmd+K) shell

--- a/specs/phase-0-foundation/README.md
+++ b/specs/phase-0-foundation/README.md
@@ -14,7 +14,7 @@ Stand up a Laravel 12 + Vue 3 + Inertia + Tailwind project with authentication, 
 | 002 | Auth scaffolding (login / register / verified email) | 🟢 |
 | 003 | Design tokens + Tailwind theme (dark, glassmorphism, neon accents) | 🟢 |
 | 004 | AppLayout + Sidebar + TopBar + RightActivityRail | 🟢 |
-| 005 | CommandPalette (Cmd+K) shell | ⬜ |
+| 005 | CommandPalette (Cmd+K) shell | 🟢 |
 | 006 | Overview page with mock KPI cards, sparklines, status badges | ⬜ |
 | 007 | ActivityFeed + ActivityHeatmap components (mock data) | ⬜ |
 | 008 | Responsive behavior (desktop / laptop / tablet / mobile) | ⬜ |


### PR DESCRIPTION
Bookkeeping for [Spec 005 — CommandPalette (Cmd+K) shell](https://github.com/Copxer/nexus/pull/10) (merged in #10).

## Summary
- `specs/phase-0-foundation/005-command-palette.md` → frontmatter `status: done`; added PR link.
- `specs/phase-0-foundation/README.md` → flip row 005 from ⬜ to 🟢.
- `specs/README.md` → flip Phase 0 from ⬜ to 🟡 with notes (5/9 specs done; next: 006).

## Test plan
- [ ] CI green (Pint + build + tests).
- [ ] Tracker tables render correctly on GitHub.