### PR TITLE
Spec 006 — Overview page with mock KPI cards, sparklines, status badges

### DIFF
--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Inertia\Inertia;
+use Inertia\Response;
+
+class OverviewController extends Controller
+{
+    /**
+     * Render the Overview dashboard with mock KPI data.
+     *
+     * Shape mirrors roadmap §8.1.1 with two phase-0 additions per card:
+     *   - `sparkline`: 12-point series the frontend renders inline.
+     *   - `status`:    one of success | warning | danger | info — drives the badge tone.
+     *
+     * Values are intentionally hardcoded; the data contract is the
+     * point of this spec, not the wiring.
+     */
+    public function __invoke(): Response
+    {
+        return Inertia::render('Overview', [
+            'dashboard' => [
+                'projects' => [
+                    'active' => 12,
+                    'new_this_week' => 2,
+                    'sparkline' => [4, 5, 6, 6, 7, 8, 9, 10, 11, 11, 12, 12],
+                    'status' => 'success',
+                ],
+                'deployments' => [
+                    'successful_24h' => 24,
+                    'change_percent' => 18,
+                    'sparkline' => [12, 14, 13, 16, 18, 20, 19, 22, 21, 23, 24, 24],
+                    'status' => 'success',
+                ],
+                'services' => [
+                    'running' => 47,
+                    'health_percent' => 100,
+                    'sparkline' => [44, 45, 45, 46, 46, 47, 47, 47, 47, 47, 47, 47],
+                    'status' => 'success',
+                ],
+                'hosts' => [
+                    'online' => 128,
+                    'new' => 4,
+                    'sparkline' => [120, 121, 122, 123, 124, 124, 125, 126, 126, 127, 128, 128],
+                    'status' => 'info',
+                ],
+                'alerts' => [
+                    'active' => 3,
+                    'critical' => 1,
+                    'sparkline' => [1, 0, 1, 2, 1, 1, 2, 2, 3, 2, 3, 3],
+                    'status' => 'danger',
+                ],
+                'uptime' => [
+                    'overall' => 99.98,
+                    'change' => 0.01,
+                    'sparkline' => [99.92, 99.93, 99.95, 99.94, 99.96, 99.97, 99.96, 99.97, 99.98, 99.98, 99.97, 99.98],
+                    'status' => 'success',
+                ],
+            ],
+        ]);
+    }
+}

--- a/resources/js/Components/Dashboard/KpiCard.vue
+++ b/resources/js/Components/Dashboard/KpiCard.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import Sparkline from '@/Components/Dashboard/Sparkline.vue';
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import TrendChip from '@/Components/Dashboard/TrendChip.vue';
+import type { LucideIcon } from 'lucide-vue-next';
+import { computed } from 'vue';
+
+type Accent = 'cyan' | 'blue' | 'purple' | 'magenta' | 'success' | 'danger';
+
+const props = withDefaults(
+    defineProps<{
+        label: string;
+        /** Big numeric (or short) value rendered in tabular nums. */
+        value: string;
+        /** Tiny secondary label beneath the value, e.g. "Successful", "Online". */
+        secondary?: string;
+        icon: LucideIcon;
+        /** Drives the icon glow + sparkline accent. */
+        accent?: Accent;
+        /** Optional trend indicator next to the value. */
+        trend?: { direction: 'up' | 'down' | 'flat'; value: string };
+        /** Optional health pill rendered top-right of the card. */
+        status?: 'success' | 'warning' | 'danger' | 'info';
+        statusLabel?: string;
+        /** Optional inline mini-sparkline data. */
+        sparkline?: number[];
+        /**
+         * Click-to-detail target. When omitted (or `disabled` is true) the
+         * card is rendered as inert with `aria-disabled` — mirrors the
+         * sidebar/palette "Soon" treatment until target sections exist.
+         */
+        href?: string;
+        disabled?: boolean;
+    }>(),
+    {
+        accent: 'cyan',
+        disabled: true,
+    },
+);
+
+const isInert = computed(() => props.disabled || !props.href);
+
+const accentIconClass: Record<Accent, string> = {
+    cyan: 'text-accent-cyan shadow-[0_0_24px_rgba(34,211,238,0.45)]',
+    blue: 'text-accent-blue shadow-[0_0_24px_rgba(56,189,248,0.45)]',
+    purple: 'text-accent-purple shadow-[0_0_24px_rgba(139,92,246,0.45)]',
+    magenta: 'text-accent-magenta shadow-[0_0_24px_rgba(217,70,239,0.45)]',
+    success: 'text-status-success shadow-glow-success',
+    danger: 'text-status-danger shadow-glow-danger',
+};
+</script>
+
+<template>
+    <component
+        :is="isInert ? 'div' : 'a'"
+        :href="!isInert ? href : undefined"
+        :aria-disabled="isInert ? 'true' : undefined"
+        :tabindex="isInert ? 0 : undefined"
+        :title="
+            isInert
+                ? `${label} detail view lands when the section ships`
+                : undefined
+        "
+        class="glass-card group relative flex flex-col gap-4 p-4 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+        :class="[isInert ? 'cursor-default' : 'cursor-pointer']"
+    >
+        <!-- Top row: icon (with accent glow) + status pill -->
+        <div class="flex items-start justify-between gap-3">
+            <span
+                class="flex h-9 w-9 items-center justify-center rounded-xl border border-border-subtle bg-background-panel-hover transition group-hover:border-accent-cyan/30"
+            >
+                <component
+                    :is="icon"
+                    class="h-4 w-4 transition"
+                    :class="accentIconClass[accent]"
+                    aria-hidden="true"
+                />
+            </span>
+            <StatusBadge v-if="status" :tone="status">
+                {{ statusLabel ?? status }}
+            </StatusBadge>
+        </div>
+
+        <!-- Value cluster -->
+        <div class="flex flex-col gap-1">
+            <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                <span
+                    class="font-display text-3xl font-semibold tabular-nums text-text-primary"
+                >
+                    {{ value }}
+                </span>
+                <TrendChip
+                    v-if="trend"
+                    :direction="trend.direction"
+                    :value="trend.value"
+                />
+            </div>
+            <div
+                class="flex items-center justify-between gap-2 text-xs text-text-muted"
+            >
+                <span class="truncate">{{ label }}</span>
+                <span v-if="secondary" class="shrink-0 text-text-secondary">
+                    {{ secondary }}
+                </span>
+            </div>
+        </div>
+
+        <!-- Sparkline footer -->
+        <Sparkline
+            v-if="sparkline && sparkline.length > 1"
+            :points="sparkline"
+            :accent="accent"
+        />
+    </component>
+</template>

