### PR TITLE
Spec 014 — Repository import (list, pick, sync metadata)

### DIFF
--- a/app/Domain/GitHub/Actions/ImportRepositoryAction.php
+++ b/app/Domain/GitHub/Actions/ImportRepositoryAction.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Domain\GitHub\Actions;
+
+use App\Domain\GitHub\Jobs\SyncGitHubRepositoryJob;
+use App\Domain\Repositories\Actions\LinkRepositoryToProjectAction;
+use App\Models\Project;
+use App\Models\Repository;
+
+/**
+ * Import a GitHub repository into a Nexus project. Reuses spec 011's
+ * `LinkRepositoryToProjectAction` to create (or find) the local row in
+ * `pending` state, then dispatches `SyncGitHubRepositoryJob` to fetch
+ * the real metadata from GitHub.
+ *
+ * Idempotent: re-importing an already-linked repo is a no-op for the
+ * row but a fresh sync is dispatched (the user is asking for "refresh
+ * me", which is the same dispatch path as a first-time import).
+ *
+ * Authorization happens at the controller layer (ProjectPolicy::update).
+ * This action assumes the caller has already cleared that gate.
+ */
+class ImportRepositoryAction
+{
+    public function __construct(
+        private readonly LinkRepositoryToProjectAction $linker,
+    ) {}
+
+    public function execute(Project $project, string $input): Repository
+    {
+        $repository = $this->linker->execute($project, $input);
+
+        SyncGitHubRepositoryJob::dispatch($repository->id);
+
+        return $repository;
+    }
+}

--- a/app/Domain/GitHub/Exceptions/GitHubApiException.php
+++ b/app/Domain/GitHub/Exceptions/GitHubApiException.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Domain\GitHub\Exceptions;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Single typed exception for any GitHub REST API failure. Callers switch
+ * on status helpers rather than instanceof against a hierarchy of
+ * subclasses; the spec calls for a single class with helpers.
+ *
+ * Two construction paths:
+ *   - `GitHubApiException::fromResponse($response)` — semantic GitHub error
+ *     payload (Response.json() has an `error`/`message` field) or any
+ *     non-2xx status code that the caller wants to wrap.
+ *   - `GitHubApiException::fromTransport($e, $message)` — wraps an
+ *     `Illuminate\Http\Client\RequestException` (HTTP transport failure
+ *     before GitHub answered).
+ */
+class GitHubApiException extends RuntimeException
+{
+    /** GitHub HTTP status code, or 0 for transport-layer failures. */
+    public readonly int $statusCode;
+
+    public function __construct(
+        string $message,
+        int $statusCode = 0,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+        $this->statusCode = $statusCode;
+    }
+
+    public static function fromResponse(Response $response, string $context = 'GitHub request failed'): self
+    {
+        $status = $response->status();
+        $body = $response->json();
+        $reason = is_array($body)
+            ? ($body['message'] ?? $body['error_description'] ?? $body['error'] ?? 'unknown')
+            : 'invalid response';
+
+        return new self("{$context}: HTTP {$status} {$reason}", $status);
+    }
+
+    public static function fromTransport(RequestException $e, string $context = 'GitHub request failed'): self
+    {
+        return new self(
+            "{$context}: ".$e->getMessage(),
+            $e->response?->status() ?? 0,
+            $e,
+        );
+    }
+
+    /** True for HTTP 401 — token revoked, expired, or never valid. */
+    public function isUnauthorized(): bool
+    {
+        return $this->statusCode === 401;
+    }
+
+    /**
+     * True for HTTP 403 with a rate-limit-exhaustion shape (GitHub's
+     * "API rate limit exceeded" path). Best-effort heuristic — caller
+     * should still log + surface to the user.
+     */
+    public function wasRateLimited(): bool
+    {
+        return $this->statusCode === 403
+            && str_contains(strtolower($this->getMessage()), 'rate limit');
+    }
+}

--- a/app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php
+++ b/app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php
@@ -146,17 +146,21 @@ class SyncGitHubRepositoryJob implements ShouldQueue
     }
 
     /**
-     * Flip the row to `failed`. Failure reason is logged at the call
-     * site (see the catches above) — spec 014's schema doesn't carry
-     * a `sync_error` column yet. A future spec that surfaces error
-     * messages on the Repository page will add the column + thread the
-     * reason through here.
+     * Flip the row to `failed`. We deliberately do NOT update
+     * `last_synced_at` — that column means "last successful sync" and
+     * is what the Settings card surfaces as "Last sync N min ago". A
+     * failed run keeps the previous successful timestamp (or null if
+     * never synced).
+     *
+     * Failure reason is logged at the call site (see the catches above)
+     * — spec 014's schema doesn't carry a `sync_error` column yet. A
+     * future spec that surfaces error messages on the Repository page
+     * will add the column + thread the reason through here.
      */
     private function markFailed(Repository $repository): void
     {
         $repository->forceFill([
             'sync_status' => RepositorySyncStatus::Failed->value,
-            'last_synced_at' => now(),
         ])->save();
     }
 

