### PR TITLE
chore(specs): mark spec 008 done; update trackers

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -35,7 +35,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 
 | # | Phase | Status | Notes |
 |---|-------|--------|-------|
-| 0 | Foundation (auth, layout, static overview) | 🟡 | 7/9 specs done (001–007). Next: 008 Responsive polish. |
+| 0 | Foundation (auth, layout, static overview) | 🟡 | 8/9 specs done (001–008). Next: 009 Redis / Horizon / queue / scheduler. |
 | 1 | Projects & Repositories | ⬜ | — |
 | 2 | GitHub Integration MVP | ⬜ | — |
 | 3 | GitHub Webhooks & Activity Feed | ⬜ | — |

--- a/specs/phase-0-foundation/008-responsive-polish.md
+++ b/specs/phase-0-foundation/008-responsive-polish.md
@@ -1,12 +1,13 @@
 ---
 spec: responsive-polish
 phase: 0-foundation
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-28
 updated: 2026-04-28
 issue: https://github.com/Copxer/nexus/issues/18
 branch: spec/008-responsive-polish
+pr: https://github.com/Copxer/nexus/pull/19
 ---
 
 # 008 — Responsive behavior (desktop / laptop / tablet / mobile)

--- a/specs/phase-0-foundation/README.md
+++ b/specs/phase-0-foundation/README.md
@@ -17,7 +17,7 @@ Stand up a Laravel 12 + Vue 3 + Inertia + Tailwind project with authentication, 
 | 005 | CommandPalette (Cmd+K) shell | 🟢 |
 | 006 | Overview page with mock KPI cards, sparklines, status badges | 🟢 |
 | 007 | ActivityFeed + ActivityHeatmap components (mock data) | 🟢 |
-| 008 | Responsive behavior (desktop / laptop / tablet / mobile) | ⬜ |
+| 008 | Responsive behavior (desktop / laptop / tablet / mobile) | 🟢 |
 | 009 | Redis / Horizon / queue / scheduler wired up | ⬜ |
 
 ## Acceptance criteria (phase-level)


### PR DESCRIPTION
Bookkeeping for [Spec 008 — Responsive polish](https://github.com/Copxer/nexus/pull/19) (merged in #19).

## Summary
- `specs/phase-0-foundation/008-responsive-polish.md` → frontmatter `status: done`; added PR link.
- `specs/phase-0-foundation/README.md` → flip row 008 from ⬜ to 🟢.
- `specs/README.md` → Phase 0 notes updated (8/9 specs done; next: 009 Redis / Horizon / queue / scheduler — the last Phase 0 spec before Phase 1 starts).

## Test plan
- [ ] CI green (Pint + build + tests).
- [ ] Tracker tables render correctly on GitHub.