### PR TITLE
chore(specs): mark spec 014 done; Phase 2 at 2/4 🟡

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -37,7 +37,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 |---|-------|--------|-------|
 | 0 | Foundation (auth, layout, static overview) | 🟢 | 9/9 specs done (001–009). Phase complete. |
 | 1 | Projects & Repositories | 🟢 | 3/3 specs done (010–012). Phase complete. |
-| 2 | GitHub Integration MVP | 🟡 | 1/4 specs done (013). Next: 014 Repository import. |
+| 2 | GitHub Integration MVP | 🟡 | 2/4 specs done (013, 014). Next: 015 Issues sync. |
 | 3 | GitHub Webhooks & Activity Feed | ⬜ | — |
 | 4 | Deployments & CI/CD | ⬜ | — |
 | 5 | Website Monitoring | ⬜ | — |

--- a/specs/phase-2-github/014-repository-import.md
+++ b/specs/phase-2-github/014-repository-import.md
@@ -1,11 +1,12 @@
 ---
 spec: repository-import
 phase: 2-github
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-29
 updated: 2026-04-29
 issue: https://github.com/Copxer/nexus/issues/36
+pr: https://github.com/Copxer/nexus/pull/37
 branch: spec/014-repository-import
 ---
 

--- a/specs/phase-2-github/README.md
+++ b/specs/phase-2-github/README.md
@@ -12,7 +12,7 @@ This phase is **read-only against GitHub**. Webhooks and near-real-time updates 
 | # | Task | Status |
 |---|------|--------|
 | 013 | GitHub App connection (OAuth flow, encrypted token storage, Settings/Integrations panel) | 🟢 |
-| 014 | Repository import (list available repos, user picks which to import, `SyncGitHubRepositoryJob` populates metadata) | ⬜ |
+| 014 | Repository import (list available repos, user picks which to import, `SyncGitHubRepositoryJob` populates metadata) | 🟢 |
 | 015 | Issues sync (database + sync job + `/work-items` issues filter) | ⬜ |
 | 016 | Pull requests sync + unified Work Items page (both filters + "Run sync" buttons) | ⬜ |
 


### PR DESCRIPTION
Bookkeeping after #37 merged.

- Flip `specs/phase-2-github/014-repository-import.md` frontmatter to `status: done` and add the PR link.
- Bump root `specs/README.md` Phase 2 row from "1/4 specs done (013)" → "2/4 specs done (013, 014). Next: 015 Issues sync."
- Bump `specs/phase-2-github/README.md` task table row 014 to 🟢.

No code, just docs.