--- a/app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php
+++ b/app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Domain\GitHub\Jobs;
+
+use App\Domain\GitHub\Exceptions\GitHubApiException;
+use App\Domain\GitHub\Services\GitHubClient;
+use App\Enums\RepositorySyncStatus;
+use App\Models\GithubConnection;
+use App\Models\Repository;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Refresh a single Repository row's metadata from GitHub.
+ *
+ * Lifecycle:
+ *   pending → syncing → synced (happy path)
+ *   pending → syncing → failed (caught GitHubApiException or Throwable)
+ *
+ * On 401 (token revoked / expired) we additionally clear the
+ * connection's `access_token` and zero out `expires_at` so spec-013's
+ * Settings card surfaces the Reconnect CTA. The job itself still ends
+ * in `failed` status — the user re-imports after re-auth.
+ *
+ * Idempotent: a replay against an already-synced row will simply
+ * refresh it.
+ */
+class SyncGitHubRepositoryJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /** Number of retry attempts before the queue gives up. */
+    public int $tries = 1;
+
+    public function __construct(public readonly int $repositoryId) {}
+
+    public function handle(): void
+    {
+        $repository = Repository::query()->find($this->repositoryId);
+
+        if ($repository === null) {
+            // Row deleted between dispatch and run. No-op.
+            return;
+        }
+
+        $connection = $this->resolveConnection($repository);
+
+        if ($connection === null) {
+            Log::warning('GitHub repository sync skipped — no connection', [
+                'repository_id' => $repository->id,
+                'full_name' => $repository->full_name,
+            ]);
+            $this->markFailed($repository);
+
+            return;
+        }
+
+        $repository->forceFill([
+            'sync_status' => RepositorySyncStatus::Syncing->value,
+        ])->save();
+
+        try {
+            $payload = (new GitHubClient($connection))
+                ->fetchRepository($repository->full_name);
+
+            $this->applyPayload($repository, $payload);
+
+            $repository->forceFill([
+                'sync_status' => RepositorySyncStatus::Synced->value,
+                'last_synced_at' => now(),
+            ])->save();
+        } catch (GitHubApiException $e) {
+            if ($e->isUnauthorized()) {
+                $this->expireConnection($connection);
+            }
+
+            Log::warning('GitHub repository sync failed', [
+                'repository_id' => $repository->id,
+                'full_name' => $repository->full_name,
+                'status' => $e->statusCode,
+                'message' => $e->getMessage(),
+            ]);
+
+            $this->markFailed($repository);
+        } catch (Throwable $e) {
+            Log::error('GitHub repository sync errored', [
+                'repository_id' => $repository->id,
+                'full_name' => $repository->full_name,
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+
+            $this->markFailed($repository);
+        }
+    }
+
+    /**
+     * The connection to use for this sync. Phase 1 ties repos to projects
+     * and projects to a single owner user; the owner's connection is the
+     * source of truth for sync. Multi-team scoping ships later.
+     */
+    private function resolveConnection(Repository $repository): ?GithubConnection
+    {
+        $project = $repository->project;
+
+        if ($project === null) {
+            return null;
+        }
+
+        $project->loadMissing('owner');
+        $owner = $project->owner;
+
+        if ($owner === null) {
+            return null;
+        }
+
+        $owner->loadMissing('githubConnection');
+
+        return $owner->githubConnection;
+    }
+
+    /** Mirror GitHub's payload onto the local Repository row. */
+    private function applyPayload(Repository $repository, array $payload): void
+    {
+        $repository->forceFill([
+            'provider_id' => isset($payload['id']) ? (string) $payload['id'] : $repository->provider_id,
+            'description' => $payload['description'] ?? $repository->description,
+            'default_branch' => $payload['default_branch'] ?? $repository->default_branch,
+            'visibility' => $payload['visibility'] ?? ($payload['private'] ?? false ? 'private' : 'public'),
+            'language' => $payload['language'] ?? $repository->language,
+            'stars_count' => (int) ($payload['stargazers_count'] ?? 0),
+            'forks_count' => (int) ($payload['forks_count'] ?? 0),
+            'open_issues_count' => (int) ($payload['open_issues_count'] ?? 0),
+            'last_pushed_at' => $this->parseTimestamp($payload['pushed_at'] ?? null),
+            'html_url' => $payload['html_url'] ?? $repository->html_url,
+        ]);
+    }
+
+    /**
+     * Flip the row to `failed`. Failure reason is logged at the call
+     * site (see the catches above) — spec 014's schema doesn't carry
+     * a `sync_error` column yet. A future spec that surfaces error
+     * messages on the Repository page will add the column + thread the
+     * reason through here.
+     */
+    private function markFailed(Repository $repository): void
+    {
+        $repository->forceFill([
+            'sync_status' => RepositorySyncStatus::Failed->value,
+            'last_synced_at' => now(),
+        ])->save();
+    }
+
+    /**
+     * Clear the connection's access token + zero its expiry. Spec 013's
+     * `isAccessTokenValid()` returns `true` when `expires_at` is null,
+     * so we set it to "now" instead of null to flip the connection into
+     * the expired branch and surface the Reconnect CTA.
+     */
+    private function expireConnection(GithubConnection $connection): void
+    {
+        $connection->forceFill([
+            'access_token' => '',
+            'expires_at' => now(),
+        ])->save();
+    }
+
+    private function parseTimestamp(?string $iso): ?Carbon
+    {
+        if ($iso === null || $iso === '') {
+            return null;
+        }
+
+        return Carbon::parse($iso);
+    }
+}

--- a/app/Domain/GitHub/Services/GitHubClient.php
+++ b/app/Domain/GitHub/Services/GitHubClient.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Domain\GitHub\Services;
+
+use App\Domain\GitHub\Exceptions\GitHubApiException;
+use App\Models\GithubConnection;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Authenticated REST wrapper around GitHub's API. Each instance is
+ * scoped to a single `GithubConnection` (per-user OAuth from spec 013)
+ * — explicit construction makes the dependency obvious and test
+ * doubles trivial.
+ *
+ * All HTTP traffic flows through Laravel's `Http` facade so tests
+ * mock with `Http::fake()`. Headers are pinned to the `2022-11-28`
+ * GitHub API version because we depend on specific response shapes
+ * (e.g. `default_branch`, `stargazers_count`) that older versions
+ * could plausibly drop.
+ */
+class GitHubClient
+{
+    private const BASE_URL = 'https://api.github.com';
+
+    /** Single-page cap; we sort by pushed-desc so freshest 100 wins. */
+    private const DEFAULT_PER_PAGE = 100;
+
+    public function __construct(private readonly GithubConnection $connection) {}
+
+    /**
+     * GET /user/repos — every repo the user can see (owner +
+     * collaborator + organization member where granted). Capped at
+     * 100 entries (sort=pushed). Multi-page support lands later if
+     * power users hit the cap.
+     */
+    public function listRepositories(int $perPage = self::DEFAULT_PER_PAGE): array
+    {
+        try {
+            $response = $this->request()->get(self::BASE_URL.'/user/repos', [
+                'sort' => 'pushed',
+                'direction' => 'desc',
+                'per_page' => max(1, min($perPage, 100)),
+                'page' => 1,
+            ]);
+
+            if ($response->failed()) {
+                throw GitHubApiException::fromResponse(
+                    $response,
+                    'GitHub /user/repos failed',
+                );
+            }
+
+            return (array) $response->json();
+        } catch (RequestException $e) {
+            throw GitHubApiException::fromTransport($e, 'GitHub /user/repos failed');
+        }
+    }
+
+    /**
+     * GET /repos/{owner}/{name} — single repo's metadata. Used by
+     * `SyncGitHubRepositoryJob` to refresh local rows. Throws on 404.
+     */
+    public function fetchRepository(string $fullName): array
+    {
+        try {
+            $response = $this->request()->get(self::BASE_URL."/repos/{$fullName}");
+
+            if ($response->failed()) {
+                throw GitHubApiException::fromResponse(
+                    $response,
+                    "GitHub /repos/{$fullName} failed",
+                );
+            }
+
+            return (array) $response->json();
+        } catch (RequestException $e) {
+            throw GitHubApiException::fromTransport(
+                $e,
+                "GitHub /repos/{$fullName} failed",
+            );
+        }
+    }
+
+    /**
+     * Shared HTTP client config — auth + pinned API version + UA.
+     * Note: we don't call `->throw()` on the PendingRequest; the
+     * callers check `$response->failed()` and route the failure into
+     * `GitHubApiException` so the typed exception is the only thing
+     * the rest of the code sees.
+     */
+    private function request(): PendingRequest
+    {
+        return Http::withToken($this->connection->access_token)
+            ->withHeaders([
+                'Accept' => 'application/vnd.github+json',
+                'X-GitHub-Api-Version' => '2022-11-28',
+                'User-Agent' => 'Nexus-Control-Center',
+            ]);
+    }
+}

--- a/app/Http/Controllers/GithubRepositoryImportController.php
+++ b/app/Http/Controllers/GithubRepositoryImportController.php
@@ -7,6 +7,7 @@ use App\Domain\GitHub\Exceptions\GitHubApiException;
 use App\Domain\GitHub\Services\GitHubClient;
 use App\Models\Project;
 use App\Models\Repository;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
@@ -102,7 +103,18 @@ class GithubRepositoryImportController extends Controller
             ],
         ]);
 
-        $repository = $import->execute($project, $validated['full_name']);
+        try {
+            $repository = $import->execute($project, $validated['full_name']);
+        } catch (UniqueConstraintViolationException) {
+            // The picker hides already-linked-elsewhere rows, but the
+            // `repositories.full_name` column is globally unique, so a
+            // forged POST or a concurrent click in two tabs can still
+            // race here. Surface the same friendly error spec 011's
+            // manual-link controller uses.
+            return back()->withErrors([
+                'full_name' => 'That repository is already linked to another project.',
+            ]);
+        }
 
         return redirect()
             ->route('projects.show', $project)

--- a/app/Http/Controllers/GithubRepositoryImportController.php
+++ b/app/Http/Controllers/GithubRepositoryImportController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\GitHub\Actions\ImportRepositoryAction;
+use App\Domain\GitHub\Exceptions\GitHubApiException;
+use App\Domain\GitHub\Services\GitHubClient;
+use App\Models\Project;
+use App\Models\Repository;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class GithubRepositoryImportController extends Controller
+{
+    /**
+     * GET /projects/{project}/repositories/import
+     *
+     * Renders the picker. We list everything the user can see on
+     * GitHub, then flag rows that are already linked to ANY project
+     * (so the user understands why a row is disabled) — same-project
+     * imports are still possible (idempotent refresh path).
+     */
+    public function index(Request $request, Project $project): Response|RedirectResponse
+    {
+        $this->authorize('update', $project);
+
+        $user = $request->user();
+        $connection = $user?->githubConnection;
+
+        if ($connection === null) {
+            return redirect()
+                ->route('settings.index')
+                ->with(
+                    'error',
+                    'Connect your GitHub account first to import repositories.',
+                );
+        }
+
+        try {
+            $payload = (new GitHubClient($connection))->listRepositories();
+        } catch (GitHubApiException $e) {
+            return redirect()
+                ->route('projects.show', $project)
+                ->with('error', 'GitHub repository list failed: '.$e->getMessage());
+        }
+
+        $existingFullNames = Repository::query()
+            ->whereIn('full_name', collect($payload)->pluck('full_name')->filter()->all())
+            ->pluck('project_id', 'full_name');
+
+        $repositories = collect($payload)
+            ->map(fn (array $repo) => [
+                'id' => $repo['id'] ?? null,
+                'full_name' => $repo['full_name'] ?? null,
+                'description' => $repo['description'] ?? null,
+                'language' => $repo['language'] ?? null,
+                'private' => (bool) ($repo['private'] ?? false),
+                'stars_count' => (int) ($repo['stargazers_count'] ?? 0),
+                'forks_count' => (int) ($repo['forks_count'] ?? 0),
+                'pushed_at' => $repo['pushed_at'] ?? null,
+                'html_url' => $repo['html_url'] ?? null,
+                'is_already_linked' => $existingFullNames->has($repo['full_name'] ?? null),
+                'linked_to_this_project' => $existingFullNames->get($repo['full_name'] ?? null) === $project->id,
+            ])
+            ->filter(fn (array $repo) => $repo['full_name'] !== null)
+            ->values()
+            ->all();
+
+        return Inertia::render('Repositories/Import', [
+            'project' => [
+                'id' => $project->id,
+                'slug' => $project->slug,
+                'name' => $project->name,
+            ],
+            'repositories' => $repositories,
+        ]);
+    }
+
+    /**
+     * POST /projects/{project}/repositories/import
+     *
+     * Validates the `full_name`, dispatches the import action, redirects
+     * back to the project's Repositories tab with a flash.
+     */
+    public function store(
+        Request $request,
+        Project $project,
+        ImportRepositoryAction $import,
+    ): RedirectResponse {
+        $this->authorize('update', $project);
+
+        $validated = $request->validate([
+            'full_name' => [
+                'required',
+                'string',
+                'max:255',
+                'regex:#^[\w.-]+/[\w.-]+$#',
+                Rule::notIn(['/']),
+            ],
+        ]);
+
+        $repository = $import->execute($project, $validated['full_name']);
+
+        return redirect()
+            ->route('projects.show', $project)
+            ->with('status', "Importing {$repository->full_name}…");
+    }
+}

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -64,6 +64,7 @@ class ProjectController extends Controller
             'project' => $this->transform($project),
             'canUpdate' => $request->user()?->can('update', $project) ?? false,
             'canDelete' => $request->user()?->can('delete', $project) ?? false,