--- a/resources/js/Components/Dashboard/KpiCard.vue
+++ b/resources/js/Components/Dashboard/KpiCard.vue
@@ -51,18 +51,24 @@ const accentIconClass: Record<Accent, string> = {
 </script>
 
 <template>
+    <!-- Inert variant renders as a plain <div>: not in the tab order, no
+         aria-disabled (which would otherwise be announced as a "dimmed
+         control" by screen readers and confuse the user). The interactive
+         variant renders as an <a> with the focus ring + cursor. -->
     <component
         :is="isInert ? 'div' : 'a'"
         :href="!isInert ? href : undefined"
-        :aria-disabled="isInert ? 'true' : undefined"
-        :tabindex="isInert ? 0 : undefined"
         :title="
             isInert
                 ? `${label} detail view lands when the section ships`
                 : undefined
         "
-        class="glass-card group relative flex flex-col gap-4 p-4 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
-        :class="[isInert ? 'cursor-default' : 'cursor-pointer']"
+        class="glass-card group relative flex flex-col gap-4 p-4"
+        :class="[
+            isInert
+                ? 'cursor-default'
+                : 'cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60',
+        ]"
     >
         <!-- Top row: icon (with accent glow) + status pill -->
         <div class="flex items-start justify-between gap-3">

--- a/resources/js/Components/Dashboard/Sparkline.vue
+++ b/resources/js/Components/Dashboard/Sparkline.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = withDefaults(
+    defineProps<{
+        /** Series values. The line is drawn proportionally to min/max within `points`. */
+        points: number[];
+        /** Stroke + fill accent. Maps to design-token colors via accentRgb below. */
+        accent?: 'cyan' | 'blue' | 'purple' | 'magenta' | 'success' | 'danger';
+        /** Visual height of the SVG element in CSS pixels. */
+        height?: number;
+    }>(),
+    {
+        accent: 'cyan',
+        height: 28,
+    },
+);
+
+/**
+ * Token RGB for stroke + gradient fill. Mirrors the values from
+ * tailwind.config.js so the sparkline stays token-driven without pulling in
+ * the JS color resolver.
+ */
+const accentRgb: Record<NonNullable<typeof props.accent>, string> = {
+    cyan: '34, 211, 238',
+    blue: '56, 189, 248',
+    purple: '139, 92, 246',
+    magenta: '217, 70, 239',
+    success: '34, 197, 94',
+    danger: '239, 68, 68',
+};
+
+const VIEW_W = 100;
+const VIEW_H = 24;
+
+const polyline = computed(() => {
+    const pts = props.points;
+    if (pts.length < 2) return '';
+    const min = Math.min(...pts);
+    const max = Math.max(...pts);
+    const range = max - min || 1;
+    const stepX = VIEW_W / (pts.length - 1);
+    return pts
+        .map((v, i) => {
+            const x = (i * stepX).toFixed(2);
+            const y = (VIEW_H - ((v - min) / range) * VIEW_H).toFixed(2);
+            return `${x},${y}`;
+        })
+        .join(' ');
+});
+
+/** Closed polygon for the gradient fill — the line plus two corners + back to start. */
+const area = computed(() => {
+    if (!polyline.value) return '';
+    const last = (props.points.length - 1) * (VIEW_W / (props.points.length - 1));
+    return `${polyline.value} ${last.toFixed(2)},${VIEW_H} 0,${VIEW_H}`;
+});
+
+const gradientId = computed(
+    () => `sparkline-${props.accent}-${Math.random().toString(36).slice(2, 8)}`,
+);
+
+const stroke = computed(() => `rgb(${accentRgb[props.accent]})`);
+const fillStart = computed(() => `rgba(${accentRgb[props.accent]}, 0.28)`);
+const fillEnd = computed(() => `rgba(${accentRgb[props.accent]}, 0)`);
+</script>
+
+<template>
+    <svg
+        :viewBox="`0 0 ${VIEW_W} ${VIEW_H}`"
+        :height="height"
+        preserveAspectRatio="none"
+        class="block w-full"
+        aria-hidden="true"
+        focusable="false"
+    >
+        <defs>
+            <linearGradient :id="gradientId" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" :stop-color="fillStart" />
+                <stop offset="100%" :stop-color="fillEnd" />
+            </linearGradient>
+        </defs>
+        <polygon v-if="area" :points="area" :fill="`url(#${gradientId})`" />
+        <polyline
+            v-if="polyline"
+            :points="polyline"
+            fill="none"
+            :stroke="stroke"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            vector-effect="non-scaling-stroke"
+        />
+    </svg>
+</template>

--- a/resources/js/Components/Dashboard/Sparkline.vue
+++ b/resources/js/Components/Dashboard/Sparkline.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { uniqueId } from '@/lib/uniqueId';
 import { computed } from 'vue';
 
 const props = withDefaults(
@@ -49,16 +50,13 @@ const polyline = computed(() => {
         .join(' ');
 });
 
-/** Closed polygon for the gradient fill — the line plus two corners + back to start. */
+/** Closed polygon for the gradient fill — line + bottom-right corner + bottom-left corner. */
 const area = computed(() => {
     if (!polyline.value) return '';
-    const last = (props.points.length - 1) * (VIEW_W / (props.points.length - 1));
-    return `${polyline.value} ${last.toFixed(2)},${VIEW_H} 0,${VIEW_H}`;
+    return `${polyline.value} ${VIEW_W},${VIEW_H} 0,${VIEW_H}`;
 });
 
-const gradientId = computed(
-    () => `sparkline-${props.accent}-${Math.random().toString(36).slice(2, 8)}`,
-);
+const gradientId = uniqueId(`sparkline-${props.accent}`);
 
 const stroke = computed(() => `rgb(${accentRgb[props.accent]})`);
 const fillStart = computed(() => `rgba(${accentRgb[props.accent]}, 0.28)`);

--- a/resources/js/Components/Dashboard/StatusBadge.vue
+++ b/resources/js/Components/Dashboard/StatusBadge.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = withDefaults(
+    defineProps<{
+        tone?: 'success' | 'warning' | 'danger' | 'info' | 'muted';
+        /** When true, render only the dot (no pill chrome). For tight spaces. */
+        dotOnly?: boolean;
+    }>(),
+    {
+        tone: 'info',
+        dotOnly: false,
+    },
+);
+
+/**
+ * Token classes per tone. Glow is reserved for `success` (per visual-reference
+ * rule "glow only for active/healthy states"). Other tones get a flat
+ * coloured dot. Pill chrome stays consistent across tones.
+ */
+const tones = {
+    success: {
+        dot: 'bg-status-success shadow-glow-success',
+        pill: 'border-status-success/30 bg-status-success/10 text-status-success',
+    },
+    warning: {
+        dot: 'bg-status-warning',
+        pill: 'border-status-warning/30 bg-status-warning/10 text-status-warning',
+    },
+    danger: {
+        dot: 'bg-status-danger',
+        pill: 'border-status-danger/30 bg-status-danger/10 text-status-danger',
+    },
+    info: {
+        dot: 'bg-status-info',
+        pill: 'border-status-info/30 bg-status-info/10 text-status-info',
+    },
+    muted: {
+        dot: 'bg-text-muted',
+        pill: 'border-border-subtle bg-background-panel-hover text-text-muted',
+    },
+} as const;
+
+const styles = computed(() => tones[props.tone]);
+</script>
+
+<template>
+    <span
+        v-if="dotOnly"
+        class="inline-block h-2 w-2 shrink-0 rounded-full"
+        :class="styles.dot"
+        aria-hidden="true"
+    />
+    <span
+        v-else
+        class="inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]"
+        :class="styles.pill"
+    >
+        <span
+            class="inline-block h-1.5 w-1.5 rounded-full"
+            :class="styles.dot"
+            aria-hidden="true"
+        />
+        <slot />
+    </span>
+</template>

--- a/resources/js/Components/Dashboard/TrendChip.vue
+++ b/resources/js/Components/Dashboard/TrendChip.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { ArrowDownRight, ArrowUpRight, Minus } from 'lucide-vue-next';
+import { computed } from 'vue';
+
+const props = withDefaults(
+    defineProps<{
+        direction: 'up' | 'down' | 'flat';
+        /** Pre-formatted change string, e.g. "+18%", "-2.3%", "+0.01". */
+        value: string;
+    }>(),
+    {
+        direction: 'flat',
+    },
+);
+
+const styles = computed(() => {
+    if (props.direction === 'up') {
+        return {
+            icon: ArrowUpRight,
+            className:
+                'border-status-success/30 bg-status-success/10 text-status-success',
+        };
+    }
+    if (props.direction === 'down') {
+        return {
+            icon: ArrowDownRight,
+            className:
+                'border-status-danger/30 bg-status-danger/10 text-status-danger',
+        };
+    }
+    return {
+        icon: Minus,
+        className:
+            'border-border-subtle bg-background-panel-hover text-text-muted',
+    };
+});
+</script>
+
+<template>
+    <span
+        class="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 font-mono text-[11px] font-semibold tabular-nums"
+        :class="styles.className"
+    >
+        <component :is="styles.icon" class="h-3 w-3" aria-hidden="true" />
+        {{ value }}
+    </span>
+</template>

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -6,11 +6,14 @@ import AppLayout from '@/Layouts/AppLayout.vue';
 import type { DashboardPayload } from '@/types';
 import { Head } from '@inertiajs/vue3';
 import {
+    Activity,
     BarChart3,
     Bell,
     FolderKanban,
+    Gauge,
     GitBranch,
     GitPullRequest,
+    Globe,
     HeartPulse,
     LineChart,
     Rocket,
@@ -99,10 +102,10 @@ const stubServices = [
 ];
 
 const visualizationStubs = [
-    { label: 'World map', icon: LineChart, phase: 'Phase 8' },
-    { label: 'Resource utilization', icon: LineChart, phase: 'Phase 6' },
+    { label: 'World map', icon: Globe, phase: 'Phase 8' },
+    { label: 'Resource utilization', icon: Activity, phase: 'Phase 6' },
     { label: 'Website performance', icon: LineChart, phase: 'Phase 5' },
-    { label: 'System metrics', icon: BarChart3, phase: 'Phase 8' },
+    { label: 'System metrics', icon: Gauge, phase: 'Phase 8' },
     { label: 'Deployment timeline', icon: Rocket, phase: 'Phase 4' },
 ] as const;
 </script>

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -1,6 +1,110 @@
 <script setup lang="ts">
+import KpiCard from '@/Components/Dashboard/KpiCard.vue';
+import Sparkline from '@/Components/Dashboard/Sparkline.vue';
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import type { DashboardPayload } from '@/types';
 import { Head } from '@inertiajs/vue3';
+import {
+    BarChart3,
+    Bell,
+    FolderKanban,
+    GitBranch,
+    GitPullRequest,
+    HeartPulse,
+    LineChart,
+    Rocket,
+    Server,
+    ShieldCheck,
+} from 'lucide-vue-next';
+
+defineProps<{
+    dashboard: DashboardPayload;
+}>();
+
+// ----- Hardcoded mock data for the populated stub widgets -----
+// These widgets each have their own dedicated spec in later phases. The
+// mock data here exists only so the page looks intentional, not skeletal —
+// each stub footer points at the phase that will replace it.
+
+const stubIssues = [
+    {
+        title: 'Login flow rejects valid 2FA codes intermittently',
+        repo: 'nexus-web',
+        time: '12 min',
+        priority: 'critical' as const,
+    },
+    {
+        title: 'Migrate analytics events to BigQuery sink',
+        repo: 'nexus-api',
+        time: '3 h',
+        priority: 'high' as const,
+    },
+    {
+        title: 'Add dark-mode tokens to email templates',
+        repo: 'nexus-mail',
+        time: '1 d',
+        priority: 'medium' as const,
+    },
+    {
+        title: 'Expose feature-flag SDK in the JS bundle',
+        repo: 'nexus-flags',
+        time: '2 d',
+        priority: 'low' as const,
+    },
+];
+
+const priorityToneMap = {
+    critical: 'danger',
+    high: 'warning',
+    medium: 'info',
+    low: 'muted',
+} as const;
+
+const stubRepos = [
+    { name: 'nexus-web', commits: 124, share: 0.92 },
+    { name: 'nexus-api', commits: 98, share: 0.74 },
+    { name: 'infra-as-code', commits: 56, share: 0.42 },
+    { name: 'nexus-mail', commits: 31, share: 0.23 },
+];
+
+const stubHosts = [
+    { name: 'prod-web-01', region: 'us-east', cpu: 0.42, mem: 0.61, status: 'success' as const },
+    { name: 'prod-api-02', region: 'us-east', cpu: 0.78, mem: 0.83, status: 'warning' as const },
+    { name: 'edge-eu-01', region: 'eu-west', cpu: 0.31, mem: 0.48, status: 'success' as const },
+    { name: 'edge-ap-01', region: 'ap-south', cpu: 0.55, mem: 0.69, status: 'success' as const },
+];
+
+const stubServices = [
+    {
+        name: 'API Gateway',
+        status: 'success' as const,
+        sparkline: [98, 99, 99, 100, 100, 99, 100, 100, 100, 99, 100, 100],
+    },
+    {
+        name: 'Auth Service',
+        status: 'success' as const,
+        sparkline: [99, 100, 100, 99, 100, 100, 100, 100, 99, 100, 100, 100],
+    },
+    {
+        name: 'Billing',
+        status: 'warning' as const,
+        sparkline: [100, 99, 98, 96, 94, 95, 96, 95, 94, 93, 95, 96],
+    },
+    {
+        name: 'Notifications',
+        status: 'success' as const,
+        sparkline: [99, 99, 100, 100, 100, 99, 100, 100, 100, 100, 100, 100],
+    },
+];
+
+const visualizationStubs = [
+    { label: 'World map', icon: LineChart, phase: 'Phase 8' },
+    { label: 'Resource utilization', icon: LineChart, phase: 'Phase 6' },
+    { label: 'Website performance', icon: LineChart, phase: 'Phase 5' },
+    { label: 'System metrics', icon: BarChart3, phase: 'Phase 8' },
+    { label: 'Deployment timeline', icon: Rocket, phase: 'Phase 4' },
+] as const;
 </script>
 
 <template>
@@ -14,18 +118,376 @@ import { Head } from '@inertiajs/vue3';
                 >
                     Phase 0
                 </span>
-                <h1 class="text-lg font-semibold text-text-primary">
-                    Overview
-                </h1>
+                <h1 class="text-lg font-semibold text-text-primary">Overview</h1>
             </div>
         </template>
 
-        <div class="px-4 py-8 sm:px-6 lg:px-8">
-            <div class="mx-auto max-w-7xl">
-                <div class="glass-card p-8 text-text-secondary">
-                    The dashboard shell is live. Real KPI cards, charts, and
-                    activity stream land in spec 006.
-                </div>
+        <div class="space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+            <!-- ─────────────── KPI row (6 cards) ─────────────── -->
+            <section
+                aria-label="Key metrics"
+                class="grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-6"
+            >
+                <KpiCard
+                    :icon="FolderKanban"
+                    accent="cyan"
+                    label="Projects"
+                    :value="String(dashboard.projects.active)"
+                    secondary="Active"
+                    :status="dashboard.projects.status"
+                    status-label="Healthy"
+                    :trend="{
+                        direction:
+                            dashboard.projects.new_this_week > 0 ? 'up' : 'flat',
+                        value: `+${dashboard.projects.new_this_week} new`,
+                    }"
+                    :sparkline="dashboard.projects.sparkline"
+                />
+                <KpiCard
+                    :icon="Rocket"
+                    accent="blue"
+                    label="Deployments (24h)"
+                    :value="String(dashboard.deployments.successful_24h)"
+                    secondary="Successful"
+                    :status="dashboard.deployments.status"
+                    status-label="On track"
+                    :trend="{
+                        direction:
+                            dashboard.deployments.change_percent >= 0
+                                ? 'up'
+                                : 'down',
+                        value: `${dashboard.deployments.change_percent >= 0 ? '+' : ''}${dashboard.deployments.change_percent}%`,
+                    }"
+                    :sparkline="dashboard.deployments.sparkline"
+                />
+                <KpiCard
+                    :icon="ShieldCheck"
+                    accent="success"
+                    label="Services"
+                    :value="String(dashboard.services.running)"
+                    secondary="Running"
+                    :status="dashboard.services.status"
+                    :status-label="`${dashboard.services.health_percent}% healthy`"
+                    :trend="{
+                        direction: 'flat',
+                        value: `${dashboard.services.health_percent}%`,
+                    }"
+                    :sparkline="dashboard.services.sparkline"
+                />
+                <KpiCard
+                    :icon="Server"
+                    accent="purple"
+                    label="Hosts"
+                    :value="String(dashboard.hosts.online)"
+                    secondary="Online"
+                    :status="dashboard.hosts.status"
+                    status-label="Steady"
+                    :trend="{
+                        direction: dashboard.hosts.new > 0 ? 'up' : 'flat',
+                        value: `+${dashboard.hosts.new} new`,
+                    }"
+                    :sparkline="dashboard.hosts.sparkline"
+                />
+                <KpiCard
+                    :icon="Bell"
+                    accent="danger"
+                    label="Alerts"
+                    :value="String(dashboard.alerts.active)"
+                    secondary="Active"
+                    :status="dashboard.alerts.status"
+                    :status-label="`${dashboard.alerts.critical} critical`"
+                    :trend="{
+                        direction: dashboard.alerts.active > 0 ? 'up' : 'flat',
+                        value: `${dashboard.alerts.active} open`,
+                    }"
+                    :sparkline="dashboard.alerts.sparkline"
+                />
+                <KpiCard
+                    :icon="HeartPulse"
+                    accent="magenta"
+                    label="Uptime"
+                    :value="`${dashboard.uptime.overall}%`"
+                    secondary="30-day"
+                    :status="dashboard.uptime.status"
+                    status-label="SLA met"
+                    :trend="{
+                        direction: dashboard.uptime.change >= 0 ? 'up' : 'down',
+                        value: `${dashboard.uptime.change >= 0 ? '+' : ''}${dashboard.uptime.change}%`,
+                    }"
+                    :sparkline="dashboard.uptime.sparkline"
+                />
+            </section>
+
+            <!-- ─────────────── Stub widgets ─────────────── -->
+            <!-- Each card below is a populated placeholder. The canonical
+                 implementation ships with the phase named in the footer. -->
+            <div class="grid grid-cols-1 gap-4 lg:grid-cols-12">
+                <!-- Issues & PRs -->
+                <section
+                    aria-label="Issues & PRs"
+                    class="glass-card flex flex-col gap-4 p-5 lg:col-span-7"
+                >
+                    <header class="flex items-center justify-between gap-3">
+                        <div class="flex items-center gap-2">
+                            <GitPullRequest
+                                class="h-4 w-4 text-accent-cyan"
+                                aria-hidden="true"
+                            />
+                            <h2 class="text-sm font-semibold text-text-primary">
+                                Issues &amp; Pull Requests
+                            </h2>
+                        </div>
+                        <span class="font-mono text-[11px] text-text-muted">
+                            {{ stubIssues.length }} open · mock
+                        </span>
+                    </header>
+                    <ul class="flex flex-col gap-2">
+                        <li
+                            v-for="issue in stubIssues"
+                            :key="issue.title"
+                            class="flex items-center gap-3 rounded-lg border border-border-subtle bg-background-panel-hover/40 p-3"
+                        >
+                            <StatusBadge :tone="priorityToneMap[issue.priority]">
+                                {{ issue.priority }}
+                            </StatusBadge>
+                            <div class="min-w-0 flex-1">
+                                <p class="truncate text-sm text-text-primary">
+                                    {{ issue.title }}
+                                </p>
+                                <p
+                                    class="truncate font-mono text-[11px] text-text-muted"
+                                >
+                                    {{ issue.repo }} · {{ issue.time }} ago
+                                </p>
+                            </div>
+                        </li>
+                    </ul>
+                    <footer class="text-[11px] text-text-muted">
+                        Full widget lands with phase 2 — Issues &amp; PRs sync.
+                    </footer>
+                </section>
+
+                <!-- Top Repositories -->
+                <section
+                    aria-label="Top Repositories"
+                    class="glass-card flex flex-col gap-4 p-5 lg:col-span-5"
+                >
+                    <header class="flex items-center justify-between gap-3">
+                        <div class="flex items-center gap-2">
+                            <GitBranch
+                                class="h-4 w-4 text-accent-purple"
+                                aria-hidden="true"
+                            />
+                            <h2 class="text-sm font-semibold text-text-primary">
+                                Top Repositories
+                            </h2>
+                        </div>
+                        <span class="font-mono text-[11px] text-text-muted">
+                            7d · mock
+                        </span>
+                    </header>
+                    <ul class="flex flex-col gap-3">
+                        <li
+                            v-for="repo in stubRepos"
+                            :key="repo.name"
+                            class="flex items-center gap-3"
+                        >
+                            <span
+                                class="w-32 shrink-0 truncate font-mono text-xs text-text-secondary"
+                            >
+                                {{ repo.name }}
+                            </span>
+                            <div
+                                class="relative h-2 flex-1 overflow-hidden rounded-full bg-background-panel-hover"
+                            >
+                                <span
+                                    class="block h-full rounded-full bg-gradient-to-r from-accent-cyan to-accent-magenta"
+                                    :style="{
+                                        width: `${Math.round(repo.share * 100)}%`,
+                                    }"
+                                />
+                            </div>
+                            <span
+                                class="w-20 shrink-0 text-right font-mono text-[11px] tabular-nums text-text-muted"
+                            >
+                                {{ repo.commits }} commits
+                            </span>
+                        </li>
+                    </ul>
+                    <footer class="text-[11px] text-text-muted">
+                        Full widget lands with phase 1 — Repositories.
+                    </footer>
+                </section>
+
+                <!-- Container Hosts -->
+                <section
+                    aria-label="Container Hosts"
+                    class="glass-card flex flex-col gap-4 p-5 lg:col-span-6"
+                >
+                    <header class="flex items-center justify-between gap-3">
+                        <div class="flex items-center gap-2">
+                            <Server
+                                class="h-4 w-4 text-accent-blue"
+                                aria-hidden="true"
+                            />
+                            <h2 class="text-sm font-semibold text-text-primary">
+                                Container Hosts
+                            </h2>
+                        </div>
+                        <span class="font-mono text-[11px] text-text-muted">
+                            {{ stubHosts.length }} hosts · mock
+                        </span>
+                    </header>
+                    <ul class="flex flex-col gap-3">
+                        <li
+                            v-for="host in stubHosts"
+                            :key="host.name"
+                            class="grid grid-cols-[auto_1fr_auto] items-center gap-3"
+                        >
+                            <StatusBadge :tone="host.status" dot-only />
+                            <div class="min-w-0">
+                                <p
+                                    class="truncate font-mono text-xs text-text-primary"
+                                >
+                                    {{ host.name }}
+                                </p>
+                                <p
+                                    class="truncate text-[11px] text-text-muted"
+                                >
+                                    {{ host.region }}
+                                </p>
+                            </div>
+                            <div class="flex flex-col gap-1 text-[10px]">
+                                <div
+                                    class="flex items-center gap-2 font-mono text-text-muted"
+                                >
+                                    <span class="w-6 shrink-0">CPU</span>
+                                    <span
+                                        class="relative h-1.5 w-20 overflow-hidden rounded-full bg-background-panel-hover"
+                                    >
+                                        <span
+                                            class="block h-full rounded-full bg-accent-cyan"
+                                            :style="{
+                                                width: `${Math.round(host.cpu * 100)}%`,
+                                            }"
+                                        />
+                                    </span>
+                                </div>
+                                <div
+                                    class="flex items-center gap-2 font-mono text-text-muted"
+                                >
+                                    <span class="w-6 shrink-0">MEM</span>
+                                    <span
+                                        class="relative h-1.5 w-20 overflow-hidden rounded-full bg-background-panel-hover"
+                                    >
+                                        <span
+                                            class="block h-full rounded-full bg-accent-purple"
+                                            :style="{
+                                                width: `${Math.round(host.mem * 100)}%`,
+                                            }"
+                                        />
+                                    </span>
+                                </div>
+                            </div>
+                        </li>
+                    </ul>
+                    <footer class="text-[11px] text-text-muted">
+                        Full widget lands with phase 6 — Docker Host Agent.
+                    </footer>
+                </section>
+
+                <!-- Service Health -->
+                <section
+                    aria-label="Service Health"
+                    class="glass-card flex flex-col gap-4 p-5 lg:col-span-6"
+                >
+                    <header class="flex items-center justify-between gap-3">
+                        <div class="flex items-center gap-2">
+                            <HeartPulse
+                                class="h-4 w-4 text-status-success"
+                                aria-hidden="true"
+                            />
+                            <h2 class="text-sm font-semibold text-text-primary">
+                                Service Health
+                            </h2>
+                        </div>
+                        <span class="font-mono text-[11px] text-text-muted">
+                            {{ stubServices.length }} services · mock
+                        </span>
+                    </header>
+                    <ul class="flex flex-col gap-3">
+                        <li
+                            v-for="svc in stubServices"
+                            :key="svc.name"
+                            class="grid grid-cols-[auto_1fr_140px] items-center gap-3"
+                        >
+                            <StatusBadge :tone="svc.status" dot-only />
+                            <span class="truncate text-sm text-text-primary">
+                                {{ svc.name }}
+                            </span>
+                            <Sparkline
+                                :points="svc.sparkline"
+                                :accent="
+                                    svc.status === 'warning'
+                                        ? 'magenta'
+                                        : 'success'
+                                "
+                                :height="20"
+                            />
+                        </li>
+                    </ul>
+                    <footer class="text-[11px] text-text-muted">
+                        Full widget lands with phase 5 — Website Monitoring.
+                    </footer>
+                </section>
+
+                <!-- Catch-all placeholder for chart-heavy widgets that need
+                     dedicated specs (map, charts, gauges, timeline). One
+                     card to keep the page dense without sprawling. -->
+                <section
+                    aria-label="Visualizations placeholder"
+                    class="glass-card flex flex-col gap-3 p-5 lg:col-span-12"
+                >
+                    <header class="flex items-center justify-between gap-3">
+                        <div class="flex items-center gap-2">
+                            <BarChart3
+                                class="h-4 w-4 text-accent-magenta"
+                                aria-hidden="true"
+                            />
+                            <h2 class="text-sm font-semibold text-text-primary">
+                                Visualizations
+                            </h2>
+                        </div>
+                        <StatusBadge tone="muted">Pending</StatusBadge>
+                    </header>
+                    <div
+                        class="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-5"
+                    >
+                        <div
+                            v-for="placeholder in visualizationStubs"
+                            :key="placeholder.label"
+                            class="flex flex-col gap-2 rounded-lg border border-dashed border-border-subtle bg-background-panel-hover/30 p-3"
+                        >
+                            <component
+                                :is="placeholder.icon"
+                                class="h-4 w-4 text-text-muted"
+                                aria-hidden="true"
+                            />
+                            <p class="text-xs text-text-secondary">
+                                {{ placeholder.label }}
+                            </p>
+                            <p
+                                class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                            >
+                                {{ placeholder.phase }}
+                            </p>
+                        </div>
+                    </div>
+                    <footer class="text-[11px] text-text-muted">
+                        Chart, map, and gauge widgets land with their owning
+                        phases. ActivityFeed + Heatmap render in spec 007.
+                    </footer>
+                </section>
             </div>
         </div>
     </AppLayout>

