### PR TITLE
chore(specs): mark spec 006 done; update trackers

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -35,7 +35,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 
 | # | Phase | Status | Notes |
 |---|-------|--------|-------|
-| 0 | Foundation (auth, layout, static overview) | 🟡 | 5/9 specs done (001–005). Next: 006 Overview KPI cards. |
+| 0 | Foundation (auth, layout, static overview) | 🟡 | 6/9 specs done (001–006). Next: 007 ActivityFeed + ActivityHeatmap. |
 | 1 | Projects & Repositories | ⬜ | — |
 | 2 | GitHub Integration MVP | ⬜ | — |
 | 3 | GitHub Webhooks & Activity Feed | ⬜ | — |

--- a/specs/phase-0-foundation/006-overview-kpi.md
+++ b/specs/phase-0-foundation/006-overview-kpi.md
@@ -1,12 +1,13 @@
 ---
 spec: overview-kpi
 phase: 0-foundation
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-27
 updated: 2026-04-27
 issue: https://github.com/Copxer/nexus/issues/12
 branch: spec/006-overview-kpi
+pr: https://github.com/Copxer/nexus/pull/13
 ---
 
 # 006 — Overview page with mock KPI cards, sparklines, status badges

--- a/specs/phase-0-foundation/README.md
+++ b/specs/phase-0-foundation/README.md
@@ -15,7 +15,7 @@ Stand up a Laravel 12 + Vue 3 + Inertia + Tailwind project with authentication, 
 | 003 | Design tokens + Tailwind theme (dark, glassmorphism, neon accents) | 🟢 |
 | 004 | AppLayout + Sidebar + TopBar + RightActivityRail | 🟢 |
 | 005 | CommandPalette (Cmd+K) shell | 🟢 |
-| 006 | Overview page with mock KPI cards, sparklines, status badges | ⬜ |
+| 006 | Overview page with mock KPI cards, sparklines, status badges | 🟢 |
 | 007 | ActivityFeed + ActivityHeatmap components (mock data) | ⬜ |
 | 008 | Responsive behavior (desktop / laptop / tablet / mobile) | ⬜ |
 | 009 | Redis / Horizon / queue / scheduler wired up | ⬜ |


### PR DESCRIPTION
Bookkeeping for [Spec 006 — Overview KPI cards](https://github.com/Copxer/nexus/pull/13) (merged in #13).

## Summary
- `specs/phase-0-foundation/006-overview-kpi.md` → frontmatter `status: done`; added PR link.
- `specs/phase-0-foundation/README.md` → flip row 006 from ⬜ to 🟢.
- `specs/README.md` → Phase 0 notes updated (6/9 specs done; next: 007 ActivityFeed + ActivityHeatmap).

## Test plan
- [ ] CI green (Pint + build + tests).
- [ ] Tracker tables render correctly on GitHub.