### PR TITLE
chore(specs): mark spec 007 done; update trackers

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -35,7 +35,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 
 | # | Phase | Status | Notes |
 |---|-------|--------|-------|
-| 0 | Foundation (auth, layout, static overview) | 🟡 | 6/9 specs done (001–006). Next: 007 ActivityFeed + ActivityHeatmap. |
+| 0 | Foundation (auth, layout, static overview) | 🟡 | 7/9 specs done (001–007). Next: 008 Responsive polish. |
 | 1 | Projects & Repositories | ⬜ | — |
 | 2 | GitHub Integration MVP | ⬜ | — |
 | 3 | GitHub Webhooks & Activity Feed | ⬜ | — |

--- a/specs/phase-0-foundation/007-activity-feed-heatmap.md
+++ b/specs/phase-0-foundation/007-activity-feed-heatmap.md
@@ -1,12 +1,13 @@
 ---
 spec: activity-feed-heatmap
 phase: 0-foundation
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-27
-updated: 2026-04-27
+updated: 2026-04-28
 issue: https://github.com/Copxer/nexus/issues/15
 branch: spec/007-activity-feed-heatmap
+pr: https://github.com/Copxer/nexus/pull/16
 ---
 
 # 007 — ActivityFeed + ActivityHeatmap components (mock data)

--- a/specs/phase-0-foundation/README.md
+++ b/specs/phase-0-foundation/README.md
@@ -16,7 +16,7 @@ Stand up a Laravel 12 + Vue 3 + Inertia + Tailwind project with authentication, 
 | 004 | AppLayout + Sidebar + TopBar + RightActivityRail | 🟢 |
 | 005 | CommandPalette (Cmd+K) shell | 🟢 |
 | 006 | Overview page with mock KPI cards, sparklines, status badges | 🟢 |
-| 007 | ActivityFeed + ActivityHeatmap components (mock data) | ⬜ |
+| 007 | ActivityFeed + ActivityHeatmap components (mock data) | 🟢 |
 | 008 | Responsive behavior (desktop / laptop / tablet / mobile) | ⬜ |
 | 009 | Redis / Horizon / queue / scheduler wired up | ⬜ |
 


### PR DESCRIPTION
Bookkeeping for [Spec 007 — ActivityFeed + ActivityHeatmap](https://github.com/Copxer/nexus/pull/16) (merged in #16).

## Summary
- `specs/phase-0-foundation/007-activity-feed-heatmap.md` → frontmatter `status: done`; added PR link.
- `specs/phase-0-foundation/README.md` → flip row 007 from ⬜ to 🟢.
- `specs/README.md` → Phase 0 notes updated (7/9 specs done; next: 008 Responsive polish).

## Test plan
- [ ] CI green (Pint + build + tests).
- [ ] Tracker tables render correctly on GitHub.