### PR TITLE
chore(specs): mark spec 010 done; flip Phase 1 to 🟡

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -36,7 +36,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | # | Phase | Status | Notes |
 |---|-------|--------|-------|
 | 0 | Foundation (auth, layout, static overview) | 🟢 | 9/9 specs done (001–009). Phase complete. |
-| 1 | Projects & Repositories | ⬜ | — |
+| 1 | Projects & Repositories | 🟡 | 1/3 specs done (010). Next: 011 Repositories. |
 | 2 | GitHub Integration MVP | ⬜ | — |
 | 3 | GitHub Webhooks & Activity Feed | ⬜ | — |
 | 4 | Deployments & CI/CD | ⬜ | — |

--- a/specs/phase-1-projects/010-projects-foundation.md
+++ b/specs/phase-1-projects/010-projects-foundation.md
@@ -1,12 +1,13 @@
 ---
 spec: projects-foundation
 phase: 1-projects
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-28
 updated: 2026-04-28
 issue: https://github.com/Copxer/nexus/issues/24
 branch: spec/010-projects-foundation
+pr: https://github.com/Copxer/nexus/pull/25
 ---
 
 # 010 — Projects (model + CRUD pages + sidebar/palette activation)

--- a/specs/phase-1-projects/README.md
+++ b/specs/phase-1-projects/README.md
@@ -10,7 +10,7 @@ Add real project and repository records to Nexus. Replace the mock dashboard dat
 
 | # | Task | Status |
 |---|------|--------|
-| 010 | Projects (model + migration + factory + policy + CRUD pages + sidebar/palette activation) | ⬜ |
+| 010 | Projects (model + migration + factory + policy + CRUD pages + sidebar/palette activation) | 🟢 |
 | 011 | Repositories (model + migration + manual link + index/show pages + sidebar/palette activation) | ⬜ |
 | 012 | Wire Overview KPIs and Top Repositories widget to the database | ⬜ |
 


### PR DESCRIPTION
Bookkeeping for [Spec 010 — Projects foundation](https://github.com/Copxer/nexus/pull/25) (merged in #25).

## Summary
- `specs/phase-1-projects/010-projects-foundation.md` → frontmatter `status: done`; added PR link.
- `specs/phase-1-projects/README.md` → flip row 010 from ⬜ to 🟢.
- `specs/README.md` → flip Phase 1 from ⬜ to 🟡 (1/3 specs done; next: 011 Repositories).

## Test plan
- [ ] CI green (Pint + build + tests).
- [ ] Tracker tables render correctly on GitHub.