### PR TITLE
chore(specs): mark spec 009 done; close out Phase 0 (9/9 🟢)

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -35,7 +35,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 
 | # | Phase | Status | Notes |
 |---|-------|--------|-------|
-| 0 | Foundation (auth, layout, static overview) | 🟡 | 8/9 specs done (001–008). Next: 009 Redis / Horizon / queue / scheduler. |
+| 0 | Foundation (auth, layout, static overview) | 🟢 | 9/9 specs done (001–009). Phase complete. |
 | 1 | Projects & Repositories | ⬜ | — |
 | 2 | GitHub Integration MVP | ⬜ | — |
 | 3 | GitHub Webhooks & Activity Feed | ⬜ | — |

--- a/specs/phase-0-foundation/009-redis-horizon-queue-scheduler.md
+++ b/specs/phase-0-foundation/009-redis-horizon-queue-scheduler.md
@@ -1,12 +1,13 @@
 ---
 spec: redis-horizon-queue-scheduler
 phase: 0-foundation
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-28
 updated: 2026-04-28
 issue: https://github.com/Copxer/nexus/issues/21
 branch: spec/009-redis-horizon-queue-scheduler
+pr: https://github.com/Copxer/nexus/pull/22
 ---
 
 # 009 — Redis / Horizon / queue / scheduler wired up

--- a/specs/phase-0-foundation/README.md
+++ b/specs/phase-0-foundation/README.md
@@ -18,7 +18,7 @@ Stand up a Laravel 12 + Vue 3 + Inertia + Tailwind project with authentication, 
 | 006 | Overview page with mock KPI cards, sparklines, status badges | 🟢 |
 | 007 | ActivityFeed + ActivityHeatmap components (mock data) | 🟢 |
 | 008 | Responsive behavior (desktop / laptop / tablet / mobile) | 🟢 |
-| 009 | Redis / Horizon / queue / scheduler wired up | ⬜ |
+| 009 | Redis / Horizon / queue / scheduler wired up | 🟢 |
 
 ## Acceptance criteria (phase-level)
 - [ ] User can register, log in, log out


### PR DESCRIPTION
Bookkeeping for [Spec 009 — Redis / Horizon / queue / scheduler](https://github.com/Copxer/nexus/pull/22) (merged in #22).

**Phase 0 — Foundation is now complete (9/9 specs done).**

## Summary
- `specs/phase-0-foundation/009-redis-horizon-queue-scheduler.md` → frontmatter `status: done`; added PR link.
- `specs/phase-0-foundation/README.md` → flip row 009 from ⬜ to 🟢.
- `specs/README.md` → flip Phase 0 from 🟡 to 🟢 (9/9 specs done; phase complete).

Next: **Phase 1 — Projects & Repositories**.

## Test plan
- [ ] CI green (Pint + build + tests).
- [ ] Tracker tables render correctly on GitHub.