--- a/resources/js/lib/uniqueId.ts
+++ b/resources/js/lib/uniqueId.ts
@@ -1,0 +1,16 @@
+/**
+ * Module-level monotonic ID generator. Used by SVG components that need a
+ * stable, collision-free `id` for `<defs>` references (gradients, masks,
+ * filters). Module scope makes the counter shared across all component
+ * instances in the same JS realm.
+ *
+ * Hydration-safe for the current CSR-only Inertia mount. When SSR is
+ * enabled, swap call sites to Vue 3.5+'s `useId()` for true SSR/CSR
+ * symmetry.
+ */
+let counter = 0;
+
+export function uniqueId(prefix = 'id'): string {
+    counter += 1;
+    return `${prefix}-${counter}`;
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -12,3 +12,54 @@ export type PageProps<
         user: User | null;
     };
 };
+
+/**
+ * Status token used by KPI cards and other dashboard widgets to drive
+ * `StatusBadge` tone. Mirrors the four status colors locked in
+ * tailwind.config.js + visual-reference.md.
+ */
+export type DashboardStatus = 'success' | 'warning' | 'danger' | 'info';
+
+/**
+ * Mock dashboard payload returned by `OverviewController` for the Overview
+ * page. Shape mirrors roadmap §8.1.1 with two phase-0 additions per card
+ * (`sparkline` for the inline series, `status` for the badge tone).
+ */
+export interface DashboardPayload {
+    projects: {
+        active: number;
+        new_this_week: number;
+        sparkline: number[];
+        status: DashboardStatus;
+    };
+    deployments: {
+        successful_24h: number;
+        change_percent: number;
+        sparkline: number[];
+        status: DashboardStatus;
+    };
+    services: {
+        running: number;
+        health_percent: number;
+        sparkline: number[];
+        status: DashboardStatus;
+    };
+    hosts: {
+        online: number;
+        new: number;
+        sparkline: number[];
+        status: DashboardStatus;
+    };
+    alerts: {
+        active: number;
+        critical: number;
+        sparkline: number[];
+        status: DashboardStatus;
+    };
+    uptime: {
+        overall: number;
+        change: number;
+        sparkline: number[];
+        status: DashboardStatus;
+    };
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\OverviewController;
 use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -11,9 +12,9 @@ Route::get('/', function () {
     ]);
 });
 