+            'hasGithubConnection' => $request->user()?->githubConnection !== null,
             'repositories' => $project->repositories->map(fn ($repo) => [
                 'id' => $repo->id,
                 'owner' => $repo->owner,

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -3,7 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Models\GithubConnection;
+use App\Models\Project;
+use App\Models\Repository;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -14,7 +17,7 @@ class SettingsController extends Controller
         $connection = $request->user()?->githubConnection;
 
         return Inertia::render('Settings/Index', [
-            'github' => $this->serializeConnection($connection),
+            'github' => $this->serializeConnection($connection, $request),
         ]);
     }
 
@@ -24,7 +27,7 @@ class SettingsController extends Controller
      * `$hidden` array protects `toArray()`, but we shape it explicitly
      * here so any future field is opt-in.
      */
-    private function serializeConnection(?GithubConnection $connection): ?array
+    private function serializeConnection(?GithubConnection $connection, Request $request): ?array
     {
         if ($connection === null) {
             return null;
@@ -36,6 +39,45 @@ class SettingsController extends Controller
             'expires_at' => $connection->expires_at?->diffForHumans(),
             'is_token_valid' => $connection->isAccessTokenValid(),
             'scopes' => $connection->scopes ?? [],
+            'recent_repositories' => $this->recentRepositoriesSummary($request),
+        ];
+    }
+
+    /**
+     * Lightweight summary of the user's repositories for the Settings
+     * card: count linked across their projects + most recent sync
+     * timestamp. Doesn't load full rows; two scalar queries.
+     */
+    private function recentRepositoriesSummary(Request $request): array
+    {
+        $userId = $request->user()?->id;
+
+        if ($userId === null) {
+            return ['count' => 0, 'last_synced_at' => null];
+        }
+
+        $projectIds = Project::query()
+            ->where('owner_user_id', $userId)
+            ->pluck('id');
+
+        if ($projectIds->isEmpty()) {
+            return ['count' => 0, 'last_synced_at' => null];
+        }
+
+        $count = Repository::query()
+            ->whereIn('project_id', $projectIds)
+            ->count();
+
+        $lastSyncedAt = Repository::query()
+            ->whereIn('project_id', $projectIds)
+            ->whereNotNull('last_synced_at')
+            ->max('last_synced_at');
+
+        return [
+            'count' => $count,
+            'last_synced_at' => $lastSyncedAt
+                ? Carbon::parse($lastSyncedAt)->diffForHumans()
+                : null,
         ];
     }
 }

