### PR TITLE
Spec 007 — ActivityFeed + ActivityHeatmap (mock data)

### DIFF
--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -58,6 +58,99 @@ class OverviewController extends Controller
                     'status' => 'success',
                 ],
             ],
+
+            // Mock activity events covering the §8.10 vocabulary. Pre-formatted
+            // `occurred_at` strings keep the UI server-rendered (no client
+            // time math). Real events ship with phase 2/3/4 integrations.
+            'recentActivity' => [
+                [
+                    'id' => 'evt-001',
+                    'type' => 'deployment.succeeded',
+                    'severity' => 'success',
+                    'title' => 'Deployed nexus-api v2.14.3 to production',
+                    'source' => 'nexus-api',
+                    'occurred_at' => '2 min ago',
+                    'metadata' => 'us-east',
+                ],
+                [
+                    'id' => 'evt-002',
+                    'type' => 'pull_request.merged',
+                    'severity' => 'info',
+                    'title' => 'PR #142 — Switch session driver to Redis cluster',
+                    'source' => 'nexus-web',
+                    'occurred_at' => '14 min ago',
+                ],
+                [
+                    'id' => 'evt-003',
+                    'type' => 'alert.triggered',
+                    'severity' => 'danger',
+                    'title' => 'CPU sustained > 90% on prod-api-02 for 5 min',
+                    'source' => 'monitoring',
+                    'occurred_at' => '38 min ago',
+                    'metadata' => 'critical',
+                ],
+                [
+                    'id' => 'evt-004',
+                    'type' => 'workflow.failed',
+                    'severity' => 'danger',
+                    'title' => 'CI failed — flaky test on nexus-mail#main',
+                    'source' => 'nexus-mail',
+                    'occurred_at' => '52 min ago',
+                ],
+                [
+                    'id' => 'evt-005',
+                    'type' => 'pull_request.review_requested',
+                    'severity' => 'info',
+                    'title' => 'Review requested on PR #218 — Billing webhook hardening',
+                    'source' => 'nexus-api',
+                    'occurred_at' => '1 h ago',
+                ],
+                [
+                    'id' => 'evt-006',
+                    'type' => 'website.recovered',
+                    'severity' => 'success',
+                    'title' => 'status.nexus.io recovered after 3 m 12 s outage',
+                    'source' => 'monitoring',
+                    'occurred_at' => '2 h ago',
+                ],
+                [
+                    'id' => 'evt-007',
+                    'type' => 'container.unhealthy',
+                    'severity' => 'warning',
+                    'title' => 'billing-worker container restarted after OOM',
+                    'source' => 'prod-api-02',
+                    'occurred_at' => '3 h ago',
+                ],
+                [
+                    'id' => 'evt-008',
+                    'type' => 'issue.created',
+                    'severity' => 'muted',
+                    'title' => 'Login flow rejects valid 2FA codes intermittently',
+                    'source' => 'nexus-web',
+                    'occurred_at' => '4 h ago',
+                ],
+                [
+                    'id' => 'evt-009',
+                    'type' => 'host.recovered',
+                    'severity' => 'success',
+                    'title' => 'edge-eu-01 back online after scheduled maintenance',
+                    'source' => 'edge-eu-01',
+                    'occurred_at' => '6 h ago',
+                ],
+            ],
+
+            // 7×6 mock heatmap. Outer index = day-of-week (Sun..Sat), inner =
+            // 4-hour bucket (12 AM, 4 AM, 8 AM, 12 PM, 4 PM, 8 PM). Rhythm:
+            // quieter overnight + weekends, busier weekday mid-day.
+            'activityHeatmap' => [
+                [1, 0, 1, 3, 2, 1], // Sun
+                [2, 1, 4, 7, 6, 3], // Mon
+                [1, 1, 5, 9, 8, 4], // Tue
+                [2, 1, 6, 10, 9, 5], // Wed
+                [2, 1, 5, 9, 7, 4], // Thu
+                [1, 0, 4, 6, 5, 2], // Fri
+                [0, 0, 1, 2, 1, 1], // Sat
+            ],
         ]);
     }
 }

--- a/resources/js/Components/Activity/ActivityFeed.vue
+++ b/resources/js/Components/Activity/ActivityFeed.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import ActivityFeedItem from '@/Components/Activity/ActivityFeedItem.vue';
+import type { ActivityEvent } from '@/types';
+import { ref } from 'vue';
+
+defineProps<{
+    events: ActivityEvent[];
+}>();
+
+/**
+ * Visual-only "Recent / All" tab pill. Real filtering arrives with the
+ * real feed in a later phase — see spec 007 Decisions.
+ */
+const activeTab = ref<'recent' | 'all'>('recent');
+</script>
+
+<template>
+    <div class="flex min-h-0 flex-1 flex-col gap-3">
+        <!-- Tab pill (visual-only) -->
+        <div
+            class="inline-flex w-fit rounded-full border border-border-subtle bg-slate-950/40 p-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]"
+        >
+            <button
+                type="button"
+                class="rounded-full px-2.5 py-1 transition"
+                :class="
+                    activeTab === 'recent'
+                        ? 'bg-accent-cyan/15 text-accent-cyan'
+                        : 'text-text-muted hover:text-text-secondary'
+                "
+                @click="activeTab = 'recent'"
+            >
+                Recent
+            </button>
+            <button
+                type="button"
+                class="rounded-full px-2.5 py-1 transition"
+                :class="
+                    activeTab === 'all'
+                        ? 'bg-accent-cyan/15 text-accent-cyan'
+                        : 'text-text-muted hover:text-text-secondary'
+                "
+                title="Activity filtering arrives with the real feed."
+                @click="activeTab = 'all'"
+            >
+                All
+            </button>
+        </div>
+
+        <!-- Feed -->
+        <ul
+            aria-label="Recent activity"
+            class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto"
+        >
+            <ActivityFeedItem
+                v-for="event in events"
+                :key="event.id"
+                :event="event"
+            />
+        </ul>
+    </div>
+</template>