-Route::get('/overview', function () {
-    return Inertia::render('Overview');
-})->middleware(['auth', 'verified'])->name('overview');
+Route::get('/overview', OverviewController::class)
+    ->middleware(['auth', 'verified'])
+    ->name('overview');
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');

--- a/specs/phase-0-foundation/006-overview-kpi.md
+++ b/specs/phase-0-foundation/006-overview-kpi.md
@@ -102,6 +102,13 @@ Dated notes as work progresses.
     - **768 × 900 (tablet):** KPIs collapse to 3 cols × 2 rows. Stub widgets stack to single column.
     - **390 × 900 (mobile):** KPIs in 2 cols × 3 rows. All widgets stack. Hosts CPU/MEM bars and the gradient repo bars remain readable. **Found:** Uptime KPI's `99.98%` value + the `+0.01%` trend chip overflowed the column. **Fix:** changed the value cluster from `flex items-baseline gap-2` to `flex flex-wrap items-baseline gap-x-2 gap-y-1` so the trend chip drops below the value when crowded. Re-verified — chip now wraps cleanly on Hosts and Uptime cards at mobile width.
 - Pipeline: vue-tsc clean, Pint clean, `npm run build` green (Overview chunk = 17 KB / 5 KB gzipped, AppLayout chunk unchanged). 2 SmokeTest cases pass with 24 assertions.