--- a/resources/js/Pages/Projects/Show.vue
+++ b/resources/js/Pages/Projects/Show.vue
@@ -63,6 +63,7 @@ const props = defineProps<{
     canUpdate: boolean;
     canDelete: boolean;
     repositories: RepositoryRow[];
+    hasGithubConnection: boolean;
 }>();
 
 const linkForm = useForm({
@@ -382,35 +383,72 @@ const confirmDelete = () => {
                 aria-label="Repositories"
                 class="flex flex-col gap-4"
             >
-                <!-- Manual link form (project owner only) -->
-                <form
-                    v-if="canUpdate"
-                    class="glass-card flex flex-col gap-3 p-5 sm:flex-row sm:items-end"
-                    @submit.prevent="linkRepository"
-                >
-                    <div class="flex-1">
-                        <InputLabel
-                            for="repository-input"
-                            value="Link a GitHub repository"
-                        />
-                        <TextInput
-                            id="repository-input"
-                            v-model="linkForm.repository"
-                            type="text"
-                            class="mt-1 block w-full"
-                            placeholder="https://github.com/owner/name  or  owner/name"
-                            autocomplete="off"
-                        />
-                        <InputError
-                            class="mt-2"
-                            :message="linkForm.errors.repository"
-                        />
-                    </div>
-                    <PrimaryButton :disabled="linkForm.processing">
-                        <Plus class="me-1 h-4 w-4" aria-hidden="true" />
-                        Link repository
-                    </PrimaryButton>
-                </form>
+                <!-- Manual link form (project owner only) + Import-from-GitHub
+                     CTA when the user has a connection wired up. -->
+                <div v-if="canUpdate" class="flex flex-col gap-3">
+                    <Link
+                        v-if="hasGithubConnection"
+                        :href="route('projects.repositories.import.index', project.slug)"
+                        class="glass-card flex items-center justify-between gap-4 p-5 transition hover:border-accent-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                    >
+                        <div class="flex items-center gap-3">
+                            <span
+                                class="flex h-10 w-10 items-center justify-center rounded-xl border border-border-subtle bg-background-panel-hover"
+                            >
+                                <GitBranch
+                                    class="h-5 w-5 text-accent-purple"
+                                    aria-hidden="true"
+                                />
+                            </span>
+                            <div>
+                                <p class="text-sm font-semibold text-text-primary">
+                                    Import from GitHub
+                                </p>
+                                <p class="text-[11px] text-text-muted">
+                                    Pick from the repositories your connected
+                                    GitHub account can see.
+                                </p>
+                            </div>
+                        </div>
+                        <span
+                            class="inline-flex items-center gap-1 text-xs font-semibold text-accent-cyan"
+                        >
+                            Browse
+                            <ChevronLeft
+                                class="h-3.5 w-3.5 rotate-180"
+                                aria-hidden="true"
+                            />
+                        </span>
+                    </Link>
+
+                    <form
+                        class="glass-card flex flex-col gap-3 p-5 sm:flex-row sm:items-end"
+                        @submit.prevent="linkRepository"
+                    >
+                        <div class="flex-1">
+                            <InputLabel
+                                for="repository-input"
+                                value="Link a GitHub repository manually"
+                            />
+                            <TextInput
+                                id="repository-input"
+                                v-model="linkForm.repository"
+                                type="text"
+                                class="mt-1 block w-full"
+                                placeholder="https://github.com/owner/name  or  owner/name"
+                                autocomplete="off"
+                            />
+                            <InputError
+                                class="mt-2"
+                                :message="linkForm.errors.repository"
+                            />
+                        </div>
+                        <PrimaryButton :disabled="linkForm.processing">
+                            <Plus class="me-1 h-4 w-4" aria-hidden="true" />
+                            Link repository
+                        </PrimaryButton>
+                    </form>
+                </div>
 
                 <!-- Linked repositories list -->
                 <div

--- a/resources/js/Pages/Repositories/Import.vue
+++ b/resources/js/Pages/Repositories/Import.vue
@@ -1,0 +1,284 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import {
+    ChevronLeft,
+    ExternalLink,
+    GitBranch,
+    Github,
+    Lock,
+    Plus,
+    Search,
+    Star,
+} from 'lucide-vue-next';
+import { computed, ref } from 'vue';
+
+interface ProjectShape {
+    id: number;
+    slug: string;
+    name: string;
+}
+
+interface ImportableRepo {
+    id: number | null;
+    full_name: string;
+    description: string | null;
+    language: string | null;
+    private: boolean;
+    stars_count: number;
+    forks_count: number;
+    pushed_at: string | null;
+    html_url: string | null;
+    is_already_linked: boolean;
+    linked_to_this_project: boolean;
+}
+
+const props = defineProps<{
+    project: ProjectShape;
+    repositories: ImportableRepo[];
+}>();
+
+const query = ref('');
+const importing = ref<string | null>(null);
+
+const filtered = computed(() => {
+    const q = query.value.trim().toLowerCase();
+    if (q.length === 0) return props.repositories;
+    return props.repositories.filter((repo) =>
+        repo.full_name.toLowerCase().includes(q)
+        || (repo.description ?? '').toLowerCase().includes(q)
+        || (repo.language ?? '').toLowerCase().includes(q),
+    );
+});
+
+const importRepository = (repo: ImportableRepo) => {
+    importing.value = repo.full_name;
+    router.post(
+        route('projects.repositories.import.store', props.project.slug),
+        { full_name: repo.full_name },
+        {
+            onFinish: () => {
+                importing.value = null;
+            },
+        },
+    );
+};
+
+const formatPushed = (iso: string | null): string => {
+    if (!iso) return '';
+    try {
+        const date = new Date(iso);
+        const days = Math.floor(
+            (Date.now() - date.getTime()) / (1000 * 60 * 60 * 24),
+        );
+        if (days < 1) return 'today';
+        if (days === 1) return 'yesterday';
+        if (days < 30) return `${days}d ago`;
+        const months = Math.floor(days / 30);
+        return months === 1 ? '1 mo ago' : `${months} mo ago`;
+    } catch {
+        return '';
+    }
+};
+</script>
+
+<template>
+    <Head title="Import from GitHub" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <Link
+                    :href="route('projects.show', project.slug)"
+                    class="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan transition hover:text-accent-cyan/80"
+                >
+                    <ChevronLeft class="h-3 w-3" aria-hidden="true" />
+                    {{ project.name }}
+                </Link>
+                <h1 class="text-lg font-semibold text-text-primary">
+                    Import from GitHub
+                </h1>
+            </div>
+        </template>
+
+        <div class="space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+            <header
+                class="glass-card flex flex-col gap-3 p-5 sm:flex-row sm:items-center sm:justify-between"
+            >
+                <div class="flex items-center gap-3">
+                    <span
+                        class="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-border-subtle bg-background-panel-hover"
+                    >
+                        <Github
+                            class="h-5 w-5 text-text-primary"
+                            aria-hidden="true"
+                        />
+                    </span>
+                    <div>
+                        <p class="text-sm text-text-secondary">
+                            <span class="font-mono">{{ repositories.length }}</span>
+                            repositories visible to your GitHub account
+                        </p>
+                        <p class="font-mono text-[11px] text-text-muted">
+                            Sorted by recently pushed · already-linked rows
+                            disabled
+                        </p>
+                    </div>
+                </div>
+                <div class="relative w-full sm:w-72">
+                    <Search
+                        class="pointer-events-none absolute start-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted"
+                        aria-hidden="true"
+                    />
+                    <input
+                        v-model="query"
+                        type="search"
+                        placeholder="Filter by name, language…"
+                        aria-label="Filter repositories"
+                        class="w-full rounded-lg border border-border-subtle bg-slate-950/60 ps-9 pe-3 py-2 text-sm text-text-primary placeholder:text-text-muted shadow-inner shadow-black/20 transition focus:border-accent-cyan focus:ring-2 focus:ring-accent-cyan/40"
+                    />
+                </div>
+            </header>
+
+            <!-- List -->
+            <section
+                v-if="filtered.length > 0"
+                aria-label="GitHub repositories"
+                class="glass-card flex flex-col divide-y divide-border-subtle"
+            >
+                <article
+                    v-for="repo in filtered"
+                    :key="repo.id ?? repo.full_name"
+                    class="flex flex-col gap-3 p-5 transition first:rounded-t-2xl last:rounded-b-2xl md:grid md:grid-cols-[minmax(0,3fr)_minmax(0,1fr)_auto_auto] md:items-center md:gap-4"
+                >
+                    <!-- Identity -->
+                    <div class="min-w-0">
+                        <div class="flex items-center gap-2">
+                            <GitBranch
+                                class="h-4 w-4 shrink-0 text-accent-purple"
+                                aria-hidden="true"
+                            />
+                            <p
+                                class="truncate font-mono text-sm text-text-primary"
+                            >
+                                {{ repo.full_name }}
+                            </p>
+                            <Lock
+                                v-if="repo.private"
+                                class="h-3 w-3 shrink-0 text-text-muted"
+                                :title="`Private`"
+                                aria-label="Private repository"
+                            />
+                        </div>
+                        <p
+                            v-if="repo.description"
+                            class="mt-1 line-clamp-1 text-[11px] text-text-muted"
+                        >
+                            {{ repo.description }}
+                        </p>
+                    </div>
+
+                    <!-- Language -->
+                    <div class="text-xs text-text-muted">
+                        {{ repo.language ?? '—' }}
+                    </div>
+
+                    <!-- Stars + pushed -->
+                    <div
+                        class="flex items-center gap-3 text-[11px] text-text-muted"
+                    >
+                        <span
+                            class="inline-flex items-center gap-1 font-mono tabular-nums"
+                        >
+                            <Star class="h-3 w-3" aria-hidden="true" />
+                            {{ repo.stars_count }}
+                        </span>
+                        <span
+                            v-if="repo.pushed_at"
+                            class="font-mono"
+                        >
+                            {{ formatPushed(repo.pushed_at) }}
+                        </span>
+                        <a
+                            v-if="repo.html_url"
+                            :href="repo.html_url"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="text-text-muted transition hover:text-accent-cyan"
+                            :aria-label="`Open ${repo.full_name} on GitHub`"
+                        >
+                            <ExternalLink
+                                class="h-3.5 w-3.5"
+                                aria-hidden="true"
+                            />
+                        </a>
+                    </div>
+
+                    <!-- Action -->
+                    <div class="flex items-center justify-end">
+                        <StatusBadge
+                            v-if="repo.linked_to_this_project"
+                            tone="info"
+                        >
+                            Already in this project
+                        </StatusBadge>
+                        <StatusBadge
+                            v-else-if="repo.is_already_linked"
+                            tone="muted"
+                        >
+                            Linked elsewhere
+                        </StatusBadge>
+                        <button
+                            v-else
+                            type="button"
+                            class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/15 px-3 py-1.5 text-xs font-semibold text-accent-cyan transition hover:border-accent-cyan/60 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                            :disabled="importing !== null"
+                            @click="importRepository(repo)"
+                        >
+                            <Plus class="h-3.5 w-3.5" aria-hidden="true" />
+                            <span v-if="importing === repo.full_name">
+                                Importing…
+                            </span>
+                            <span v-else>Import</span>
+                        </button>
+                    </div>
+                </article>
+            </section>
+
+            <!-- Empty state -->
+            <section
+                v-else-if="repositories.length === 0"
+                aria-label="No repositories"
+                class="glass-card flex flex-col items-center gap-3 p-10 text-center"
+            >
+                <span
+                    class="flex h-12 w-12 items-center justify-center rounded-full border border-border-subtle bg-slate-950/40"
+                >
+                    <Github
+                        class="h-5 w-5 text-text-muted"
+                        aria-hidden="true"
+                    />
+                </span>
+                <h2 class="text-base font-semibold text-text-primary">
+                    No repositories visible
+                </h2>
+                <p class="max-w-sm text-sm text-text-muted">
+                    Your GitHub account doesn't see any repositories with the
+                    granted scopes. Connect a different account or grant
+                    additional access from GitHub.
+                </p>
+            </section>
+
+            <!-- Filter empty state -->
+            <section
+                v-else
+                aria-label="No matches"
+                class="rounded-lg border border-dashed border-border-subtle bg-background-panel-hover/30 p-6 text-center text-sm text-text-muted"
+            >
+                No repositories match
+                <code class="font-mono text-text-secondary">{{ query }}</code>.
+            </section>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Settings/Index.vue
+++ b/resources/js/Pages/Settings/Index.vue
@@ -20,6 +20,10 @@ interface GithubConnectionShape {
     expires_at: string | null;
     is_token_valid: boolean;
     scopes: string[];
+    recent_repositories: {
+        count: number;
+        last_synced_at: string | null;
+    };
 }
 
 const props = defineProps<{
@@ -240,6 +244,25 @@ const disconnect = () => {
                         </dd>
                     </div>
                 </dl>
+
+                <!-- Repository sync indicator (spec 014). Only renders
+                     once at least one repo is linked under the user's
+                     projects — keeps the card honest pre-import. -->
+                <p
+                    v-if="github !== null && github.recent_repositories.count > 0"
+                    class="rounded-lg border border-border-subtle bg-background-panel-hover/40 p-4 text-xs text-text-muted"
+                >
+                    <span class="font-mono text-text-secondary">
+                        {{ github.recent_repositories.count }}
+                    </span>
+                    {{ github.recent_repositories.count === 1 ? 'repository' : 'repositories' }}
+                    linked across your projects.
+                    <span v-if="github.recent_repositories.last_synced_at">
+                        Last sync
+                        <span class="font-mono text-text-secondary">
+                            {{ github.recent_repositories.last_synced_at }}</span>.
+                    </span>
+                </p>
 
                 <!-- Disconnected helper text + roadmap pointer -->
                 <p

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\GithubConnectionController;
+use App\Http\Controllers\GithubRepositoryImportController;
 use App\Http\Controllers\OverviewController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ProjectController;
@@ -37,6 +38,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('integrations.github.callback');
     Route::delete('/integrations/github', [GithubConnectionController::class, 'destroy'])
         ->name('integrations.github.disconnect');
+
+    // Project-scoped GitHub repository import flow (spec 014).
+    Route::get('/projects/{project}/repositories/import', [GithubRepositoryImportController::class, 'index'])
+        ->name('projects.repositories.import.index');
+    Route::post('/projects/{project}/repositories/import', [GithubRepositoryImportController::class, 'store'])
+        ->name('projects.repositories.import.store');
 });
 
 Route::middleware('auth')->group(function () {

--- a/specs/phase-2-github/014-repository-import.md
+++ b/specs/phase-2-github/014-repository-import.md
@@ -1,0 +1,142 @@
+---
+spec: repository-import
+phase: 2-github
+status: in-progress
+owner: yoany
+created: 2026-04-29
+updated: 2026-04-29
+issue: https://github.com/Copxer/nexus/issues/36
+branch: spec/014-repository-import
+---
+
+# 014 — Repository import (list, pick, sync metadata)
+
+## Goal
+Turn the GitHub connection from spec 013 into something useful: a logged-in Nexus user can list the repositories their connected GitHub account can see, pick which to import into a Nexus project, and watch the existing `repositories` table fill with real metadata (description, default branch, language, stars/forks counts, last push, sync status). After this spec, the `Repositories` index, the per-project Repositories tab, the Top Repositories widget, and the Hosts KPI proxy on Overview all start showing live GitHub numbers automatically — that's the payoff of spec 012's Domain query layer.
+
+This spec adds the **import** + **first sync** flows. Per-repo refresh ("Run sync" button) and bulk re-sync ride with spec 015/016 (alongside issues + PRs sync). Webhooks remain phase 3.
+
+Roadmap reference: §8.3 Repositories (`SyncGitHubRepositoryJob` is the canonical filename), §27 (`app/Domain/GitHub/Services/GitHubClient.php`, `app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php`).
+
+## Scope
+**In scope:**
+
+- **`App\Domain\GitHub\Services\GitHubClient`** — a thin authenticated wrapper over GitHub's REST API. Gets a connected `User` (or `GithubConnection`) and exposes:
+    - `listRepositories(int $perPage = 100): array` — calls `GET /user/repos?type=owner,collaborator&sort=pushed&per_page=...&page=...` (multi-page if needed) and returns the parsed list. Used by the import picker.
+    - `fetchRepository(string $fullName): array` — calls `GET /repos/{owner}/{name}` for the metadata sync.
+    - HTTP-client-injectable so tests use `Http::fake()`. All calls send `User-Agent: Nexus-Control-Center` (consistent with the `GitHubOAuthService::defaultHeaders()` helper from spec 013) and `Accept: application/vnd.github+json` + `X-GitHub-Api-Version: 2022-11-28` — pinned now since we lean on specific response shapes.
+    - Throws a typed `GitHubApiException` on transport failures + GitHub error payloads. Token-expired (401) bubbles up so the caller can mark the connection expired in spec 013's UI.
+    - **No retry / backoff yet.** Phase 9 polish layer.
+
+- **`App\Domain\GitHub\Jobs\SyncGitHubRepositoryJob`** — `ShouldQueue` job that takes a `Repository` model id, calls `GitHubClient::fetchRepository($repo->full_name)`, updates the local row in place (description, default_branch, language, visibility, stars_count, forks_count, open_issues_count, last_pushed_at, last_synced_at, sync_status). Sets `sync_status = 'syncing'` while running, `'synced'` on success, `'failed'` on caught exception. Idempotent (replays land the same row in the same final state).
+
+- **`App\Domain\GitHub\Actions\ImportRepositoryAction`** — given a Nexus user, a target Project, and a GitHub `full_name`, creates the local `Repository` row in `pending` state and dispatches `SyncGitHubRepositoryJob`. The action is idempotent — re-importing an already-linked repo refreshes its metadata via a fresh sync without duplicating the row. Reuses spec 011's existing `LinkRepositoryToProjectAction` parser for `full_name` validation.
+
+- **`App\Http\Controllers\GithubRepositoryImportController`** — two actions:
+    - `index(Project $project)` — calls `GitHubClient::listRepositories()` for the current user's connection, returns the list as an Inertia response so the picker can render. The page is project-scoped (`/projects/{slug}/repositories/import`) so the import flow always has a target project.
+    - `store(Project $project, Request $request)` — accepts a `full_name` (validated via the same regex from spec 011), calls `ImportRepositoryAction`, redirects to the project's Repositories tab with a flash.
+    - Policy-gated via `ProjectPolicy::update` — only the project owner can import repos into their project.
+
+- **Routes.** `routes/web.php` adds:
+    ```php
+    Route::middleware(['auth', 'verified'])->group(function () {
+        Route::get('/projects/{project}/repositories/import', [GithubRepositoryImportController::class, 'index'])
+            ->name('projects.repositories.import.index');
+        Route::post('/projects/{project}/repositories/import', [GithubRepositoryImportController::class, 'store'])
+            ->name('projects.repositories.import.store');
+    });
+    ```
+
+- **`Pages/Repositories/Import.vue`** — the picker. Pre-loaded list of repos (from the controller), plus a search input that filters client-side. Each row: avatar/icon + `owner/name` + description (truncated) + language + stars + last-push relative time + an "Import" button. Already-imported repos show as "Already linked" (disabled). Bulk-import is out of scope; one click per row.
+
+- **Update Project Show — Repositories tab.** Add a small "Import from GitHub" CTA next to the existing manual link form, only visible when the user has a GitHub connection. The button links to `/projects/{slug}/repositories/import`. The manual link form from spec 011 stays as the fallback for users without a connection.
+
+- **Settings page sync indicator.** When a sync is in flight or failed, the Integrations card surfaces a small "Last sync N min ago" + retry CTA on the GitHub row. The status text reads from a new computed prop (`recent_repositories: { count, last_synced_at }`) so the Settings controller can show high-level health without dragging in the full repo list.
+
+- **`SyncGitHubRepositoryJob` queue dispatch.** Default queue. We rely on Horizon (spec 009 wired it). The action dispatches synchronously in tests via `Bus::fake()` + `Queue::assertPushed()` — no real worker needed in CI.
+
+- **Tests** (PHP feature tests):
+    - `GitHubClientTest` — `listRepositories` paginates correctly via `Http::fake()`; `fetchRepository` returns the parsed repo; 401 surfaces a typed exception.
+    - `SyncGitHubRepositoryJobTest` — happy path updates the Repository row; failure flips `sync_status` to `failed` and re-throws; running on a row with `sync_status = pending` flips through `syncing → synced`.
+    - `ImportRepositoryActionTest` — first-time import creates row + dispatches the job; idempotent on re-import (same row, fresh job).
+    - `GithubRepositoryImportControllerTest` — index renders with the picker payload; store dispatches the job; non-owner is 403.
+
+- **Update phase trackers** as part of the same PR (and the post-merge bookkeeping flips 014 to 🟢, matches the established workflow).
+
+**Out of scope:**
+
+- Issues sync (spec 015) and PRs sync + Work Items page (spec 016).
+- Webhook ingestion + near-real-time updates (phase 3).
+- Bulk import (multi-select + batch dispatch). Add later if the one-at-a-time flow feels slow.
+- Per-repo "Run sync" button on the Repository show page. That ships with spec 015 once the sync surface area grows.
+- Token-refresh handling. Spec 013 explicitly defers it; if the GitHub call returns 401, we mark the connection expired and surface a Reconnect CTA. The job records `failed` so the user can re-import after re-authenticating.
+- Sync status broadcasting via Reverb. Phase 9.
+- A `GitHubAvatar` component. The picker uses GitHub's `avatar_url` directly via `<img>`; if the image fails it falls back to the existing `GitBranch` lucide icon.
+- Rate-limit handling beyond surfacing the GitHub error message. Real backoff + retry comes with phase 9.
+
+## Plan
+
+1. **`GitHubClient` service.** Constructor takes a `GithubConnection` (so tests can pass a fake one). Reads the (decrypted) token from the model and uses Laravel's `Http::withToken()`. Pin Accept + version headers. Multi-page `listRepositories` via Link-header-driven pagination or a fixed `?per_page=100` cap if a single page suffices for MVP (we'll cap at 100 for now — if a user has 100+ repos they probably want a search).
+2. **`GitHubApiException`.** Typed exception with helpers (`isUnauthorized()`, `wasRateLimited()`) used by callers to map error → UI state.
+3. **`SyncGitHubRepositoryJob`.** `ShouldQueue` + `Queueable`. `handle(GitHubClient $client)` updates the local row.
+4. **`ImportRepositoryAction`.** `execute(User $user, Project $project, string $fullName): Repository`. Reuses spec 011's parser, calls `LinkRepositoryToProjectAction::execute($project, $fullName)`, then dispatches the sync job.
+5. **`GithubRepositoryImportController` + routes.** Index loads the connection-scoped repo list; store validates + dispatches.
+6. **`Pages/Repositories/Import.vue`.** Loads the list, client-side filter, per-row Import button, redirect-on-success.
+7. **`Pages/Projects/Show.vue` Repositories tab tweak.** Add the "Import from GitHub" CTA; show only when `auth().user.has_github_connection` (a new prop on the page).
+8. **Settings card extension.** Add `last_synced_at` + `recently_imported_count` to the Integrations card metadata strip. Tiny visual touch.
+9. **Tests.** Service, job, action, controller — all `Http::fake()` + `Bus::fake()`.
+10. **Manual UX walk** — stub a connection in tinker, mock GitHub's `/user/repos` response via a localdebug script (or just stub the controller's `listRepositories` for the manual walk), exercise the picker, click Import on one row, watch the Repositories tab update.
+11. **Pipeline** — Pint, vue-tsc, build, full PHP test run.
+12. **Self-review** with `superpowers:code-reviewer`.
+
+## Acceptance criteria
+- [ ] `GitHubClient::listRepositories()` returns parsed GitHub repo objects via authenticated GET (mocked via `Http::fake()` in tests).
+- [ ] `GitHubClient::fetchRepository($fullName)` returns one repo's metadata. 401 throws `GitHubApiException::isUnauthorized() === true`.
+- [ ] `SyncGitHubRepositoryJob`: handles a Repository id; updates `description, default_branch, language, visibility, stars_count, forks_count, open_issues_count, last_pushed_at, last_synced_at, sync_status` on success; marks `failed` on caught exception.
+- [ ] `ImportRepositoryAction` creates the local row (or refreshes an existing one) and dispatches the sync job. Idempotent.
+- [ ] `GithubRepositoryImportController`: index renders `Pages/Repositories/Import.vue` with the user's GitHub repo list; store validates + dispatches; non-owner is 403.
+- [ ] `Pages/Repositories/Import.vue` shows a searchable list with per-row Import buttons; already-imported repos are disabled with "Already linked".
+- [ ] `Pages/Projects/Show.vue` Repositories tab shows an "Import from GitHub" CTA when the user has a connection (alongside the existing manual link form).
+- [ ] After importing, the `repositories` row's `sync_status` cycles `pending → syncing → synced` (or `failed`) via the job.
+- [ ] Overview Top Repositories widget reflects newly-synced star counts without code changes (spec 012's wiring already reads from the `repositories` table).
+- [ ] No real GitHub credentials in CI; `Http::fake()` + `Bus::fake()` only.
+- [ ] No `gray-*` / `red-*` / `green-*` / `indigo-*` Tailwind classes.
+- [ ] Pint + vue-tsc + build clean. CI green.
+- [ ] Self-review pass with `superpowers:code-reviewer`.
+
+## Files touched
+- `app/Domain/GitHub/Services/GitHubClient.php` — new.
+- `app/Domain/GitHub/Exceptions/GitHubApiException.php` — new.
+- `app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php` — new.
+- `app/Domain/GitHub/Actions/ImportRepositoryAction.php` — new.
+- `app/Http/Controllers/GithubRepositoryImportController.php` — new.
+- `routes/web.php` — add `projects.repositories.import.{index,store}` routes.
+- `resources/js/Pages/Repositories/Import.vue` — new.
+- `resources/js/Pages/Projects/Show.vue` — add "Import from GitHub" CTA in the Repositories tab.
+- `resources/js/Pages/Settings/Index.vue` — show `last_synced_at` + `recently_imported_count` on the Integrations card (when connected).
+- `app/Http/Controllers/SettingsController.php` — extend the serialized GitHub shape.
+- `tests/Feature/GitHub/GitHubClientTest.php` — new.
+- `tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php` — new.
+- `tests/Feature/GitHub/ImportRepositoryActionTest.php` — new.
+- `tests/Feature/GitHub/GithubRepositoryImportControllerTest.php` — new.
+
+## Work log
+Dated notes as work progresses.
+
+### 2026-04-29
+- Spec drafted; scope confirmed (7 decisions locked: GitHubClient takes GithubConnection, single-page pagination cap, per-row Import, full sync-status lifecycle, Queue::fake + direct handler test, single typed exception, on-401 clear token + flag expired).
+- Opened issue [#36](https://github.com/Copxer/nexus/issues/36) and branch `spec/014-repository-import` off `main`.
+
+## Decisions (locked 2026-04-29)
+- **GitHubClient takes a `GithubConnection`.** Explicit, easy to mock, fail-fast.
+- **Single-page `?per_page=100`.** 100 repos is plenty for MVP. Multi-page follow-up if it earns its keep.
+- **Per-row Import buttons.** No bulk select. Batch import becomes a phase-9 polish.
+- **Full sync-status lifecycle:** `pending → syncing → synced/failed`. Free progress signal.
+- **`Queue::fake()` for dispatch assertions** + one direct `handle()` test for the job's sync logic.
+- **Single `GitHubApiException`** with status helpers. Subclass only if caller code starts switching on type.
+- **On 401, clear `access_token` + flag connection expired.** Explicit Reconnect path; no silent failures on subsequent API calls.
+
+## Open questions / blockers
+
+- **`/user/repos` includes private repos when scope `repo` is granted.** Spec 013's default scopes are `read:user` + `repo`. Confirm at manual-walk time that the picker shows both public + private repos correctly.
+- **PHP 8.5 + Laravel 13.6 CSRF-in-tests issue** still present locally. Same disclaimer.

--- a/specs/phase-2-github/014-repository-import.md
+++ b/specs/phase-2-github/014-repository-import.md
@@ -126,6 +126,8 @@ Dated notes as work progresses.
 ### 2026-04-29
 - Spec drafted; scope confirmed (7 decisions locked: GitHubClient takes GithubConnection, single-page pagination cap, per-row Import, full sync-status lifecycle, Queue::fake + direct handler test, single typed exception, on-401 clear token + flag expired).
 - Opened issue [#36](https://github.com/Copxer/nexus/issues/36) and branch `spec/014-repository-import` off `main`.
+- Implementation complete: `GitHubApiException`, `GitHubClient`, `SyncGitHubRepositoryJob`, `ImportRepositoryAction`, `GithubRepositoryImportController` + routes, `Pages/Repositories/Import.vue`, Project Show CTA, Settings indicator. 4 feature test files, 88 tests + 395 assertions green. Pint/vue-tsc/build clean.
+- Manual UX walk via Playwright: Project Show Repositories tab renders the new "Import from GitHub" CTA next to the manual link form; Settings card surfaces "9 repositories linked across your projects. Last sync 13 minutes ago." with the seeded fake connection.
 
 ## Decisions (locked 2026-04-29)
 - **GitHubClient takes a `GithubConnection`.** Explicit, easy to mock, fail-fast.

--- a/tests/Feature/GitHub/GitHubClientTest.php
+++ b/tests/Feature/GitHub/GitHubClientTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Domain\GitHub\Exceptions\GitHubApiException;
+use App\Domain\GitHub\Services\GitHubClient;
+use App\Models\GithubConnection;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class GitHubClientTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function client(): GitHubClient
+    {
+        $user = User::factory()->create();
+        $connection = GithubConnection::query()->create([
+            'user_id' => $user->id,
+            'github_user_id' => '9001',
+            'github_username' => 'octocat',
+            'access_token' => 'gho_token',
+            'connected_at' => now(),
+        ]);
+
+        return new GitHubClient($connection);
+    }
+
+    public function test_list_repositories_returns_parsed_payload(): void
+    {
+        Http::fake([
+            'api.github.com/user/repos*' => Http::response([
+                ['id' => 1, 'full_name' => 'octocat/hello-world'],
+                ['id' => 2, 'full_name' => 'octocat/spoon-knife'],
+            ]),
+        ]);
+
+        $repos = $this->client()->listRepositories();
+
+        $this->assertCount(2, $repos);
+        $this->assertSame('octocat/hello-world', $repos[0]['full_name']);
+    }
+
+    public function test_list_repositories_throws_unauthorized_on_401(): void
+    {
+        Http::fake([
+            'api.github.com/user/repos*' => Http::response(
+                ['message' => 'Bad credentials'],
+                401,
+            ),
+        ]);
+
+        try {
+            $this->client()->listRepositories();
+            $this->fail('Expected GitHubApiException.');
+        } catch (GitHubApiException $e) {
+            $this->assertTrue($e->isUnauthorized());
+            $this->assertSame(401, $e->statusCode);
+        }
+    }
+
+    public function test_list_repositories_detects_rate_limit(): void
+    {
+        Http::fake([
+            'api.github.com/user/repos*' => Http::response(
+                ['message' => 'API rate limit exceeded for user.'],
+                403,
+            ),
+        ]);
+
+        try {
+            $this->client()->listRepositories();
+            $this->fail('Expected GitHubApiException.');
+        } catch (GitHubApiException $e) {
+            $this->assertTrue($e->wasRateLimited());
+            $this->assertSame(403, $e->statusCode);
+        }
+    }
+
+    public function test_fetch_repository_returns_repo_metadata(): void
+    {
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world' => Http::response([
+                'id' => 1,
+                'full_name' => 'octocat/hello-world',
+                'description' => 'My first GitHub repo',
+                'default_branch' => 'main',
+                'language' => 'Ruby',
+                'stargazers_count' => 1234,
+                'forks_count' => 56,
+                'open_issues_count' => 7,
+                'pushed_at' => '2024-12-01T00:00:00Z',
+            ]),
+        ]);
+
+        $repo = $this->client()->fetchRepository('octocat/hello-world');
+
+        $this->assertSame('octocat/hello-world', $repo['full_name']);
+        $this->assertSame(1234, $repo['stargazers_count']);
+    }
+
+    public function test_fetch_repository_throws_on_404(): void
+    {
+        Http::fake([
+            'api.github.com/repos/octocat/missing' => Http::response(
+                ['message' => 'Not Found'],
+                404,
+            ),
+        ]);
+
+        $this->expectException(GitHubApiException::class);
+        $this->client()->fetchRepository('octocat/missing');
+    }
+
+    public function test_request_pins_api_version_and_user_agent_headers(): void
+    {
+        Http::fake([
+            'api.github.com/user/repos*' => Http::response([]),
+        ]);
+
+        $this->client()->listRepositories();
+
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('X-GitHub-Api-Version', '2022-11-28')
+                && $request->hasHeader('Accept', 'application/vnd.github+json')
+                && $request->hasHeader('User-Agent', 'Nexus-Control-Center');
+        });
+    }
+}

