### PR TITLE
chore(specs): mark spec 012 done; close out Phase 1 (3/3 🟢)

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -36,7 +36,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | # | Phase | Status | Notes |
 |---|-------|--------|-------|
 | 0 | Foundation (auth, layout, static overview) | 🟢 | 9/9 specs done (001–009). Phase complete. |
-| 1 | Projects & Repositories | 🟡 | 2/3 specs done (010–011). Next: 012 Wire Overview to DB. |
+| 1 | Projects & Repositories | 🟢 | 3/3 specs done (010–012). Phase complete. |
 | 2 | GitHub Integration MVP | ⬜ | — |
 | 3 | GitHub Webhooks & Activity Feed | ⬜ | — |
 | 4 | Deployments & CI/CD | ⬜ | — |

--- a/specs/phase-1-projects/012-overview-to-db.md
+++ b/specs/phase-1-projects/012-overview-to-db.md
@@ -1,12 +1,13 @@
 ---
 spec: overview-to-db
 phase: 1-projects
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-28
 updated: 2026-04-28
 issue: https://github.com/Copxer/nexus/issues/30
 branch: spec/012-overview-to-db
+pr: https://github.com/Copxer/nexus/pull/31
 ---
 
 # 012 — Wire Overview KPIs and Top Repositories widget to the database

--- a/specs/phase-1-projects/README.md
+++ b/specs/phase-1-projects/README.md
@@ -12,7 +12,7 @@ Add real project and repository records to Nexus. Replace the mock dashboard dat
 |---|------|--------|
 | 010 | Projects (model + migration + factory + policy + CRUD pages + sidebar/palette activation) | 🟢 |
 | 011 | Repositories (model + migration + manual link + index/show pages + sidebar/palette activation) | 🟢 |
-| 012 | Wire Overview KPIs and Top Repositories widget to the database | ⬜ |
+| 012 | Wire Overview KPIs and Top Repositories widget to the database | 🟢 |
 
 ## Acceptance criteria (phase-level)
 - [ ] User can create, edit, and delete a project from the UI (`/projects` index, create form, detail page).


### PR DESCRIPTION
Bookkeeping for [Spec 012 — Wire Overview to DB](https://github.com/Copxer/nexus/pull/31) (merged in #31).

**Phase 1 — Projects & Repositories is now complete (3/3 specs done).**

## Summary
- `specs/phase-1-projects/012-overview-to-db.md` → frontmatter `status: done`; added PR link.
- `specs/phase-1-projects/README.md` → flip row 012 from ⬜ to 🟢.
- `specs/README.md` → flip Phase 1 from 🟡 to 🟢 (3/3 specs done; phase complete).

Next: **Phase 2 — GitHub Integration MVP** (real GitHub OAuth/App connection, repo selection, issue + PR sync, Work Items page, manual sync button).

## Test plan
- [ ] CI green (Pint + build + tests).
- [ ] Tracker tables render correctly on GitHub.