+- Self-review with `superpowers:code-reviewer`. No blockers; 2 material findings + 2 nits addressed:
+    - **[material]** `KpiCard` rendered `tabindex="0" aria-disabled="true"` together for inert cards — WAI-ARIA contradicts that combination (announces a "dimmed" control with no available action). Fix: inert variant now renders as a plain `<div>` with neither `tabindex` nor `aria-disabled`. Interactive variant keeps the focus ring on `<a>`.
+    - **[material]** `Sparkline` used `Math.random()` for the gradient ID — fine for the current CSR-only mount but a hydration-mismatch hazard the day SSR ships. Fix: extracted `resources/js/lib/uniqueId.ts` (module-level monotonic counter) and used it in `Sparkline`. Note in the helper says swap to Vue 3.5+'s `useId()` once the project upgrades / SSR lands.
+    - **[nit]** Sparkline's `area` polygon used `(length-1) * (W/(length-1))` which simplifies to `VIEW_W`. Replaced with the constant.
+    - **[nit]** Three Visualization stubs reused the same `LineChart` icon. Switched to `Globe` (world map), `Activity` (resource utilization), `LineChart` (website performance), `Gauge` (system metrics), `Rocket` (deployment timeline) — five distinct icons.
+    - Skipped: flat-series midpoint rendering (cosmetic; phase 0 KPIs never have all-equal points), and a controller↔type drift fixture (acceptable mock-data cost).
+- Re-ran pipeline + a quick visual recheck after fixes — vue-tsc clean, Pint clean, build green, smoke tests still pass; the Visualizations row now shows five distinct icons.
 
 ## Decisions (locked 2026-04-27)
 - **Sparkline implementation — roll our own.** Pure-SVG polyline + faint area fill (~30 LOC), no dep. Charting library is a future phase decision when real charts ship.