--- a/tests/Feature/GitHub/GithubRepositoryImportControllerTest.php
+++ b/tests/Feature/GitHub/GithubRepositoryImportControllerTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Domain\GitHub\Jobs\SyncGitHubRepositoryJob;
+use App\Models\GithubConnection;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class GithubRepositoryImportControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function ownerWithConnection(): array
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        GithubConnection::query()->create([
+            'user_id' => $user->id,
+            'github_user_id' => '9001',
+            'github_username' => 'octocat',
+            'access_token' => 'gho_token',
+            'expires_at' => now()->addHours(8),
+            'connected_at' => now(),
+        ]);
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        return ['user' => $user, 'project' => $project];
+    }
+
+    public function test_index_renders_the_picker_with_github_repos(): void
+    {
+        $context = $this->ownerWithConnection();
+
+        Http::fake([
+            'api.github.com/user/repos*' => Http::response([
+                [
+                    'id' => 1,
+                    'full_name' => 'octocat/hello-world',
+                    'description' => 'Test repo',
+                    'language' => 'Ruby',
+                    'private' => false,
+                    'stargazers_count' => 100,
+                    'forks_count' => 10,
+                    'pushed_at' => '2026-04-29T00:00:00Z',
+                    'html_url' => 'https://github.com/octocat/hello-world',
+                ],
+                [
+                    'id' => 2,
+                    'full_name' => 'octocat/spoon-knife',
+                    'description' => 'Another test repo',
+                    'language' => 'JavaScript',
+                    'private' => true,
+                    'stargazers_count' => 50,
+                    'forks_count' => 5,
+                    'pushed_at' => '2026-04-28T00:00:00Z',
+                    'html_url' => 'https://github.com/octocat/spoon-knife',
+                ],
+            ]),
+        ]);
+
+        $this->actingAs($context['user'])
+            ->get(route('projects.repositories.import.index', $context['project']))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Repositories/Import')
+                    ->where('project.slug', $context['project']->slug)
+                    ->has('repositories', 2)
+                    ->where('repositories.0.full_name', 'octocat/hello-world')
+                    ->where('repositories.1.private', true)
+            );
+    }
+
+    public function test_index_marks_already_linked_repos(): void
+    {
+        $context = $this->ownerWithConnection();
+        Repository::factory()->create([
+            'project_id' => $context['project']->id,
+            'full_name' => 'octocat/hello-world',
+        ]);
+
+        Http::fake([
+            'api.github.com/user/repos*' => Http::response([
+                [
+                    'id' => 1,
+                    'full_name' => 'octocat/hello-world',
+                    'description' => 'Test repo',
+                    'private' => false,
+                    'stargazers_count' => 100,
+                    'forks_count' => 10,
+                    'pushed_at' => '2026-04-29T00:00:00Z',
+                    'html_url' => 'https://github.com/octocat/hello-world',
+                ],
+            ]),
+        ]);
+
+        $this->actingAs($context['user'])
+            ->get(route('projects.repositories.import.index', $context['project']))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->where('repositories.0.is_already_linked', true)
+                    ->where('repositories.0.linked_to_this_project', true)
+            );
+    }
+
+    public function test_index_redirects_to_settings_when_user_has_no_connection(): void
+    {
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+
+        $this->actingAs($owner)
+            ->get(route('projects.repositories.import.index', $project))
+            ->assertRedirect(route('settings.index'))
+            ->assertSessionHas('error');
+    }
+
+    public function test_index_is_403_for_non_owner(): void
+    {
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+        $other = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+
+        $this->actingAs($other)
+            ->get(route('projects.repositories.import.index', $project))
+            ->assertForbidden();
+    }
+
+    public function test_store_dispatches_the_sync_job_for_owner(): void
+    {
+        Queue::fake();
+        $context = $this->ownerWithConnection();
+
+        $response = $this->actingAs($context['user'])->post(
+            route('projects.repositories.import.store', $context['project']),
+            ['full_name' => 'octocat/hello-world'],
+        );
+
+        $response->assertRedirect(route('projects.show', $context['project']));
+        $this->assertDatabaseHas('repositories', [
+            'full_name' => 'octocat/hello-world',
+            'project_id' => $context['project']->id,
+        ]);
+        Queue::assertPushed(SyncGitHubRepositoryJob::class);
+    }
+
+    public function test_store_rejects_garbage_full_name(): void
+    {
+        $context = $this->ownerWithConnection();
+
+        $this->actingAs($context['user'])
+            ->from(route('projects.show', $context['project']))
+            ->post(
+                route('projects.repositories.import.store', $context['project']),
+                ['full_name' => 'not a repo at all'],
+            )
+            ->assertSessionHasErrors('full_name');
+    }
+
+    public function test_store_is_403_for_non_owner(): void
+    {
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+        $other = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+
+        $this->actingAs($other)
+            ->post(
+                route('projects.repositories.import.store', $project),
+                ['full_name' => 'octocat/hello-world'],
+            )
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/GitHub/GithubRepositoryImportControllerTest.php
+++ b/tests/Feature/GitHub/GithubRepositoryImportControllerTest.php
@@ -150,6 +150,27 @@ class GithubRepositoryImportControllerTest extends TestCase
         Queue::assertPushed(SyncGitHubRepositoryJob::class);
     }
 
