### PR TITLE
chore(specs): mark spec 013 done; flip Phase 2 to 🟡

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -37,7 +37,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 |---|-------|--------|-------|
 | 0 | Foundation (auth, layout, static overview) | 🟢 | 9/9 specs done (001–009). Phase complete. |
 | 1 | Projects & Repositories | 🟢 | 3/3 specs done (010–012). Phase complete. |
-| 2 | GitHub Integration MVP | ⬜ | — |
+| 2 | GitHub Integration MVP | 🟡 | 1/4 specs done (013). Next: 014 Repository import. |
 | 3 | GitHub Webhooks & Activity Feed | ⬜ | — |
 | 4 | Deployments & CI/CD | ⬜ | — |
 | 5 | Website Monitoring | ⬜ | — |

--- a/specs/phase-2-github/013-github-app-connection.md
+++ b/specs/phase-2-github/013-github-app-connection.md
@@ -1,12 +1,13 @@
 ---
 spec: github-app-connection
 phase: 2-github
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-29
 updated: 2026-04-29
 issue: https://github.com/Copxer/nexus/issues/33
 branch: spec/013-github-app-connection
+pr: https://github.com/Copxer/nexus/pull/34
 ---
 
 # 013 — GitHub App connection (OAuth flow, encrypted token storage, Settings/Integrations panel)

--- a/specs/phase-2-github/README.md
+++ b/specs/phase-2-github/README.md
@@ -11,7 +11,7 @@ This phase is **read-only against GitHub**. Webhooks and near-real-time updates 
 
 | # | Task | Status |
 |---|------|--------|
-| 013 | GitHub App connection (OAuth flow, encrypted token storage, Settings/Integrations panel) | ⬜ |
+| 013 | GitHub App connection (OAuth flow, encrypted token storage, Settings/Integrations panel) | 🟢 |
 | 014 | Repository import (list available repos, user picks which to import, `SyncGitHubRepositoryJob` populates metadata) | ⬜ |
 | 015 | Issues sync (database + sync job + `/work-items` issues filter) | ⬜ |
 | 016 | Pull requests sync + unified Work Items page (both filters + "Run sync" buttons) | ⬜ |


### PR DESCRIPTION
Bookkeeping for [Spec 013 — GitHub App connection](https://github.com/Copxer/nexus/pull/34) (merged in #34).

## Summary
- `specs/phase-2-github/013-github-app-connection.md` → frontmatter `status: done`; added PR link.
- `specs/phase-2-github/README.md` → flip row 013 from ⬜ to 🟢.
- `specs/README.md` → flip Phase 2 from ⬜ to 🟡 (1/4 specs done; next: 014 Repository import).

## Test plan
- [ ] CI green (Pint + build + tests).
- [ ] Tracker tables render correctly on GitHub.