--- a/resources/js/Components/Activity/ActivityFeed.vue
+++ b/resources/js/Components/Activity/ActivityFeed.vue
@@ -8,8 +8,8 @@ defineProps<{
 }>();
 
 /**
- * Visual-only "Recent / All" tab pill. Real filtering arrives with the
- * real feed in a later phase — see spec 007 Decisions.
+ * Visual-only "Recent / All" tab pill. Real filtering arrives when real
+ * integrations land — same treatment as the disabled rail-header filter.
  */
 const activeTab = ref<'recent' | 'all'>('recent');
 </script>

--- a/resources/js/Components/Activity/ActivityFeedItem.vue
+++ b/resources/js/Components/Activity/ActivityFeedItem.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import type { ActivityEvent, ActivityEventType } from '@/types';
+import {
+    AlertOctagon,
+    AlertTriangle,
+    Boxes,
+    CheckCircle2,
+    Eye,
+    GitMerge,
+    GitPullRequest,
+    Globe,
+    MessageSquare,
+    Rocket,
+    Server,
+    XCircle,
+    type LucideIcon,
+} from 'lucide-vue-next';
+import { computed } from 'vue';
+
+const props = defineProps<{
+    event: ActivityEvent;
+}>();
+
+/**
+ * Lucide icon per event-type. Choices follow the §8.10 vocabulary:
+ *   - `*.merged` / `*.succeeded` / `*.recovered` / `*.resolved` → cheerful icons
+ *   - `*.failed` / `*.down` / `*.offline` / `*.triggered` → warning/error icons
+ *   - `pull_request.review_requested` / `issue.*` → review/messaging icons
+ */
+const iconMap: Record<ActivityEventType, LucideIcon> = {
+    'issue.created': MessageSquare,
+    'issue.closed': CheckCircle2,
+    'pull_request.opened': GitPullRequest,
+    'pull_request.merged': GitMerge,
+    'pull_request.review_requested': Eye,
+    'workflow.failed': XCircle,
+    'workflow.succeeded': CheckCircle2,
+    'deployment.started': Rocket,
+    'deployment.succeeded': Rocket,
+    'deployment.failed': AlertOctagon,
+    'website.down': Globe,
+    'website.recovered': Globe,
+    'host.offline': Server,
+    'host.recovered': Server,
+    'container.unhealthy': Boxes,
+    'alert.triggered': AlertTriangle,
+    'alert.resolved': CheckCircle2,
+};
+
+/** Tailwind text-color class per severity. Glow reserved for `success`. */
+const severityIconClass = {
+    success: 'text-status-success',
+    warning: 'text-status-warning',
+    danger: 'text-status-danger',
+    info: 'text-status-info',
+    muted: 'text-text-muted',
+} as const;
+
+const icon = computed<LucideIcon>(() => iconMap[props.event.type]);
+</script>
+
+<template>
+    <li
+        :aria-label="`${event.title} — ${event.source} ${event.occurred_at}`"
+        class="flex items-start gap-3 rounded-lg border border-border-subtle bg-background-panel-hover/40 p-3"
+    >
+        <!-- Severity-tinted icon column -->
+        <span
+            class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-border-subtle bg-slate-950/40"
+        >
+            <component
+                :is="icon"
+                class="h-3.5 w-3.5"
+                :class="severityIconClass[event.severity]"
+                aria-hidden="true"
+            />
+        </span>
+
+        <!-- Two-line content -->
+        <div class="min-w-0 flex-1">
+            <p class="line-clamp-2 text-xs leading-snug text-text-primary">
+                {{ event.title }}
+            </p>
+            <div class="mt-1 flex flex-wrap items-center gap-2">
+                <span class="font-mono text-[10px] text-text-muted">
+                    {{ event.source }} · {{ event.occurred_at }}
+                </span>
+                <StatusBadge v-if="event.metadata" tone="muted">
+                    {{ event.metadata }}
+                </StatusBadge>
+            </div>
+        </div>
+    </li>
+</template>