+    public function test_store_rejects_repo_already_linked_to_another_project(): void
+    {
+        $context = $this->ownerWithConnection();
+        $otherProject = Project::factory()->create([
+            'owner_user_id' => $context['user']->id,
+        ]);
+        Repository::factory()->create([
+            'project_id' => $otherProject->id,
+            'full_name' => 'octocat/hello-world',
+        ]);
+
+        $this->actingAs($context['user'])
+            ->from(route('projects.show', $context['project']))
+            ->post(
+                route('projects.repositories.import.store', $context['project']),
+                ['full_name' => 'octocat/hello-world'],
+            )
+            ->assertRedirect(route('projects.show', $context['project']))
+            ->assertSessionHasErrors('full_name');
+    }
+
     public function test_store_rejects_garbage_full_name(): void
     {
         $context = $this->ownerWithConnection();

--- a/tests/Feature/GitHub/ImportRepositoryActionTest.php
+++ b/tests/Feature/GitHub/ImportRepositoryActionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Domain\GitHub\Actions\ImportRepositoryAction;
+use App\Domain\GitHub\Jobs\SyncGitHubRepositoryJob;
+use App\Enums\RepositorySyncStatus;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class ImportRepositoryActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creates_a_pending_repository_and_dispatches_the_sync_job(): void
+    {
+        Queue::fake();
+
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+
+        $repo = app(ImportRepositoryAction::class)->execute($project, 'octocat/hello-world');
+
+        $this->assertSame('octocat/hello-world', $repo->full_name);
+        $this->assertSame($project->id, $repo->project_id);
+        $this->assertSame(RepositorySyncStatus::Pending, $repo->sync_status);
+
+        Queue::assertPushed(
+            SyncGitHubRepositoryJob::class,
+            fn ($job) => $job->repositoryId === $repo->id,
+        );
+    }
+
+    public function test_is_idempotent_on_re_import(): void
+    {
+        Queue::fake();
+
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+
+        $first = app(ImportRepositoryAction::class)->execute($project, 'octocat/hello-world');
+        $second = app(ImportRepositoryAction::class)->execute($project, 'octocat/hello-world');
+
+        $this->assertSame($first->id, $second->id);
+        $this->assertSame(
+            1,
+            Repository::query()
+                ->where('full_name', 'octocat/hello-world')
+                ->count(),
+        );
+
+        // Both calls dispatched a sync — second one's a manual refresh path.
+        Queue::assertPushed(SyncGitHubRepositoryJob::class, 2);
+    }
+
+    public function test_accepts_full_github_url_via_the_underlying_parser(): void
+    {
+        Queue::fake();
+
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+
+        $repo = app(ImportRepositoryAction::class)->execute(
+            $project,
+            'https://github.com/nexus-org/nexus-api',
+        );
+
+        $this->assertSame('nexus-org/nexus-api', $repo->full_name);
+        Queue::assertPushed(SyncGitHubRepositoryJob::class);
+    }
+}