--- a/specs/phase-0-foundation/006-overview-kpi.md
+++ b/specs/phase-0-foundation/006-overview-kpi.md
@@ -95,6 +95,13 @@ Dated notes as work progresses.
 ### 2026-04-27
 - Spec drafted; scope confirmed (4 decisions locked: roll-our-own SVG sparkline, inert+aria-disabled click-to-detail, thin controller, populated stub widgets).
 - Opened issue [#12](https://github.com/Copxer/nexus/issues/12) and branch `spec/006-overview-kpi` off `main`.
+- Implemented `Components/Dashboard/{Sparkline,StatusBadge,TrendChip,KpiCard}.vue` (4 primitives), `OverviewController` (single-action, hardcoded §8.1.1 payload + per-card `sparkline` + `status`), `routes/web.php` switched to controller, `types/index.d.ts` extended with `DashboardStatus` + `DashboardPayload`, `Pages/Overview.vue` rebuilt with the 6-card KPI row + 4 populated stub widgets (Issues & PRs, Top Repositories, Container Hosts, Service Health) + a single Visualizations placeholder card for the chart-heavy widgets that need their own specs (map, charts, gauges, timeline).
+- Extended `tests/Feature/SmokeTest.php` with an Inertia `assertInertia` that verifies the `dashboard` prop carries all 6 KPI keys + correct status tokens for projects (`success`) and alerts (`danger`).
+- Manual verification in dev server (Playwright Chrome) at three breakpoints:
+    - **1440 × 900 (desktop):** 6 KPIs in a single row with full sparklines + glowing icons + status pills + trend chips. 4 stub widgets in 7+5 / 6+6 columns. Visualizations card spans 12 cols at the bottom.
+    - **768 × 900 (tablet):** KPIs collapse to 3 cols × 2 rows. Stub widgets stack to single column.
+    - **390 × 900 (mobile):** KPIs in 2 cols × 3 rows. All widgets stack. Hosts CPU/MEM bars and the gradient repo bars remain readable. **Found:** Uptime KPI's `99.98%` value + the `+0.01%` trend chip overflowed the column. **Fix:** changed the value cluster from `flex items-baseline gap-2` to `flex flex-wrap items-baseline gap-x-2 gap-y-1` so the trend chip drops below the value when crowded. Re-verified — chip now wraps cleanly on Hosts and Uptime cards at mobile width.
+- Pipeline: vue-tsc clean, Pint clean, `npm run build` green (Overview chunk = 17 KB / 5 KB gzipped, AppLayout chunk unchanged). 2 SmokeTest cases pass with 24 assertions.
 
 ## Decisions (locked 2026-04-27)
 - **Sparkline implementation — roll our own.** Pure-SVG polyline + faint area fill (~30 LOC), no dep. Charting library is a future phase decision when real charts ship.

--- a/specs/phase-0-foundation/006-overview-kpi.md
+++ b/specs/phase-0-foundation/006-overview-kpi.md
@@ -1,0 +1,114 @@
+---
+spec: overview-kpi
+phase: 0-foundation
+status: in-progress
+owner: yoany
+created: 2026-04-27
+updated: 2026-04-27
+issue: https://github.com/Copxer/nexus/issues/12
+branch: spec/006-overview-kpi
+---
+
+# 006 — Overview page with mock KPI cards, sparklines, status badges
+
+## Goal
+Replace the placeholder body of `/overview` with the futuristic 6-card KPI row from the visual reference, fed by mock data from a thin controller. Introduce the three reusable dashboard primitives — `KpiCard`, `Sparkline`, `StatusBadge` — that every later widget (Service Health, Container Hosts, Top Repositories, etc.) will compose.
+
+After this spec, the Overview page should look populated: the headline KPI row up top, then placeholder glass-cards for the widgets that ship in spec 007 and later (Activity feed/heatmap, map, charts, hosts, etc.). No real integrations — every value is hardcoded in the controller and matches the JSON shape from roadmap §8.1.1.
+
+Roadmap reference: §8.1 Overview Dashboard, §8.1.1 KPI Cards.
+Visual target: [`../visual-reference.md`](../visual-reference.md) → [`../../nexus-dashboard.png`](../../nexus-dashboard.png) (top KPI row + the empty grid below it).
+
+## Scope
+**In scope:**
+- `App\Http\Controllers\OverviewController` (single-action, `__invoke`) returning an Inertia response with a single `dashboard` prop matching §8.1.1's JSON shape verbatim. Hardcoded values for now; the data shape is the contract.
+- `routes/web.php` updated to dispatch `/overview` to `OverviewController` instead of the inline closure. Middleware (`auth`, `verified`) and route name (`overview`) preserved exactly.
+- Three new dashboard primitives, all under `resources/js/Components/Dashboard/`:
+    - **`KpiCard.vue`** — composes the others; props: `label`, `value`, `valueLabel?`, `icon`, `accent` (one of `cyan|blue|purple|magenta|success|warning|danger`), `trend?` (`{ direction: 'up' | 'down' | 'flat'; value: string }`), `status?` (`'success' | 'warning' | 'danger' | 'info'`), `sparkline?` (`number[]`), and an optional `href?`/`disabled?` for click-to-detail. Renders inside a `glass-card` with the icon top-left (soft accent glow), the big tabular-nums numeric value, the secondary label, the trend chip, and the sparkline behind/under the number.
+    - **`Sparkline.vue`** — pure inline SVG `<polyline>` + faint area fill. Props: `points: number[]`, `accent?` (default `cyan`), `aria-hidden`. ~30 LOC. No third-party charting dep.
+    - **`StatusBadge.vue`** — small pill: dot + label, with a soft accent glow only on `success` (consistent with "glow reserved for active states" rule in visual-reference). Props: `tone: 'success' | 'warning' | 'danger' | 'info'`, default slot for label.
+    - **`TrendChip.vue`** — small inline pill rendered next to the value: ↑/↓/→ icon + change string + optional `tone` override. Up = success-tinted, down = danger-tinted, flat = muted.
+- `resources/js/Pages/Overview.vue` rebuilt:
+    - 6 KPI cards (Projects, Deployments, Services, Hosts, Alerts, Uptime) in a responsive grid: 2 cols mobile → 3 cols tablet → 6 cols desktop. Each card is `aria-disabled` for now (target sections not yet built), but visually styled as a clickable card with a focus ring — consistent with the "Soon" treatment from sidebar/palette.
+    - Below the KPI row: a 12-col grid of placeholder glass-cards stubbing the next-spec widgets (Activity feed, Activity heatmap, World map, Resource Utilization chart, Website Performance chart, Container hosts, Service health, Top repositories, Deployment timeline, System metrics). Each placeholder includes:
+        - A real heading + icon (matches the visual reference's chrome).
+        - A small representative preview using 2–4 lines of hardcoded mock data (e.g., 3 mock activity rows for the activity-feed stub, 3 mock hosts with status dots for the hosts stub, 4 mock services for service-health, 3 mock repos for top-repositories) so the page looks populated rather than empty.
+        - A faint footer microcopy like "Full widget lands with spec 007" linking to the owning spec — reviewer can tell at a glance which chunks are stubs.
+    - The stubs reuse existing primitives only (`glass-card`, `Sparkline`, `StatusBadge`, lucide icons). They are intentionally not interactive and are not the canonical implementation of those widgets — each future spec replaces its own stub with the real component.
+- Tests:
+    - Update `tests/Feature/SmokeTest.php` to also assert the response contains a `dashboard` prop with the 6 expected keys (one Inertia assertion). The existing `200` check stays.
+
+**Out of scope:**
+- Real backend data. Every value is hardcoded.
+- A `Domain/Dashboard/Queries/GetOverviewDashboardQuery` class — the controller hardcodes the data; we'll formalize the domain layer once we have real integrations.
+- Wiring the click-to-detail navigation. Cards are inert this spec.
+- Activity feed / heatmap (spec 007), map / charts / hosts / service health / repositories / timeline / metrics (later phases).
+- Theme variants — dark only.
+- Animations beyond the existing ≤200ms hover transitions.
+
+## Plan
+1. Build the leaf primitives first so the integration step is easy:
+    - `Sparkline.vue` (mock with 12-point arrays, normalize to `viewBox="0 0 100 24"`).
+    - `StatusBadge.vue`.
+    - `TrendChip.vue`.
+2. Build `KpiCard.vue` composing them.
+3. Backend wiring:
+    - Generate `OverviewController` (single-action, `__invoke`).
+    - Hardcode the dashboard payload from §8.1.1 example data, plus a `sparkline: number[]` per card and a `status` token per card.
+    - Update `routes/web.php`.
+4. Rebuild `Pages/Overview.vue`:
+    - Receive `dashboard` prop typed via the existing inertia.d.ts pattern (extend the page-prop typing).
+    - Render the 6 KpiCards in the responsive grid.
+    - Render the placeholder grid below.
+5. Run dev server and visually compare with `nexus-dashboard.png`. Adjust spacing / sizes / accents until the KPI row matches.
+6. Update the smoke test to assert the new prop shape; optionally add a small Vitest-style logical assertion if Vitest gets wired in time (remember: deferred from spec 005, separate chore PR).
+7. Pipeline (Pint, vue-tsc, build, tests).
+8. Self-review with `superpowers:code-reviewer`.
+
+## Acceptance criteria
+- [ ] `/overview` renders 6 KPI cards (Projects, Deployments, Services, Hosts, Alerts, Uptime) populated with the §8.1.1 example numbers.
+- [ ] Each card shows: icon (top-left, soft accent glow), big tabular-nums value, secondary label, trend chip, status badge (or dot), mini sparkline.
+- [ ] Cards are responsive: 2 cols < md, 3 cols md, 6 cols xl. Numbers and chips don't truncate awkwardly at any breakpoint.
+- [ ] `KpiCard.vue`, `Sparkline.vue`, `StatusBadge.vue`, `TrendChip.vue` all live under `resources/js/Components/Dashboard/` and are exported as standalone components for reuse in later widgets.
+- [ ] Cards are `aria-disabled` (click-to-detail comes when the target section exists) but render with a focus ring on Tab.
+- [ ] Below the KPI row, the page renders placeholder glass-cards for the next-spec widgets at correct grid sizes, each with a "Lands with spec 0XX" microcopy line.
+- [ ] `OverviewController` returns an Inertia response with a single `dashboard` prop matching the §8.1.1 JSON shape (controller is invocable; route name `overview` and middleware preserved).
+- [ ] No real integrations / API calls / DB queries — values are hardcoded.
+- [ ] No `gray-*` / `red-*` / `green-*` / `indigo-*` Tailwind classes leak in — design tokens only.
+- [ ] No regressions: existing tests still pass on CI; the SmokeTest now also asserts the `dashboard` prop shape.
+- [ ] Pint clean, `vue-tsc` clean, `npm run build` green, CI green on the PR.
+- [ ] Self-review pass with `superpowers:code-reviewer`; material findings addressed before PR.
+
+## Files touched
+- `app/Http/Controllers/OverviewController.php` — new single-action controller returning the mock dashboard payload.
+- `routes/web.php` — dispatch `/overview` to `OverviewController` instead of an inline closure (middleware + name preserved).
+- `resources/js/Components/Dashboard/KpiCard.vue` — composed card.
+- `resources/js/Components/Dashboard/Sparkline.vue` — pure SVG sparkline.
+- `resources/js/Components/Dashboard/StatusBadge.vue` — pill badge with tone variants.
+- `resources/js/Components/Dashboard/TrendChip.vue` — ↑/↓/→ trend pill.
+- `resources/js/Pages/Overview.vue` — rebuilt to render the KPI row and placeholder widget grid.
+- `tests/Feature/SmokeTest.php` — extend with `dashboard` prop shape assertion.
+
+## Work log
+Dated notes as work progresses.
+
+### 2026-04-27
+- Spec drafted; scope confirmed (4 decisions locked: roll-our-own SVG sparkline, inert+aria-disabled click-to-detail, thin controller, populated stub widgets).
+- Opened issue [#12](https://github.com/Copxer/nexus/issues/12) and branch `spec/006-overview-kpi` off `main`.
+
+## Decisions (locked 2026-04-27)
+- **Sparkline implementation — roll our own.** Pure-SVG polyline + faint area fill (~30 LOC), no dep. Charting library is a future phase decision when real charts ship.
+- **Click-to-detail behavior — inert + aria-disabled.** Cards render with focus rings but don't navigate. Same treatment as the sidebar / command palette "Soon" entries. Activated when the target sections exist.
+- **Backend abstraction — thin controller, hardcoded data.** No `App\Domain\Dashboard\Queries\GetOverviewDashboardQuery` layer yet; we'll formalize it when real integrations land. Saves a layer of indirection over what is currently a constant.
+- **Placeholder widgets — populated stubs, not empty boxes.** Each future-spec widget renders with real chrome + 2–4 lines of representative mock data + a "Full widget lands with spec 0XX" footer. Page should look populated, not skeletal. Each future spec replaces its own stub with the canonical implementation.
+
+## Open questions / blockers
+- **Status mapping per card.** Need to lock which `status` token each KPI displays at the example values:
+    - Projects (active 12): success
+    - Deployments (24 successful, +18%): success
+    - Services (47 running, 100% health): success
+    - Hosts (128 online, 4 new): info
+    - Alerts (3 active, 1 critical): danger
+    - Uptime (99.98%, +0.01): success
+  These are placeholder mappings only. Real status logic comes when the integrations land.
+- **Inertia page-prop typing.** The repo already types Inertia props in `resources/js/types/`. Extending that for the new `dashboard` prop is part of this spec — no new typing infrastructure.

--- a/tests/Feature/SmokeTest.php
+++ b/tests/Feature/SmokeTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
 
 class SmokeTest extends TestCase
@@ -19,5 +20,30 @@ class SmokeTest extends TestCase
         $this->actingAs($user)
             ->get('/overview')
             ->assertStatus(200);
+    }
+
+    public function test_overview_carries_the_mock_dashboard_payload(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->get('/overview')
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Overview')
+                    ->has('dashboard', fn (AssertableInertia $dashboard) => $dashboard
+                        ->has('projects.active')
+                        ->has('projects.sparkline')
+                        ->where('projects.status', 'success')
+                        ->has('deployments.successful_24h')
+                        ->has('services.running')
+                        ->has('hosts.online')
+                        ->has('alerts.active')
+                        ->where('alerts.status', 'danger')
+                        ->has('uptime.overall')
+                    )
+            );
     }
 }


