### PR TITLE
chore(specs): mark spec 011 done; Phase 1 to 2/3

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -36,7 +36,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | # | Phase | Status | Notes |
 |---|-------|--------|-------|
 | 0 | Foundation (auth, layout, static overview) | 🟢 | 9/9 specs done (001–009). Phase complete. |
-| 1 | Projects & Repositories | 🟡 | 1/3 specs done (010). Next: 011 Repositories. |
+| 1 | Projects & Repositories | 🟡 | 2/3 specs done (010–011). Next: 012 Wire Overview to DB. |
 | 2 | GitHub Integration MVP | ⬜ | — |
 | 3 | GitHub Webhooks & Activity Feed | ⬜ | — |
 | 4 | Deployments & CI/CD | ⬜ | — |

--- a/specs/phase-1-projects/011-repositories.md
+++ b/specs/phase-1-projects/011-repositories.md
@@ -1,12 +1,13 @@
 ---
 spec: repositories
 phase: 1-projects
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-28
 updated: 2026-04-28
 issue: https://github.com/Copxer/nexus/issues/27
 branch: spec/011-repositories
+pr: https://github.com/Copxer/nexus/pull/28
 ---
 
 # 011 — Repositories (model + manual link + index/show + sidebar/palette activation)

--- a/specs/phase-1-projects/README.md
+++ b/specs/phase-1-projects/README.md
@@ -11,7 +11,7 @@ Add real project and repository records to Nexus. Replace the mock dashboard dat
 | # | Task | Status |
 |---|------|--------|
 | 010 | Projects (model + migration + factory + policy + CRUD pages + sidebar/palette activation) | 🟢 |
-| 011 | Repositories (model + migration + manual link + index/show pages + sidebar/palette activation) | ⬜ |
+| 011 | Repositories (model + migration + manual link + index/show pages + sidebar/palette activation) | 🟢 |
 | 012 | Wire Overview KPIs and Top Repositories widget to the database | ⬜ |
 
 ## Acceptance criteria (phase-level)


### PR DESCRIPTION
Bookkeeping for [Spec 011 — Repositories](https://github.com/Copxer/nexus/pull/28) (merged in #28).

## Summary
- `specs/phase-1-projects/011-repositories.md` → frontmatter `status: done`; added PR link.
- `specs/phase-1-projects/README.md` → flip row 011 from ⬜ to 🟢.
- `specs/README.md` → Phase 1 notes updated (2/3 specs done; next: 012 Wire Overview to DB — last Phase 1 spec).

## Test plan
- [ ] CI green (Pint + build + tests).
- [ ] Tracker tables render correctly on GitHub.