--- a/tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php
+++ b/tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Domain\GitHub\Jobs\SyncGitHubRepositoryJob;
+use App\Enums\RepositorySyncStatus;
+use App\Models\GithubConnection;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SyncGitHubRepositoryJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setUpProjectWithConnection(): array
+    {
+        $user = User::factory()->create();
+        GithubConnection::query()->create([
+            'user_id' => $user->id,
+            'github_user_id' => '9001',
+            'github_username' => 'octocat',
+            'access_token' => 'gho_token',
+            'expires_at' => now()->addHours(8),
+            'connected_at' => now(),
+        ]);
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+            'sync_status' => RepositorySyncStatus::Pending->value,
+        ]);
+
+        return ['user' => $user, 'repository' => $repository];
+    }
+
+    public function test_handle_updates_the_repository_metadata_on_happy_path(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world' => Http::response([
+                'id' => 1234,
+                'description' => 'Hello world from GitHub.',
+                'default_branch' => 'develop',
+                'visibility' => 'public',
+                'language' => 'TypeScript',
+                'stargazers_count' => 482,
+                'forks_count' => 18,
+                'open_issues_count' => 5,
+                'pushed_at' => '2026-04-29T00:00:00Z',
+                'html_url' => 'https://github.com/octocat/hello-world',
+            ]),
+        ]);
+
+        (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Synced, $repo->sync_status);
+        $this->assertSame('TypeScript', $repo->language);
+        $this->assertSame(482, $repo->stars_count);
+        $this->assertSame('develop', $repo->default_branch);
+        $this->assertNotNull($repo->last_synced_at);
+        $this->assertNotNull($repo->last_pushed_at);
+    }
+
+    public function test_handle_marks_failed_and_expires_connection_on_401(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world' => Http::response(
+                ['message' => 'Bad credentials'],
+                401,
+            ),
+        ]);
+
+        (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->sync_status);
+
+        $connection = $context['user']->fresh()->githubConnection;
+        $this->assertSame('', $connection->access_token);
+        $this->assertFalse($connection->isAccessTokenValid());
+    }
+
+    public function test_handle_marks_failed_on_generic_error(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world' => Http::response(
+                ['message' => 'Server error'],
+                500,
+            ),
+        ]);
+
+        (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->sync_status);
+
+        // 500 is not unauthorized — connection should NOT be expired.
+        $connection = $context['user']->fresh()->githubConnection;
+        $this->assertNotSame('', $connection->access_token);
+        $this->assertTrue($connection->isAccessTokenValid());
+    }
+
+    public function test_handle_marks_failed_when_owner_has_no_connection(): void
+    {
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'sync_status' => RepositorySyncStatus::Pending->value,
+        ]);
+
+        (new SyncGitHubRepositoryJob($repository->id))->handle();
+
+        $this->assertSame(RepositorySyncStatus::Failed, $repository->fresh()->sync_status);
+    }
+
+    public function test_handle_is_a_no_op_when_repository_is_missing(): void
+    {
+        // No exception, no DB writes — the job just returns early.
+        (new SyncGitHubRepositoryJob(999_999))->handle();
+
+        $this->assertSame(0, Repository::query()->count());
+    }
+}