### PR DESCRIPTION
Closes #12

Spec: [`specs/phase-0-foundation/006-overview-kpi.md`](https://github.com/Copxer/nexus/blob/spec/006-overview-kpi/specs/phase-0-foundation/006-overview-kpi.md)

## Summary
- Replaces `/overview`'s placeholder body with the futuristic 6-card KPI row from `nexus-dashboard.png`. Cards: Projects, Deployments, Services, Hosts, Alerts, Uptime. Each card carries the §8.1.1 example numbers + a status pill + a trend chip + a mini sparkline.
- Introduces four reusable dashboard primitives under `resources/js/Components/Dashboard/`: `KpiCard`, `Sparkline` (pure-SVG polyline + gradient area, no chart dep), `StatusBadge` (pill or dot-only with success/warning/danger/info/muted tones), `TrendChip` (↑/↓/→).
- Backend: thin `OverviewController` (single-action `__invoke`) returns the §8.1.1 JSON shape with two phase-0 additions per card — `sparkline: number[]` and `status: 'success'|'warning'|'danger'|'info'`. Hardcoded values; no Domain query layer yet.
- Below the KPI row: 4 populated stub widgets (Issues & PRs, Top Repositories, Container Hosts, Service Health) with mock data, plus a single Visualizations placeholder card listing the 5 chart-heavy widgets that need their own specs (World map, Resource utilization, Website performance, System metrics, Deployment timeline) — each with a distinct lucide icon and a "Phase X" pill.
- Cards are non-interactive in this spec (target detail sections don't exist yet) — inert variant renders as a plain `<div>` with no `tabindex` / `aria-disabled` to avoid the screen-reader "dimmed control" announcement.
- New `resources/js/lib/uniqueId.ts` helper for stable SVG gradient IDs (replaces `Math.random()`); a swap-to-`useId()` note is included for the day SSR lands.
- `tests/Feature/SmokeTest.php` extended with an `assertInertia` case that verifies the `dashboard` prop carries all 6 KPI keys and the projects/alerts status tokens.

## Test plan
- [x] `/overview` returns 200 for a verified user (existing test).
- [x] `/overview` Inertia response carries `dashboard` prop with `projects.active`, `projects.sparkline`, `projects.status === 'success'`, `deployments.successful_24h`, `services.running`, `hosts.online`, `alerts.active`, `alerts.status === 'danger'`, `uptime.overall` (new test).
- [x] 6 KPI cards render with icon + value + status pill + trend chip + sparkline.
- [x] Responsive grid: 6 / 3 / 2 cols at desktop / tablet / mobile (verified at 1440 / 768 / 390).
- [x] Inert cards render with no `tabindex` / `aria-disabled` and don't appear as actionable to screen readers.
- [x] No `gray-*` / `red-*` / `green-*` / `indigo-*` Tailwind classes.
- [x] Pint clean, vue-tsc clean, `npm run build` green.

## Self-review notes
Ran `superpowers:code-reviewer` on `git diff main...HEAD`. No blockers.

- **[material, fixed]** `KpiCard` had `tabindex="0"` + `aria-disabled="true"` together — WAI-ARIA reads that as a "dimmed control" the user could focus, which is misleading for a non-interactive card. Inert variant now renders as a plain `<div>` (no tabindex, no aria-disabled). Interactive variant (when `href` is set + `disabled === false`) keeps the focus ring on `<a>`.
- **[material, fixed]** `Sparkline` used `Math.random()` for the SVG gradient ID. Fine for CSR-only today; would race on SSR hydration. Replaced with a module-level monotonic counter in `resources/js/lib/uniqueId.ts`. Note in the helper points future-us at Vue 3.5+'s `useId()` once that lands.
- **[nit, fixed]** Sparkline polygon arithmetic (`last = (length-1) * (W/(length-1))`) simplified to the `VIEW_W` constant.
- **[nit, fixed]** Three Visualization stubs all used the `LineChart` icon. Now use distinct icons: `Globe` (world map), `Activity` (resource utilization), `LineChart` (website performance), `Gauge` (system metrics), `Rocket` (deployment timeline).
- **Skipped (acceptable for phase 0):** flat-series midpoint rendering in Sparkline (cosmetic; KPI sparkline data is never all-equal); a controller↔TypeScript drift fixture (mock-data cost; will move to a Domain query layer when real integrations land).

## Local note
The 14 pre-existing PHP 8.5 + Laravel 13.6 CSRF-in-tests failures from the spec 005 PR remain unchanged — same pattern; not introduced or affected by this spec. CI (PHP 8.4) is green.