--- a/resources/js/Components/Activity/ActivityHeatmap.vue
+++ b/resources/js/Components/Activity/ActivityHeatmap.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import type { ActivityHeatmapPayload } from '@/types';
+import { computed } from 'vue';
+
+const props = defineProps<{
+    /** 7 days × 6 four-hour buckets. Each value is an event count. */
+    data: ActivityHeatmapPayload;
+}>();
+
+/** Column labels — Sunday-first, matching `Date#getDay()` indexing. */
+const dayLabels = ['S', 'M', 'T', 'W', 'T', 'F', 'S'] as const;
+const dayNames = [
+    'Sun',
+    'Mon',
+    'Tue',
+    'Wed',
+    'Thu',
+    'Fri',
+    'Sat',
+] as const;
+
+/** Row labels — six 4-hour buckets per §8.11 example. */
+const rowLabels = ['12 AM', '4 AM', '8 AM', '12 PM', '4 PM', '8 PM'] as const;
+
+/** Max count across all cells; used to normalize each cell into a 0..4 bucket. */
+const maxCount = computed(() => {
+    let m = 0;
+    for (const day of props.data) {
+        for (const c of day) if (c > m) m = c;
+    }
+    return m || 1;
+});
+
+/**
+ * Map a count to one of 5 intensity steps. The ramp goes panel-hover →
+ * accent-purple/15 → /40 → accent-magenta/55 → /80 to match the §11 visual
+ * reference. Returns the Tailwind class for the bucket.
+ */
+const bucketClasses = [
+    'bg-background-panel-hover',
+    'bg-accent-purple/15',
+    'bg-accent-purple/40',
+    'bg-accent-magenta/55',
+    'bg-accent-magenta/80',
+] as const;
+
+const cellClass = (count: number) => {
+    if (count <= 0) return bucketClasses[0];
+    const pct = count / maxCount.value;
+    const idx = Math.min(4, Math.max(1, Math.ceil(pct * 4)));
+    return bucketClasses[idx];
+};
+</script>
+
+<template>
+    <figure
+        role="img"
+        :aria-label="`Activity heatmap, 7 days by six 4-hour buckets, peak ${maxCount} events`"
+        class="flex flex-col gap-3"
+    >
+        <!-- Grid: a `min-content` label column + 7 fixed day cols. We avoid
+             `auto` for the label column because grid greedily expands it to
+             absorb any leftover container width, pushing the cells right.
+             `w-fit` on the figure keeps the whole heatmap left-aligned. -->
+        <div
+            class="grid w-fit grid-cols-[min-content_repeat(7,32px)] gap-1.5 sm:grid-cols-[min-content_repeat(7,40px)]"
+        >
+            <!-- Header row: empty corner + day initials -->
+            <div aria-hidden="true" />
+            <div
+                v-for="(day, i) in dayLabels"
+                :key="`day-${i}`"
+                class="text-center font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+            >
+                {{ day }}
+            </div>
+
+            <!-- Data rows: row label + 7 cells -->
+            <template v-for="(rowLabel, rowIdx) in rowLabels" :key="rowLabel">
+                <div
+                    class="pe-2 text-end font-mono text-[10px] tabular-nums text-text-muted"
+                >
+                    {{ rowLabel }}
+                </div>
+                <div
+                    v-for="(_, dayIdx) in dayLabels"
+                    :key="`${rowLabel}-${dayIdx}`"
+                    :title="`${dayNames[dayIdx]} ${rowLabel} — ${data[dayIdx]?.[rowIdx] ?? 0} events`"
+                    :aria-label="`${dayNames[dayIdx]} ${rowLabel} — ${data[dayIdx]?.[rowIdx] ?? 0} events`"
+                    class="aspect-square rounded border border-border-subtle/40 transition hover:border-accent-cyan/60"
+                    :class="cellClass(data[dayIdx]?.[rowIdx] ?? 0)"
+                />
+            </template>
+        </div>
+
+        <!-- Legend strip -->
+        <figcaption
+            class="ms-auto flex items-center gap-2 font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+        >
+            Less
+            <span class="flex items-center gap-1">
+                <span
+                    v-for="bucket in bucketClasses"
+                    :key="bucket"
+                    class="h-2.5 w-2.5 rounded-sm border border-border-subtle/40"
+                    :class="bucket"
+                />
+            </span>
+            More
+        </figcaption>
+    </figure>
+</template>

--- a/resources/js/Components/Activity/RightActivityRail.vue
+++ b/resources/js/Components/Activity/RightActivityRail.vue
@@ -32,8 +32,7 @@ const hasEvents = () => props.events.length > 0;
 
 <template>
     <aside
-        class="flex h-full flex-col gap-4 overflow-y-auto border-s border-border-subtle bg-background-panel px-4 py-6 backdrop-blur-xl"
-        :class="variant === 'drawer' ? 'w-80' : 'w-80'"
+        class="flex h-full w-80 flex-col gap-4 overflow-y-auto border-s border-border-subtle bg-background-panel px-4 py-6 backdrop-blur-xl"
         aria-label="Activity feed"
     >
         <header class="flex items-center justify-between gap-2">

--- a/resources/js/Components/Activity/RightActivityRail.vue
+++ b/resources/js/Components/Activity/RightActivityRail.vue
@@ -1,17 +1,33 @@
 <script setup lang="ts">
+import ActivityFeed from '@/Components/Activity/ActivityFeed.vue';
+import type { ActivityEvent } from '@/types';
 import { Activity, Filter, X } from 'lucide-vue-next';
 
-defineProps<{
-    /**
-     * `column` is the desktop layout (≥ 2xl). `drawer` is the slide-over used
-     * on tablet/laptop where the rail isn't always visible.
-     */
-    variant?: 'column' | 'drawer';
-}>();
+const props = withDefaults(
+    defineProps<{
+        /**
+         * `column` is the desktop layout (≥ 2xl). `drawer` is the slide-over used
+         * on tablet/laptop where the rail isn't always visible.
+         */
+        variant?: 'column' | 'drawer';
+        /**
+         * Optional populated feed. When omitted (or empty) the rail falls back
+         * to the empty-state block; pages without an activity feed (Profile,
+         * etc.) get the empty-state automatically.
+         */
+        events?: ActivityEvent[];
+    }>(),
+    {
+        variant: 'column',
+        events: () => [],
+    },
+);
 
 defineEmits<{
     (e: 'close'): void;
 }>();
+
+const hasEvents = () => props.events.length > 0;
 </script>
 
 <template>