--- a/tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php
+++ b/tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php
@@ -110,6 +110,33 @@ class SyncGitHubRepositoryJobTest extends TestCase
         $this->assertTrue($connection->isAccessTokenValid());
     }
 
+    public function test_handle_preserves_last_synced_at_on_failure(): void
+    {
+        // `last_synced_at` is the contract Settings surfaces as
+        // "Last sync N min ago" — a failed run must NOT bump it,
+        // otherwise a repo that's never synced successfully would
+        // misleadingly read as recently synced.
+        $context = $this->setUpProjectWithConnection();
+        $priorSync = now()->subHours(3);
+        $context['repository']->forceFill(['last_synced_at' => $priorSync])->save();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world' => Http::response(
+                ['message' => 'Server error'],
+                500,
+            ),
+        ]);
+
+        (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->sync_status);
+        $this->assertEquals(
+            $priorSync->toIso8601String(),
+            $repo->last_synced_at->toIso8601String(),
+        );
+    }
+
     public function test_handle_marks_failed_when_owner_has_no_connection(): void
     {
         $owner = User::factory()->create();


### PR DESCRIPTION
Closes #36

Spec: `specs/phase-2-github/014-repository-import.md`

## Summary

- Turns spec 013's connected GitHub identity into something useful: list the repos a connected GitHub account can see, pick one to import into a Nexus project, dispatch a sync job that fills the existing `repositories` row with real metadata.
- New domain layer under `app/Domain/GitHub/`: typed `GitHubApiException` with `isUnauthorized()` / `wasRateLimited()` helpers, `GitHubClient` REST wrapper (pinned `Accept` + API-version + `User-Agent` headers, `?per_page=100` cap), `SyncGitHubRepositoryJob` (`pending → syncing → synced/failed` lifecycle; on 401 also clears `access_token` + sets `expires_at = now()` so spec 013's Settings card flips into the Reconnect branch), and an idempotent `ImportRepositoryAction` that wraps spec 011's `LinkRepositoryToProjectAction`.
- New `GithubRepositoryImportController` (`/projects/{project}/repositories/import`, GET + POST). Index annotates each row with `is_already_linked` / `linked_to_this_project`; store validates `full_name` and runs the action. Both gated by `ProjectPolicy::update`. Index redirects to `/settings` when the user has no connection; redirects back with a flash on `GitHubApiException`. Store catches `UniqueConstraintViolationException` for the cross-project race (same friendly error spec 011 surfaces).
- `Pages/Repositories/Import.vue` — searchable picker with a per-row Import button; already-linked rows show a status badge instead. Project Show Repositories tab gains an "Import from GitHub" CTA when the user has a connection. Settings card gains a `recent_repositories` indicator block ("N repositories linked across your projects. Last sync …") once at least one repo is linked.
- Manual UX walk via Playwright: Project Show Repositories tab and Settings indicator render exactly as designed against a stubbed connection + 9 seeded repositories.

## Test plan

- [x] `GitHubClient::listRepositories()` returns parsed GitHub repo objects via authenticated GET (mocked via `Http::fake()` in tests).
- [x] `GitHubClient::fetchRepository($fullName)` returns one repo's metadata. 401 throws `GitHubApiException::isUnauthorized() === true`.
- [x] `SyncGitHubRepositoryJob`: handles a Repository id; updates `description, default_branch, language, visibility, stars_count, forks_count, open_issues_count, last_pushed_at, last_synced_at, sync_status` on success; marks `failed` on caught exception; **`last_synced_at` is preserved across a failure** (regression test added during self-review).
- [x] `ImportRepositoryAction` creates the local row (or refreshes an existing one) and dispatches the sync job. Idempotent.
- [x] `GithubRepositoryImportController`: index renders `Pages/Repositories/Import.vue` with the user's GitHub repo list; store validates + dispatches; non-owner is 403; **cross-project conflict surfaces a friendly error** (regression test added during self-review).
- [x] `Pages/Repositories/Import.vue` shows a searchable list with per-row Import buttons; already-imported repos render a status badge instead.
- [x] `Pages/Projects/Show.vue` Repositories tab shows an "Import from GitHub" CTA when the user has a connection (alongside the existing manual link form).
- [x] After importing, the `repositories` row's `sync_status` cycles `pending → syncing → synced` (or `failed`) via the job (verified via `SyncGitHubRepositoryJobTest`).
- [x] Overview Top Repositories widget reflects newly-synced star counts without code changes (spec 012's wiring already reads from the `repositories` table).
- [x] No real GitHub credentials in CI; `Http::fake()` + `Queue::fake()` only.
- [x] No `gray-*` / `red-*` / `green-*` / `indigo-*` Tailwind classes.
- [x] Pint + vue-tsc + build clean. 115 tests, 462 assertions green locally.
- [x] Self-review pass with `superpowers:code-reviewer`.

## Self-review notes

Ran `superpowers:code-reviewer` on the diff. Material findings addressed in the follow-up commit:

- **`last_synced_at` was being stamped on failure too** (`SyncGitHubRepositoryJob::markFailed`). The Settings card surfaces it as "Last sync N min ago" — a repo whose only history is failed runs would have misleadingly read as recently synced. Fix: only set on success. Added a regression test that pre-sets `last_synced_at`, fails a sync, and asserts the timestamp survives.
- **Cross-project unique violation wasn't caught in `store()`.** The picker hides already-linked-elsewhere rows but `repositories.full_name` is globally unique, so a forged POST or a fast cross-tab click could 500. Fix: catch `UniqueConstraintViolationException` and return the same friendly `back()->withErrors()` spec 011's manual-link controller already uses. Added a regression test.

Reviewer also flagged some non-material items deferred to future specs:

- `tries = 1` is intentional per the locked spec decision; a flaky GitHub 502 will permanently mark the row failed. Acceptable for MVP — retries land with the spec 015/016 sync-surface expansion.
- `applyPayload` defaults `stars_count`/`forks_count`/`open_issues_count` to `0` rather than the existing column when the payload omits them. GitHub's `/repos/{full_name}` always returns these fields, so practically a no-op; flagged for resilience polish if the schema ever drifts.
- `GitHubClient::request()` could memoize the `PendingRequest` per instance; trivial micro-opt.

Token-leak surface verified clean: `GitHubApiException` only echoes `message`/`error_description`/`error` body fields, never headers; `SettingsController::serializeConnection` shapes Inertia props explicitly, no raw `access_token` ever crosses the boundary.