### PR TITLE
chore(specs): mark spec 015 done; Phase 2 at 3/4 🟡

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -37,7 +37,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 |---|-------|--------|-------|
 | 0 | Foundation (auth, layout, static overview) | 🟢 | 9/9 specs done (001–009). Phase complete. |
 | 1 | Projects & Repositories | 🟢 | 3/3 specs done (010–012). Phase complete. |
-| 2 | GitHub Integration MVP | 🟡 | 2/4 specs done (013, 014). Next: 015 Issues sync. |
+| 2 | GitHub Integration MVP | 🟡 | 3/4 specs done (013, 014, 015). Next: 016 Pull requests + Work Items page. |
 | 3 | GitHub Webhooks & Activity Feed | ⬜ | — |
 | 4 | Deployments & CI/CD | ⬜ | — |
 | 5 | Website Monitoring | ⬜ | — |

--- a/specs/phase-2-github/015-issues-sync.md
+++ b/specs/phase-2-github/015-issues-sync.md
@@ -1,11 +1,12 @@
 ---
 spec: issues-sync
 phase: 2-github
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-29
 updated: 2026-04-29
 issue: https://github.com/Copxer/nexus/issues/39
+pr: https://github.com/Copxer/nexus/pull/40
 branch: spec/015-issues-sync
 ---
 

--- a/specs/phase-2-github/README.md
+++ b/specs/phase-2-github/README.md
@@ -13,7 +13,7 @@ This phase is **read-only against GitHub**. Webhooks and near-real-time updates 
 |---|------|--------|
 | 013 | GitHub App connection (OAuth flow, encrypted token storage, Settings/Integrations panel) | 🟢 |
 | 014 | Repository import (list available repos, user picks which to import, `SyncGitHubRepositoryJob` populates metadata) | 🟢 |
-| 015 | Issues sync (database + sync job + `/work-items` issues filter) | ⬜ |
+| 015 | Issues sync (database + sync job + Repository Issues tab) | 🟢 |
 | 016 | Pull requests sync + unified Work Items page (both filters + "Run sync" buttons) | ⬜ |
 
 ## Acceptance criteria (phase-level)


### PR DESCRIPTION
Bookkeeping after #40 merged.

- Flip `specs/phase-2-github/015-issues-sync.md` frontmatter to `status: done` and add the PR link.
- Bump root `specs/README.md` Phase 2 row from "2/4 specs done (013, 014)" → "3/4 specs done (013, 014, 015). Next: 016 Pull requests + Work Items page."
- Bump `specs/phase-2-github/README.md` task table row 015 to 🟢. Also adjust the row's parenthetical from "/work-items issues filter" to "Repository Issues tab" — the unified `/work-items` page moved into spec 016 during scope confirmation.

No code, just docs.