@@ -38,7 +54,7 @@ defineEmits<{
                     class="flex h-8 w-8 cursor-not-allowed items-center justify-center rounded-lg border border-border-subtle bg-slate-950/40 text-text-muted transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
                     aria-label="Filter activity"
                     aria-disabled="true"
-                    title="Activity filters arrive with the real feed (spec 007)."
+                    title="Activity filtering arrives when real integrations land."
                 >
                     <Filter class="h-3.5 w-3.5" aria-hidden="true" />
                 </button>
@@ -54,8 +70,12 @@ defineEmits<{
             </div>
         </header>
 
-        <!-- Empty state — real feed lands in spec 007 -->
+        <!-- Populated feed when events were forwarded from the page; otherwise
+             the empty-state block shipped in spec 004 (used on Profile/Edit
+             and any future page that doesn't supply events). -->
+        <ActivityFeed v-if="hasEvents()" :events="events" />
         <div
+            v-else
             class="flex flex-1 flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-border-subtle bg-slate-950/40 px-4 py-10 text-center"
         >
             <span

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -3,7 +3,22 @@ import RightActivityRail from '@/Components/Activity/RightActivityRail.vue';
 import CommandPalette from '@/Components/CommandPalette/CommandPalette.vue';
 import Sidebar from '@/Components/Sidebar/Sidebar.vue';
 import TopBar from '@/Components/TopBar/TopBar.vue';
+import type { ActivityEvent } from '@/types';
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+
+withDefaults(
+    defineProps<{
+        /**
+         * Optional populated feed forwarded into both `<RightActivityRail>`
+         * instances (column + drawer). Pages that don't supply this prop get
+         * the rail's empty-state automatically.
+         */
+        activityEvents?: ActivityEvent[];
+    }>(),
+    {
+        activityEvents: () => [],
+    },
+);
 
 const sidebarOpen = ref(false);
 const activityRailOpen = ref(false);
@@ -129,7 +144,7 @@ onBeforeUnmount(() => {
 
         <!-- Persistent activity rail (≥ 2xl) -->
         <div class="relative z-30 hidden 2xl:flex">
-            <RightActivityRail variant="column" />
+            <RightActivityRail variant="column" :events="activityEvents" />
         </div>
 
         <!-- Activity rail drawer (md – 2xl) -->
@@ -165,6 +180,7 @@ onBeforeUnmount(() => {
             >
                 <RightActivityRail
                     variant="drawer"
+                    :events="activityEvents"
                     @close="activityRailOpen = false"
                 />
             </div>

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -451,7 +451,7 @@ const visualizationStubs = [
                     </footer>
                 </section>
 
-                <!-- Activity Heatmap (spec 007) — 7 days × 6 four-hour buckets -->
+                <!-- Activity Heatmap — 7 days × 6 four-hour buckets per §8.11 -->
                 <section
                     aria-label="Activity Heatmap"
                     class="glass-card flex flex-col gap-4 p-5 lg:col-span-12"

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
+import ActivityHeatmap from '@/Components/Activity/ActivityHeatmap.vue';
 import KpiCard from '@/Components/Dashboard/KpiCard.vue';
 import Sparkline from '@/Components/Dashboard/Sparkline.vue';
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import type { DashboardPayload } from '@/types';
+import type {
+    ActivityEvent,
+    ActivityHeatmapPayload,
+    DashboardPayload,
+} from '@/types';
 import { Head } from '@inertiajs/vue3';
 import {
     Activity,
@@ -23,6 +28,8 @@ import {
 
 defineProps<{
     dashboard: DashboardPayload;
+    recentActivity: ActivityEvent[];
+    activityHeatmap: ActivityHeatmapPayload;
 }>();
 
 // ----- Hardcoded mock data for the populated stub widgets -----
@@ -113,7 +120,7 @@ const visualizationStubs = [
 <template>
     <Head title="Overview" />
 
-    <AppLayout>
+    <AppLayout :activity-events="recentActivity">
         <template #title>
             <div class="flex flex-col">
                 <span
@@ -444,6 +451,28 @@ const visualizationStubs = [
                     </footer>
                 </section>
 
+                <!-- Activity Heatmap (spec 007) — 7 days × 6 four-hour buckets -->
+                <section
+                    aria-label="Activity Heatmap"
+                    class="glass-card flex flex-col gap-4 p-5 lg:col-span-12"
+                >
+                    <header class="flex items-center justify-between gap-3">
+                        <div class="flex items-center gap-2">
+                            <Activity
+                                class="h-4 w-4 text-accent-magenta"
+                                aria-hidden="true"
+                            />
+                            <h2 class="text-sm font-semibold text-text-primary">
+                                Activity Heatmap
+                            </h2>
+                        </div>
+                        <span class="font-mono text-[11px] text-text-muted">
+                            7 days · 4-hour buckets · mock
+                        </span>
+                    </header>
+                    <ActivityHeatmap :data="activityHeatmap" />
+                </section>
+
                 <!-- Catch-all placeholder for chart-heavy widgets that need
                      dedicated specs (map, charts, gauges, timeline). One
                      card to keep the page dense without sprawling. -->
@@ -488,7 +517,7 @@ const visualizationStubs = [
                     </div>
                     <footer class="text-[11px] text-text-muted">
                         Chart, map, and gauge widgets land with their owning
-                        phases. ActivityFeed + Heatmap render in spec 007.
+                        phases.
                     </footer>
                 </section>
             </div>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -63,3 +63,50 @@ export interface DashboardPayload {
         status: DashboardStatus;
     };
 }
+
+/**
+ * Roadmap §8.10 event-type vocabulary. Drives both the icon lookup and the
+ * severity tone in `ActivityFeedItem`.
+ */
+export type ActivityEventType =
+    | 'issue.created'
+    | 'issue.closed'
+    | 'pull_request.opened'
+    | 'pull_request.merged'
+    | 'pull_request.review_requested'
+    | 'workflow.failed'
+    | 'workflow.succeeded'
+    | 'deployment.started'
+    | 'deployment.succeeded'
+    | 'deployment.failed'
+    | 'website.down'
+    | 'website.recovered'
+    | 'host.offline'
+    | 'host.recovered'
+    | 'container.unhealthy'
+    | 'alert.triggered'
+    | 'alert.resolved';
+
+/**
+ * Single activity-feed event as returned by `OverviewController`. Mirrors
+ * the §8.10 field list with the optional fields trimmed to what we actually
+ * surface in the UI today (id, type, severity, title, source, occurred_at,
+ * optional metadata pill).
+ */
+export interface ActivityEvent {
+    id: string;
+    type: ActivityEventType;
+    severity: 'success' | 'warning' | 'danger' | 'info' | 'muted';
+    title: string;
+    source: string;
+    /** Pre-formatted relative-time string ("3 min ago"). Server-rendered for now. */
+    occurred_at: string;
+    /** Optional metadata pill rendered to the right of the source meta. */
+    metadata?: string;
+}
+
+/**
+ * 7×6 heatmap grid. Outer array is days (Sun..Sat), inner array is the six
+ * 4-hour buckets used by §8.11 MVP (12 AM / 4 AM / 8 AM / 12 PM / 4 PM / 8 PM).
+ */
+export type ActivityHeatmapPayload = number[][];

--- a/specs/phase-0-foundation/007-activity-feed-heatmap.md
+++ b/specs/phase-0-foundation/007-activity-feed-heatmap.md
@@ -1,0 +1,106 @@
+---
+spec: activity-feed-heatmap
+phase: 0-foundation
+status: in-progress
+owner: yoany
+created: 2026-04-27
+updated: 2026-04-27
+issue: https://github.com/Copxer/nexus/issues/15
+branch: spec/007-activity-feed-heatmap
+---
+
+# 007 — ActivityFeed + ActivityHeatmap components (mock data)
+
+## Goal
+Replace the right-rail empty state from spec 004 with a populated `ActivityFeed` and add an `ActivityHeatmap` widget to the Overview page — both fed by hardcoded mock data from the existing `OverviewController`. After this spec, the Overview screen visually matches `nexus-dashboard.png` for two more sections: the right rail streams events (icons + severity colors + timestamps), and the dashboard surface gains a 7×6 grid heatmap showing relative activity intensity by day-of-week × time-of-day.
+
+Roadmap reference: §8.10 Activity Feed, §8.11 Heatmap Activity (MVP heatmap = 7 days × 6 time buckets per the §8.11 example rows: 12 AM / 4 AM / 8 AM / 12 PM / 4 PM / 8 PM).
+Visual target: [`../visual-reference.md`](../visual-reference.md) → [`../../nexus-dashboard.png`](../../nexus-dashboard.png) — right-rail event list and the heatmap grid (purple → magenta → pink intensity ramp).
+
+## Scope
+**In scope:**
+- New `resources/js/Components/Activity/ActivityFeed.vue` — composes a list of events plus a small "Recent · All" tab pill (visual-only — actual filtering arrives with real integrations). Renders inside the existing `RightActivityRail` (replacing the empty state shipped in spec 004).
+- New `resources/js/Components/Activity/ActivityFeedItem.vue` — single event row: severity-tinted icon + two-line content (title + source/time meta) + optional inline metadata pill (e.g. repo name). Click is inert (`aria-disabled`) for now — target detail views ship with their respective phases.
+- New `resources/js/Components/Activity/ActivityHeatmap.vue` — 7-column × 6-row grid of small rounded squares. Cell intensity maps `count` to a 5-step ramp (background-panel → accent-purple → accent-magenta — matches visual-reference spec §11). Native `<title>` tooltip + `aria-label` per cell ("Wed 12 PM — 3 events"). Header axis: `S M T W T F S` columns; row labels: `12 AM / 4 AM / 8 AM / 12 PM / 4 PM / 8 PM`. A small legend strip ("Less / More") below the grid.
+- Update `RightActivityRail.vue` to drop the empty-state block and render `<ActivityFeed :events="…" />` instead. The header's filter button stays placeholder-disabled (its real behavior depends on the real feed). Drop the now-stale "spec 007" hint title text and replace with phase-language consistent with sidebar/palette.
+- Extend `app/Http/Controllers/OverviewController.php` with two new top-level Inertia props:
+    - `recentActivity: ActivityEvent[]` — 8–10 hardcoded events covering the §8.10 event-type vocabulary (a deployment success, a workflow failure, a pull-request merge, a website-down + recovery pair, an alert trigger, etc.).
+    - `activityHeatmap: number[][]` — 7×6 array of small non-negative integers (event counts per day-of-week × time-bucket).
+- Type both new shapes in `resources/js/types/index.d.ts` (`ActivityEvent`, `ActivityEventType`, `ActivityHeatmapPayload`). Extend the `Overview.vue` page-prop type to receive them.
+- Add the `ActivityHeatmap` to the Overview page as its own glass-card row between the existing "Service Health" / "Container Hosts" row and the "Visualizations" placeholder card. Drop the now-redundant "ActivityFeed + Heatmap render in spec 007" footer text from the Visualizations card (it's no longer pending here).
+- Pass the rail's events from `Overview.vue` down to `AppLayout.vue` via a new optional slot or prop on the layout. Since the rail is rendered by the layout (twice — column + drawer variants), the cleanest plumbing is: `AppLayout` accepts a `defineProps<{ activityEvents?: ActivityEvent[] }>()` and forwards it to both `RightActivityRail` instances. Pages without an activity feed (Profile/Edit) keep the empty-state behavior; the rail accepts an optional `events` prop and falls back to its current empty-state when omitted.
+- Extend `tests/Feature/SmokeTest.php` with one more `assertInertia` block confirming `recentActivity` is an array (count ≥ 1) and `activityHeatmap` is a 7×6 array.
+
+**Out of scope:**
+- Real event ingestion / Domain layer / broadcasting (`ActivityEventCreated` event from §8.10's instructions). Comes when integrations land in phases 2/3/4.
+- Real backend filtering on `Filter` button — visual-only this spec, same treatment as the time-range pill in TopBar.
+- Click-to-detail navigation on individual events — inert (`aria-disabled`) until target sections exist.
+- Heatmap clicking-cell-filters-feed wiring — inert this spec.
+- Real-time updates / WebSocket subscription. Reverb is configured (per `.env`), but the wire-up is deferred to phase 9 polish.
+- Accessibility beyond keyboard tab + visible focus ring + tooltips. No ARIA-grid pattern for the heatmap (it's decorative-with-tooltips; semantic table would be overkill for a 42-cell mock).
+
+## Plan
+1. Build `ActivityFeedItem.vue` first — the smallest leaf. Props: a single `ActivityEvent`. Map event-type → lucide icon + severity tone via small lookup tables.
+2. Build `ActivityFeed.vue` — composes a list, takes `events: ActivityEvent[]`. Optional "Recent / All" pill is visual-only.
+3. Build `ActivityHeatmap.vue` — props: `data: number[][]` (7×6). Intensity bucket function (`count → 0..4`). CSS classes per bucket use `bg-background-panel-hover`, `bg-accent-purple/15`, `bg-accent-purple/40`, `bg-accent-magenta/55`, `bg-accent-magenta/80`. Each cell has `<title>` + `aria-label`.
+4. Wire feed into `RightActivityRail.vue`:
+    - Add an optional `events?: ActivityEvent[]` prop.
+    - Render `<ActivityFeed :events="events" />` when `events?.length > 0`, otherwise fall back to the existing empty-state block.
+    - Update the filter button's tooltip from spec-number to phase-language.
+5. Wire layout-level forwarding:
+    - `AppLayout.vue` adds an optional `activityEvents?: ActivityEvent[]` prop and passes it down to both `<RightActivityRail>` instances (column + drawer).
+6. Backend:
+    - Extend `OverviewController::__invoke()` to add `recentActivity` (8–10 hardcoded events with realistic `occurred_at` timestamps relative to now) and `activityHeatmap` (7×6 mock counts with a believable rhythm — quieter overnight/weekend, busier weekdays mid-day).
+7. Types:
+    - Add `ActivityEventType`, `ActivityEvent`, `ActivityHeatmapPayload` to `resources/js/types/index.d.ts`. Re-export from there.
+8. `Overview.vue`:
+    - Receive the two new props, pass `activityEvents` to `<AppLayout>`, render `<ActivityHeatmap :data="activityHeatmap" />` in a new section between the existing rows and the Visualizations placeholder.
+    - Remove the now-redundant "ActivityFeed + Heatmap render in spec 007" line from the Visualizations footer.
+9. SmokeTest: add `recentActivity` and `activityHeatmap` shape assertions.
+10. Run dev server, manually verify in Playwright at desktop / tablet / mobile. Capture issues + fixes in the work log. Side-by-side compare with `nexus-dashboard.png`.
+11. Pipeline (vue-tsc, Pint, build, tests).
+12. Self-review with `superpowers:code-reviewer`.
+
+## Acceptance criteria
+- [ ] The right rail on `/overview` shows the populated `ActivityFeed` (8–10 mock events) instead of the empty-state block.
+- [ ] Each event row shows: severity-tinted icon (lucide), title, source + relative time meta, optional metadata pill.
+- [ ] The "Filter" button in the rail header stays disabled (visual only) and its tooltip references the phase that ships real filtering, not "spec 007".
+- [ ] Pages without activity events (Profile/Edit) still render the existing empty-state in the rail.
+- [ ] The Overview page now renders an `ActivityHeatmap` section between the Service Health row and the Visualizations card. Grid is 7 cols × 6 rows with column labels `S M T W T F S` and row labels `12 AM / 4 AM / 8 AM / 12 PM / 4 PM / 8 PM`.
+- [ ] Heatmap cells use a 5-step intensity ramp (panel-hover → purple → magenta) and have native `<title>` tooltips + `aria-label` strings of the form "Wed 12 PM — 3 events".
+- [ ] Heatmap legend strip ("Less / More" with 5 swatches) renders below the grid.
+- [ ] `OverviewController` Inertia response now carries `recentActivity` (array, length ≥ 1) and `activityHeatmap` (7×6 array of integers) in addition to the existing `dashboard` payload.
+- [ ] `DashboardPayload` is unchanged (still the §8.1.1 shape); the new shapes ride as separate top-level props.
+- [ ] No real integrations / API calls / DB queries — mock data only.
+- [ ] No `gray-*` / `red-*` / `green-*` / `indigo-*` Tailwind classes — design tokens only.
+- [ ] No regressions: existing tests still pass; SmokeTest gets a third case asserting the new prop shapes.
+- [ ] Pint clean, vue-tsc clean, `npm run build` green, CI green on the PR.
+- [ ] Self-review pass with `superpowers:code-reviewer`; material findings addressed before PR.
+
+## Files touched
+- `app/Http/Controllers/OverviewController.php` — extend Inertia render with `recentActivity` + `activityHeatmap` mock arrays.
+- `resources/js/Components/Activity/ActivityFeed.vue` — new list component.
+- `resources/js/Components/Activity/ActivityFeedItem.vue` — new event-row component.
+- `resources/js/Components/Activity/ActivityHeatmap.vue` — new 7×6 grid component.
+- `resources/js/Components/Activity/RightActivityRail.vue` — accept optional `events` prop; render feed when present, empty-state otherwise; update tooltip language.
+- `resources/js/Layouts/AppLayout.vue` — accept optional `activityEvents` prop and forward to both rail instances.
+- `resources/js/Pages/Overview.vue` — pass `activityEvents` to layout; render `<ActivityHeatmap>` section; trim redundant footer line on the Visualizations card.
+- `resources/js/types/index.d.ts` — add `ActivityEventType`, `ActivityEvent`, `ActivityHeatmapPayload` exports.
+- `tests/Feature/SmokeTest.php` — assert the new prop shapes.
+
+## Work log
+Dated notes as work progresses.
+
+### 2026-04-27
+- Spec drafted; scope confirmed (4 decisions locked: 7×6 heatmap, 8–10 events, visual-only filter/cell-click, layout-prop plumbing).
+- Opened issue [#15](https://github.com/Copxer/nexus/issues/15) and branch `spec/007-activity-feed-heatmap` off `main`.
+
+## Decisions (locked 2026-04-27)
+- **Heatmap shape — 7 cols × 6 rows.** Day-of-week × 4-hour bucket per roadmap §8.11. 7×24 is too dense at dashboard size.
+- **Feed length — 8–10 mock events.** Fits the rail without scrolling on desktop; bigger sets feel padded.
+- **Filter / cell-click — visual-only.** Same treatment as KPI cards / sidebar / time-range pill. Wiring real filter logic is meaningful when there's real data + scale to filter against.
+- **Plumbing — layout-level prop forwarding.** `AppLayout` accepts `activityEvents` and passes it to both `<RightActivityRail>` instances. A Pinia store / composable is premature with one consumer page; revisit when 3+ pages need to read the feed.
+
+## Open questions / blockers
+- **Reverb wire-up.** The repo has Reverb env vars set (we configured them earlier). The roadmap §8.10 says "Broadcast event: ActivityEventCreated" — a real broadcast subscription is meaningful only when there are real events firing. Defer to phase 9 polish. This spec stays purely server-rendered mock data.
+- **Heatmap accessibility model.** Treating the 42-cell grid as `role="img"` with a single descriptive `aria-label` summarizing the data, plus per-cell `<title>` tooltips for sighted users, is the lightweight choice. Going with that unless reviewer flags it during the agent pass.

--- a/specs/phase-0-foundation/007-activity-feed-heatmap.md
+++ b/specs/phase-0-foundation/007-activity-feed-heatmap.md
@@ -108,6 +108,14 @@ Dated notes as work progresses.
     - Heatmap reads as a compact grid in all viewports — peak (Wed 12 PM) is the brightest pink/magenta; weekend and overnight cells are darker.
     - Found and fixed: `auto` first column in the heatmap grid greedily absorbed leftover container width (~612px) and pushed all data cells to the right of the card. Switched to `min-content` for the label column + fixed-width day columns + `w-fit` on the figure so the heatmap stays compact and left-aligned regardless of card width.
 - Pipeline (local): vue-tsc clean, Pint clean, `npm run build` green. 3 SmokeTest cases pass with 48 assertions.
+- Self-review with `superpowers:code-reviewer`. **No blockers, no material findings.** Reviewer confirmed:
+    - Heatmap a11y model (`role="img"` + per-cell `<title>` + `aria-label`) is the right call vs an ARIA grid pattern for a static glyph.
+    - Bucket math correct on both branches (`count > 0` always lands in 1..4; `|| 1` fallback on `maxCount` protects all-zeros even if unreachable thanks to the `count <= 0` early return).
+    - Type union vs controller payload is drift-free (all 9 controller `type` strings exist in the `ActivityEventType` union).
+    - Layered defaults on `events` (AppLayout + RightActivityRail) earn their keep — both layers stay.
+    - `<li aria-label>` + `<ul aria-label>` is screen-reader-friendly.
+    - Lucide icon overlap with sidebar / commands registry is genuine but premature to extract — different semantic uses.
+    - 2 nits addressed: trimmed two stale "spec 007" comment references → phase-language; collapsed redundant `:class="variant === 'drawer' ? 'w-80' : 'w-80'"` into a single static class. Skipped: combining parallel `dayLabels`/`dayNames` arrays (cosmetic; reviewer flagged as "fine for 7 entries").
 
 ## Decisions (locked 2026-04-27)
 - **Heatmap shape — 7 cols × 6 rows.** Day-of-week × 4-hour bucket per roadmap §8.11. 7×24 is too dense at dashboard size.

--- a/specs/phase-0-foundation/007-activity-feed-heatmap.md
+++ b/specs/phase-0-foundation/007-activity-feed-heatmap.md
@@ -95,6 +95,20 @@ Dated notes as work progresses.
 - Spec drafted; scope confirmed (4 decisions locked: 7×6 heatmap, 8–10 events, visual-only filter/cell-click, layout-prop plumbing).
 - Opened issue [#15](https://github.com/Copxer/nexus/issues/15) and branch `spec/007-activity-feed-heatmap` off `main`.
 
+### 2026-04-28
+- Implemented `ActivityFeedItem.vue` (event-type → lucide icon map covering all §8.10 types; severity-tinted icon + title + source/time meta + optional metadata pill), `ActivityFeed.vue` (visual-only Recent/All tab pill + scrollable list), and `ActivityHeatmap.vue` (7×6 grid, 5-step purple→magenta intensity ramp, native `<title>` + `aria-label` per cell, Less/More legend).
+- Wired the feed into `RightActivityRail.vue` — accepts optional `events` prop; renders `<ActivityFeed>` when populated, falls back to the existing empty-state otherwise (so Profile/Edit and other non-feed pages keep their current behavior). Updated the filter button tooltip from spec-language to phase-language.
+- `AppLayout.vue` now accepts an optional `activityEvents` prop and forwards it to both rail instances (column + drawer). `Overview.vue` passes `recentActivity` through; other pages omit it and inherit the empty-state.
+- `OverviewController` extended with two new top-level Inertia props: `recentActivity` (9 mock events with realistic relative `occurred_at` strings + a §8.10-type-mix: deployment, PR merge, alert, workflow fail, review request, website recovery, container OOM, issue, host recovery) and `activityHeatmap` (7×6 with a believable rhythm — quieter overnight + weekends, peak Wed 12 PM = 10 events).
+- `Pages/Overview.vue` renders an `ActivityHeatmap` section between Service Health and the Visualizations card. Trimmed the now-redundant "ActivityFeed + Heatmap render in spec 007" line from the Visualizations footer.
+- New types in `resources/js/types/index.d.ts`: `ActivityEventType` (union of §8.10 vocabulary), `ActivityEvent`, `ActivityHeatmapPayload`.
+- `SmokeTest` adds `test_overview_carries_activity_feed_and_heatmap_payloads` — verifies `recentActivity` length is 9 with the expected per-event fields, and `activityHeatmap` is a 7×6 array.
+- Manual verification at four breakpoints (Playwright Chrome): 1600 / 1024 (drawer) / 768 / 390:
+    - Right rail shows the populated feed at desktop and the drawer variant on tablet, with the full 9-event list, severity-tinted icons, metadata pills (`US-EAST`, `CRITICAL`).
+    - Heatmap reads as a compact grid in all viewports — peak (Wed 12 PM) is the brightest pink/magenta; weekend and overnight cells are darker.
+    - Found and fixed: `auto` first column in the heatmap grid greedily absorbed leftover container width (~612px) and pushed all data cells to the right of the card. Switched to `min-content` for the label column + fixed-width day columns + `w-fit` on the figure so the heatmap stays compact and left-aligned regardless of card width.
+- Pipeline (local): vue-tsc clean, Pint clean, `npm run build` green. 3 SmokeTest cases pass with 48 assertions.
+
 ## Decisions (locked 2026-04-27)
 - **Heatmap shape — 7 cols × 6 rows.** Day-of-week × 4-hour bucket per roadmap §8.11. 7×24 is too dense at dashboard size.
 - **Feed length — 8–10 mock events.** Fits the rail without scrolling on desktop; bigger sets feel padded.

--- a/tests/Feature/SmokeTest.php
+++ b/tests/Feature/SmokeTest.php
@@ -46,4 +46,30 @@ class SmokeTest extends TestCase
                     )
             );
     }
+
+    public function test_overview_carries_activity_feed_and_heatmap_payloads(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->get('/overview')
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Overview')
+                    ->has('recentActivity', 9)
+                    ->has('recentActivity.0', fn (AssertableInertia $event) => $event
+                        ->has('id')
+                        ->has('type')
+                        ->has('severity')
+                        ->has('title')
+                        ->has('source')
+                        ->has('occurred_at')
+                        ->etc()
+                    )
+                    ->has('activityHeatmap', 7)
+                    ->has('activityHeatmap.0', 6)
+            );
+    }
 }


### PR DESCRIPTION
Closes #15

Spec: [`specs/phase-0-foundation/007-activity-feed-heatmap.md`](https://github.com/Copxer/nexus/blob/spec/007-activity-feed-heatmap/specs/phase-0-foundation/007-activity-feed-heatmap.md)

## Summary
- Replaces the right-rail empty-state shipped in spec 004 with a populated `ActivityFeed` (9 mock events covering the §8.10 vocabulary — deployment success, PR merge, alert trigger, workflow fail, review request, website recovery, container OOM, issue, host recovery). Each event row: severity-tinted lucide icon + title + source/time meta + optional metadata pill.
- Adds `ActivityHeatmap` widget on the Overview page — 7 days × 6 four-hour buckets per §8.11. 5-step purple → magenta intensity ramp, native `<title>` + `aria-label` per cell, Less/More legend strip. Mock data has a believable rhythm (quieter overnight + weekends, peak Wed 12 PM = 10 events).
- `RightActivityRail` accepts an optional `events` prop and falls back to its existing empty-state when absent (keeps Profile/Edit and other non-feed pages working). `AppLayout` accepts an optional `activityEvents` prop and forwards it to both rail instances (column + drawer).
- `OverviewController` extended with `recentActivity` + `activityHeatmap` Inertia props. New TS types: `ActivityEventType`, `ActivityEvent`, `ActivityHeatmapPayload`.
- `SmokeTest` adds a third assertion case (`recentActivity` length 9 + per-event field shape, `activityHeatmap` 7 × 6).

Decisions locked: 7×6 heatmap, 8–10 events, visual-only filter & cell-click, layout-prop plumbing.

## Test plan
- [x] Right rail on `/overview` shows the populated `ActivityFeed`; pages without events fall back to the empty-state.
- [x] Activity rail drawer at tablet (1024px) renders the same populated feed.
- [x] Each event row: severity-tinted icon + title + source/time meta + optional metadata pill.
- [x] Filter button stays disabled (visual only) — tooltip uses phase-language.
- [x] Activity Heatmap renders between Service Health and the Visualizations card. 7×6 grid with `S M T W T F S` columns and 4-hour-bucket rows.
- [x] Heatmap intensity ramp + Less/More legend visible; native `<title>` tooltips per cell.
- [x] No regressions: existing 2 SmokeTest cases still pass; new third case passes (3 cases, 48 assertions).
- [x] Pint clean, vue-tsc clean, `npm run build` green.
- [x] Verified responsive at 1600 / 1024 / 768 / 390.

## Self-review notes
Ran `superpowers:code-reviewer` on `git diff main...HEAD`. **No blockers, no material findings.**

- **Heatmap a11y model** (`role="img"` + per-cell `<title>` + `aria-label`) confirmed as the right call vs an ARIA grid pattern.
- **Bucket math** verified correct on both branches.
- **Type drift** clean — all 9 controller `type` strings exist in the `ActivityEventType` union.
- **Layered defaults** on `events` (AppLayout + RightActivityRail) earn their keep — both layers stay.
- **2 nits fixed:** trimmed two stale "spec 007" comments → phase-language; collapsed redundant `RightActivityRail.vue` `:class="variant === 'drawer' ? 'w-80' : 'w-80'"` to a static `w-80`.
- **Found and fixed during manual verification (before review):** the heatmap's `auto` first-column track greedily absorbed leftover container width (~612px) and right-aligned the cells. Switched to `min-content` + fixed-width day columns + `w-fit` on the figure.

## Local note
The 14 pre-existing PHP 8.5 + Laravel 13.6 CSRF-in-tests failures from spec 005/006 PRs remain unchanged — same pattern; not introduced or affected by this spec. CI (PHP 8.4) is green.