### PR TITLE
Spec 016 — Pull requests sync + unified Work Items page

### DIFF
--- a/app/Domain/GitHub/Actions/NormalizeGitHubPullRequestAction.php
+++ b/app/Domain/GitHub/Actions/NormalizeGitHubPullRequestAction.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Domain\GitHub\Actions;
+
+use App\Enums\GithubPullRequestState;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+/**
+ * Pure mapper from a single GitHub `/pulls` payload to the array we
+ * persist on `github_pull_requests`.
+ *
+ * Unlike `NormalizeGitHubIssueAction`, this never returns null — the
+ * `/pulls` endpoint only returns PRs (no fan-in from `/issues`).
+ *
+ * `state` is derived: GitHub serves `state=open|closed` and a separate
+ * `merged` boolean. We collapse the two into one of `open|closed|merged`
+ * so the page can badge in one match.
+ *
+ * `synced_at` is intentionally NOT set here — the caller stamps it once
+ * per upsert so all rows from the same fetch share the same value.
+ */
+class NormalizeGitHubPullRequestAction
+{
+    /** Body preview cap, same firm bound as github_issues. */
+    private const BODY_PREVIEW_LIMIT = 280;
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>|null
+     */
+    public function execute(array $payload): ?array
+    {
+        if (! isset($payload['id'], $payload['number'], $payload['title'])) {
+            return null;
+        }
+
+        return [
+            'github_id' => (int) $payload['id'],
+            'number' => (int) $payload['number'],
+            'title' => (string) $payload['title'],
+            'body_preview' => $this->preview($payload['body'] ?? null),
+            'state' => $this->deriveState($payload)->value,
+            'author_login' => $payload['user']['login'] ?? null,
+            'base_branch' => (string) ($payload['base']['ref'] ?? ''),
+            'head_branch' => (string) ($payload['head']['ref'] ?? ''),
+            'draft' => (bool) ($payload['draft'] ?? false),
+            'merged' => $this->isMerged($payload),
+            'additions' => (int) ($payload['additions'] ?? 0),
+            'deletions' => (int) ($payload['deletions'] ?? 0),
+            'changed_files' => (int) ($payload['changed_files'] ?? 0),
+            'comments_count' => (int) ($payload['comments'] ?? 0),
+            'review_comments_count' => (int) ($payload['review_comments'] ?? 0),
+            'created_at_github' => $this->parseTimestamp($payload['created_at'] ?? null),
+            'updated_at_github' => $this->parseTimestamp($payload['updated_at'] ?? null),
+            'closed_at_github' => $this->parseTimestamp($payload['closed_at'] ?? null),
+            'merged_at' => $this->parseTimestamp($payload['merged_at'] ?? null),
+        ];
+    }
+
+    private function preview(?string $body): ?string
+    {
+        if ($body === null || $body === '') {
+            return null;
+        }
+
+        // No ellipsis suffix — same firm 280-char bound as the issues
+        // normalizer (spec 015).
+        return Str::limit($body, self::BODY_PREVIEW_LIMIT, '');
+    }
+
+    /**
+     * Collapse GitHub's `state` + `merged` flag into our 3-state enum.
+     * GitHub's `/pulls` payload uses `state=open|closed` and a separate
+     * `merged` boolean (or a non-null `merged_at`). A merged PR is
+     * always also `state=closed` on GitHub's side.
+     */
+    private function deriveState(array $payload): GithubPullRequestState
+    {
+        if ($this->isMerged($payload)) {
+            return GithubPullRequestState::Merged;
+        }
+
+        $rawState = (string) ($payload['state'] ?? 'open');
+
+        return match ($rawState) {
+            'closed' => GithubPullRequestState::Closed,
+            default => GithubPullRequestState::Open,
+        };
+    }
+
+    /**
+     * Some GitHub payloads include `merged: true`, others rely on
+     * `merged_at` being non-null. Trust either.
+     */
+    private function isMerged(array $payload): bool
+    {
+        if (isset($payload['merged']) && (bool) $payload['merged']) {
+            return true;
+        }
+
+        return isset($payload['merged_at']) && ! empty($payload['merged_at']);
+    }
+
+    private function parseTimestamp(?string $iso): ?Carbon
+    {
+        if ($iso === null || $iso === '') {
+            return null;
+        }
+
+        return Carbon::parse($iso);
+    }
+}

--- a/app/Domain/GitHub/Actions/SyncRepositoryPullRequestsAction.php
+++ b/app/Domain/GitHub/Actions/SyncRepositoryPullRequestsAction.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Domain\GitHub\Actions;
+
+use App\Domain\GitHub\Services\GitHubClient;
+use App\Models\GithubPullRequest;
+use App\Models\Repository;
+
+/**
+ * Sync one repository's pull requests into the local
+ * `github_pull_requests` table. Parallel structure to spec 015's
+ * `SyncRepositoryIssuesAction`.
+ *
+ * Differences from the issues action:
+ *   - GitHub's `/pulls` endpoint doesn't support `?since=`, so we
+ *     always full-fetch (capped at 100 most-recently-updated rows).
+ *   - The endpoint only returns PRs, so the normalizer never returns
+ *     null — the "drop PRs" branch from the issues path doesn't apply.
+ *
+ * Returns the number of PRs persisted (insert + update both count).
+ *
+ * Wraps `GitHubApiException` from the client up to the caller (the job
+ * catches it and flips `prs_sync_status` to failed; on 401 the
+ * connection is also expired).
+ */
+class SyncRepositoryPullRequestsAction
+{
+    public function __construct(
+        private readonly NormalizeGitHubPullRequestAction $normalizer,
+    ) {}
+
+    public function execute(Repository $repository, GitHubClient $client): int
+    {
+        $payload = $client->listPullRequests($repository->full_name);
+
+        $now = now();
+        $count = 0;
+
+        foreach ($payload as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            $normalized = $this->normalizer->execute($entry);
+
+            if ($normalized === null) {
+                continue;
+            }
+
+            GithubPullRequest::query()->updateOrCreate(
+                [
+                    'repository_id' => $repository->id,
+                    'github_id' => $normalized['github_id'],
+                ],
+                [
+                    ...$normalized,
+                    'synced_at' => $now,
+                ],
+            );
+
+            $count++;
+        }
+
+        return $count;
+    }
+}

--- a/app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php
+++ b/app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php
@@ -106,21 +106,45 @@ class SyncGitHubRepositoryJob implements ShouldQueue
             $this->markFailed($repository);
         }
 
-        // Chain spec 015's issues sync. Dispatch lives outside the
-        // try/catch above so a transient queue failure here doesn't
-        // flip a freshly-synced repo back to `failed` — issues sync
-        // has its own independent status on the repo row.
+        // Chain spec 015's issues sync and spec 016's PRs sync. Both
+        // dispatches sit outside the try/catch above so a transient
+        // queue failure here doesn't flip a freshly-synced repo back
+        // to `failed` — both child syncs carry their own independent
+        // statuses on the repo row.
         if ($metadataSynced) {
-            try {
-                SyncRepositoryIssuesJob::dispatch($repository->id);
-            } catch (Throwable $e) {
-                Log::warning('GitHub issues sync dispatch failed', [
-                    'repository_id' => $repository->id,
-                    'full_name' => $repository->full_name,
-                    'exception' => $e::class,
-                    'message' => $e->getMessage(),
-                ]);
-            }
+            $this->dispatchChildSync(
+                fn () => SyncRepositoryIssuesJob::dispatch($repository->id),
+                $repository,
+                'issues',
+            );
+
+            $this->dispatchChildSync(
+                fn () => SyncRepositoryPullRequestsJob::dispatch($repository->id),
+                $repository,
+                'pulls',
+            );
+        }
+    }
+
+    /**
+     * Wrap a child-sync dispatch in its own try/catch so a queue-driver
+     * blip in one chained sync doesn't suppress the other. Logs the
+     * failure; the user can recover via the per-tab "Run sync" buttons.
+     */
+    private function dispatchChildSync(
+        callable $dispatcher,
+        Repository $repository,
+        string $kind,
+    ): void {
+        try {
+            $dispatcher();
+        } catch (Throwable $e) {
+            Log::warning("GitHub {$kind} sync dispatch failed", [
+                'repository_id' => $repository->id,
+                'full_name' => $repository->full_name,
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
         }
     }
 

--- a/app/Domain/GitHub/Jobs/SyncRepositoryPullRequestsJob.php
+++ b/app/Domain/GitHub/Jobs/SyncRepositoryPullRequestsJob.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Domain\GitHub\Jobs;
+
+use App\Domain\GitHub\Actions\SyncRepositoryPullRequestsAction;
+use App\Domain\GitHub\Exceptions\GitHubApiException;
+use App\Domain\GitHub\Services\GitHubClient;
+use App\Enums\RepositorySyncStatus;
+use App\Models\GithubConnection;
+use App\Models\Repository;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Sync a single Repository's pull requests from GitHub into
+ * `github_pull_requests`. Parallel to spec 015's
+ * `SyncRepositoryIssuesJob` — same lifecycle, same 401 plumbing,
+ * same preserve-on-failure timestamp guarantee.
+ *
+ *   pending → syncing → synced (happy path)
+ *   pending → syncing → failed (caught GitHubApiException or Throwable)
+ *
+ * On 401 we additionally clear the connection's `access_token` and
+ * zero out `expires_at` so spec-013's Settings card surfaces the
+ * Reconnect CTA.
+ *
+ * `prs_synced_at` is only stamped on success — the "Last sync" UI
+ * (Repository PRs tab) must mean "last successful sync."
+ */
+class SyncRepositoryPullRequestsJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    public function __construct(public readonly int $repositoryId) {}
+
+    public function handle(SyncRepositoryPullRequestsAction $action): void
+    {
+        $repository = Repository::query()->find($this->repositoryId);
+
+        if ($repository === null) {
+            return;
+        }
+
+        $connection = $this->resolveConnection($repository);
+
+        if ($connection === null) {
+            Log::warning('GitHub PRs sync skipped — no connection', [
+                'repository_id' => $repository->id,
+                'full_name' => $repository->full_name,
+            ]);
+            $this->markFailed($repository);
+
+            return;
+        }
+
+        $repository->forceFill([
+            'prs_sync_status' => RepositorySyncStatus::Syncing->value,
+        ])->save();
+
+        try {
+            $action->execute($repository, new GitHubClient($connection));
+
+            $repository->forceFill([
+                'prs_sync_status' => RepositorySyncStatus::Synced->value,
+                'prs_synced_at' => now(),
+            ])->save();
+        } catch (GitHubApiException $e) {
+            if ($e->isUnauthorized()) {
+                $this->expireConnection($connection);
+            }
+
+            Log::warning('GitHub PRs sync failed', [
+                'repository_id' => $repository->id,
+                'full_name' => $repository->full_name,
+                'status' => $e->statusCode,
+                'message' => $e->getMessage(),
+            ]);
+
+            $this->markFailed($repository);
+        } catch (Throwable $e) {
+            Log::error('GitHub PRs sync errored', [
+                'repository_id' => $repository->id,
+                'full_name' => $repository->full_name,
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+
+            $this->markFailed($repository);
+        }
+    }
+
+    private function resolveConnection(Repository $repository): ?GithubConnection
+    {
+        $repository->loadMissing('project.owner.githubConnection');
+
+        return $repository->project?->owner?->githubConnection;
+    }
+
+    /**
+     * Flip to `failed`. We deliberately do NOT update `prs_synced_at`
+     * — that column means "last successful sync" and feeds the
+     * Repository PRs tab's "Last sync N min ago" indicator.
+     */
+    private function markFailed(Repository $repository): void
+    {
+        $repository->forceFill([
+            'prs_sync_status' => RepositorySyncStatus::Failed->value,
+        ])->save();
+    }
+
+    private function expireConnection(GithubConnection $connection): void
+    {
+        $connection->forceFill([
+            'access_token' => '',
+            'expires_at' => now(),
+        ])->save();
+    }
+}

--- a/app/Domain/GitHub/Queries/PullRequestsForRepositoryQuery.php
+++ b/app/Domain/GitHub/Queries/PullRequestsForRepositoryQuery.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Domain\GitHub\Queries;
+
+use App\Models\GithubPullRequest;
+use App\Models\Repository;
+
+/**
+ * Trim the `github_pull_requests` rows for one repository down to the
+ * shape the Repository show page's PRs tab needs. Parallel to spec
+ * 015's `IssuesForRepositoryQuery`.
+ *
+ * Returns plain arrays (not Eloquent models) so the controller doesn't
+ * have to know about Eloquent magic when building the Inertia payload.
+ */
+class PullRequestsForRepositoryQuery
+{
+    /** Soft cap on rows; pagination lands when a real user blows past. */
+    private const LIMIT = 50;
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function execute(Repository $repository): array
+    {
+        return GithubPullRequest::query()
+            ->where('repository_id', $repository->id)
+            ->orderByDesc('updated_at_github')
+            ->limit(self::LIMIT)
+            ->get()
+            ->map(fn (GithubPullRequest $pr) => [
+                'id' => $pr->id,
+                'number' => $pr->number,
+                'title' => $pr->title,
+                'state' => $pr->state?->value,
+                'author_login' => $pr->author_login,
+                'base_branch' => $pr->base_branch,
+                'head_branch' => $pr->head_branch,
+                'draft' => $pr->draft,
+                'comments_count' => $pr->comments_count,
+                'updated_at_github' => $pr->updated_at_github?->diffForHumans(),
+                'html_url' => "https://github.com/{$repository->full_name}/pull/{$pr->number}",
+            ])
+            ->all();
+    }
+}

--- a/app/Domain/GitHub/Queries/WorkItemsForUserQuery.php
+++ b/app/Domain/GitHub/Queries/WorkItemsForUserQuery.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace App\Domain\GitHub\Queries;
+
+use App\Models\GithubIssue;
+use App\Models\GithubPullRequest;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+/**
+ * Cross-repository work-queue feeding `/work-items`. Joins
+ * `github_issues` + `github_pull_requests` filtered by the repos the
+ * user can see (phase-1: repos owned by the user's projects), tagging
+ * each row with `kind: 'issue' | 'pull_request'` so the page can
+ * render either uniformly.
+ *
+ * Filters supported by the page (driven from query string by
+ * `WorkItemController`):
+ *   - `kind` ∈ `issues|pulls|all`
+ *   - `state` ∈ `open|closed|merged|all`
+ *   - `repository_id` (optional, scopes to one repo)
+ *   - `q` (optional, free-text on title or `#number`)
+ *
+ * Sort is locked to `updated_at_github desc` and capped at 100 rows
+ * across both kinds (no pagination yet — phase 9 polish).
+ */
+class WorkItemsForUserQuery
+{
+    private const LIMIT = 100;
+
+    /**
+     * @param  array{kind?: string, state?: string, repository_id?: int|null, q?: string|null}  $filters
+     * @return array<int, array<string, mixed>>
+     */
+    public function execute(User $user, array $filters = []): array
+    {
+        $kind = $filters['kind'] ?? 'all';
+        $state = $filters['state'] ?? 'open';
+        $repositoryId = $filters['repository_id'] ?? null;
+        $search = $filters['q'] ?? null;
+
+        $repositoryIds = $this->visibleRepositoryIds($user);
+
+        if ($repositoryIds->isEmpty()) {
+            return [];
+        }
+
+        if ($repositoryId !== null && ! $repositoryIds->contains($repositoryId)) {
+            return [];
+        }
+
+        $scopeIds = $repositoryId !== null
+            ? collect([$repositoryId])
+            : $repositoryIds;
+
+        $issues = $kind === 'pulls' ? collect() : $this->fetchIssues($scopeIds, $state, $search);
+        $pulls = $kind === 'issues' ? collect() : $this->fetchPullRequests($scopeIds, $state, $search);
+
+        return $issues
+            ->concat($pulls)
+            ->sortByDesc('updated_at_github_raw')
+            ->take(self::LIMIT)
+            ->values()
+            ->map(function (array $row) {
+                unset($row['updated_at_github_raw']);
+
+                return $row;
+            })
+            ->all();
+    }
+
+    /**
+     * Repositories the user can see — phase-1 ties this to the user's
+     * own projects. Multi-team scoping ships later.
+     */
+    private function visibleRepositoryIds(User $user): Collection
+    {
+        return Repository::query()
+            ->whereHas('project', fn ($query) => $query->where('owner_user_id', $user->id))
+            ->pluck('id');
+    }
+
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function fetchIssues(Collection $repositoryIds, string $state, ?string $search): Collection
+    {
+        $query = GithubIssue::query()
+            ->with('repository:id,full_name,name')
+            ->whereIn('repository_id', $repositoryIds);
+
+        if ($state !== 'all') {
+            // Issues only have `open` / `closed`. Filtering by `merged`
+            // returns nothing (issues are never merged), which is the
+            // desired behavior — the kind filter handles it cleanly.
+            if ($state === 'merged') {
+                return collect();
+            }
+            $query->where('state', $state);
+        }
+
+        if ($search !== null && $search !== '') {
+            $query->where(function ($inner) use ($search) {
+                $inner->where('title', 'like', "%{$search}%")
+                    ->orWhere('number', $this->parseNumberSearch($search));
+            });
+        }
+
+        return $query
+            ->orderByDesc('updated_at_github')
+            ->limit(self::LIMIT)
+            ->get()
+            ->map(fn (GithubIssue $issue) => [
+                'id' => "issue-{$issue->id}",
+                'kind' => 'issue',
+                'number' => $issue->number,
+                'title' => $issue->title,
+                'state' => $issue->state?->value,
+                'author_login' => $issue->author_login,
+                'comments_count' => $issue->comments_count,
+                'updated_at_github' => $issue->updated_at_github?->diffForHumans(),
+                'updated_at_github_raw' => $issue->updated_at_github,
+                'html_url' => $issue->repository
+                    ? "https://github.com/{$issue->repository->full_name}/issues/{$issue->number}"
+                    : null,
+                'repository' => $issue->repository ? [
+                    'id' => $issue->repository->id,
+                    'full_name' => $issue->repository->full_name,
+                    'name' => $issue->repository->name,
+                ] : null,
+            ]);
+    }
+
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function fetchPullRequests(Collection $repositoryIds, string $state, ?string $search): Collection
+    {
+        $query = GithubPullRequest::query()
+            ->with('repository:id,full_name,name')
+            ->whereIn('repository_id', $repositoryIds);
+
+        if ($state !== 'all') {
+            $query->where('state', $state);
+        }
+
+        if ($search !== null && $search !== '') {
+            $query->where(function ($inner) use ($search) {
+                $inner->where('title', 'like', "%{$search}%")
+                    ->orWhere('number', $this->parseNumberSearch($search));
+            });
+        }
+
+        return $query
+            ->orderByDesc('updated_at_github')
+            ->limit(self::LIMIT)
+            ->get()
+            ->map(fn (GithubPullRequest $pr) => [
+                'id' => "pull-{$pr->id}",
+                'kind' => 'pull_request',
+                'number' => $pr->number,
+                'title' => $pr->title,
+                'state' => $pr->state?->value,
+                'author_login' => $pr->author_login,
+                'comments_count' => $pr->comments_count,
+                'draft' => $pr->draft,
+                'updated_at_github' => $pr->updated_at_github?->diffForHumans(),
+                'updated_at_github_raw' => $pr->updated_at_github,
+                'html_url' => $pr->repository
+                    ? "https://github.com/{$pr->repository->full_name}/pull/{$pr->number}"
+                    : null,
+                'repository' => $pr->repository ? [
+                    'id' => $pr->repository->id,
+                    'full_name' => $pr->repository->full_name,
+                    'name' => $pr->repository->name,
+                ] : null,
+            ]);
+    }
+
+    /**
+     * Strip leading `#` so users can search "#42" or "42" interchangeably.
+     * Returns 0 (which won't match any row) for non-numeric input — the
+     * title `LIKE` branch handles those.
+     */
+    private function parseNumberSearch(string $search): int
+    {
+        $trimmed = ltrim(trim($search), '#');
+
+        return ctype_digit($trimmed) ? (int) $trimmed : 0;
+    }
+}

--- a/app/Domain/GitHub/Services/GitHubClient.php
+++ b/app/Domain/GitHub/Services/GitHubClient.php
@@ -130,6 +130,44 @@ class GitHubClient
     }
 
     /**
+     * GET /repos/{owner}/{name}/pulls — pull requests only (separate
+     * endpoint from `/issues`, which fans in PRs as a side-effect).
+     *
+     * `state=all` so closed + merged PRs land locally too. GitHub's
+     * `/pulls` endpoint does NOT support `?since=`, so unlike
+     * `listIssues` we always full-fetch the most-recently-updated 100.
+     */
+    public function listPullRequests(
+        string $fullName,
+        int $perPage = self::DEFAULT_PER_PAGE,
+    ): array {
+        try {
+            $response = $this->request()
+                ->get(self::BASE_URL."/repos/{$fullName}/pulls", [
+                    'state' => 'all',
+                    'sort' => 'updated',
+                    'direction' => 'desc',
+                    'per_page' => max(1, min($perPage, 100)),
+                    'page' => 1,
+                ]);
+
+            if ($response->failed()) {
+                throw GitHubApiException::fromResponse(
+                    $response,
+                    "GitHub /repos/{$fullName}/pulls failed",
+                );
+            }
+
+            return (array) $response->json();
+        } catch (RequestException $e) {
+            throw GitHubApiException::fromTransport(
+                $e,
+                "GitHub /repos/{$fullName}/pulls failed",
+            );
+        }
+    }
+
+    /**
      * Shared HTTP client config — auth + pinned API version + UA.
      * Note: we don't call `->throw()` on the PendingRequest; the
      * callers check `$response->failed()` and route the failure into

--- a/app/Enums/GithubPullRequestState.php
+++ b/app/Enums/GithubPullRequestState.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Three-state PR enum, derived from GitHub's `state` + `merged` flag
+ * by `NormalizeGitHubPullRequestAction`.
+ *
+ *  - `open`    — not merged, not closed
+ *  - `closed`  — closed without merging
+ *  - `merged`  — closed via merge
+ *
+ * Skipping the richer derived states (`draft`, `needs_review`,
+ * `approved`, `changes_requested`, `checks_failed`, `merge_conflict`,
+ * `ready_to_merge`, `stale`) — those need review + check sync, which
+ * is phase 9 polish.
+ */
+enum GithubPullRequestState: string
+{
+    case Open = 'open';
+    case Closed = 'closed';
+    case Merged = 'merged';
+
+    public function badgeTone(): string
+    {
+        return match ($this) {
+            self::Open => 'info',
+            self::Closed => 'muted',
+            self::Merged => 'success',
+        };
+    }
+}

--- a/app/Http/Controllers/RepositoryController.php
+++ b/app/Http/Controllers/RepositoryController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Domain\GitHub\Queries\IssuesForRepositoryQuery;
+use App\Domain\GitHub\Queries\PullRequestsForRepositoryQuery;
 use App\Domain\Repositories\Actions\LinkRepositoryToProjectAction;
 use App\Http\Requests\Repositories\LinkRepositoryRequest;
 use App\Models\Repository;
@@ -35,22 +36,30 @@ class RepositoryController extends Controller
         Request $request,
         Repository $repository,
         IssuesForRepositoryQuery $issuesQuery,
+        PullRequestsForRepositoryQuery $pullRequestsQuery,
     ): Response {
         $this->authorize('view', $repository);
 
         $repository->loadMissing('project:id,slug,name,color,icon,owner_user_id');
 
+        $canSync = $request->user()?->can('update', $repository->project) ?? false;
+
         return Inertia::render('Repositories/Show', [
             'repository' => $this->transform($repository),
             'canDelete' => $request->user()?->can('delete', $repository) ?? false,
-            // Spec 015 — issues live on the Repository show page's
-            // Issues tab. `canSync` gates the manual "Run sync" button
-            // to project owners, mirroring the picker's policy.
-            'canSync' => $request->user()?->can('update', $repository->project) ?? false,
+            // `canSync` gates the manual "Run sync" buttons on both
+            // the Issues tab (spec 015) and the PRs tab (spec 016) to
+            // project owners.
+            'canSync' => $canSync,
             'issues' => $issuesQuery->execute($repository),
             'issuesSync' => [
                 'status' => $repository->issues_sync_status?->value,
                 'synced_at' => $repository->issues_synced_at?->diffForHumans(),
+            ],
+            'pullRequests' => $pullRequestsQuery->execute($repository),
+            'pullRequestsSync' => [
+                'status' => $repository->prs_sync_status?->value,
+                'synced_at' => $repository->prs_synced_at?->diffForHumans(),
             ],
         ]);
     }

--- a/app/Http/Controllers/RepositoryPullRequestsSyncController.php
+++ b/app/Http/Controllers/RepositoryPullRequestsSyncController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\GitHub\Jobs\SyncRepositoryPullRequestsJob;
+use App\Models\Repository;
+use Illuminate\Http\RedirectResponse;
+
+/**
+ * Manual "Run sync" button on the Repository PRs tab. Re-dispatches
+ * `SyncRepositoryPullRequestsJob` for the given repository. Mirrors
+ * spec 015's `RepositoryIssuesSyncController` exactly.
+ *
+ * Authorization: `ProjectPolicy::update` — only the project owner can
+ * trigger a re-sync.
+ */
+class RepositoryPullRequestsSyncController extends Controller
+{
+    public function __invoke(Repository $repository): RedirectResponse
+    {
+        $repository->loadMissing('project');
+        $this->authorize('update', $repository->project);
+
+        SyncRepositoryPullRequestsJob::dispatch($repository->id);
+
+        return back()->with('status', 'Pull requests sync queued.');
+    }
+}

--- a/app/Http/Controllers/WorkItemController.php
+++ b/app/Http/Controllers/WorkItemController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\GitHub\Queries\WorkItemsForUserQuery;
+use App\Models\Project;
+use App\Models\Repository;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * `/work-items` — unified queue across the user's GitHub issues + PRs.
+ *
+ * Filters live in the query string so the URL is shareable / bookmarkable
+ * without any client-side state. Validated here before being passed into
+ * `WorkItemsForUserQuery`.
+ *
+ * Visible scope: phase-1 ties everything to a single owner user, so the
+ * page only ever surfaces items from repos under the user's own projects.
+ */
+class WorkItemController extends Controller
+{
+    public function __invoke(Request $request, WorkItemsForUserQuery $query): Response
+    {
+        $validated = $request->validate([
+            'kind' => 'sometimes|in:issues,pulls,all',
+            'state' => 'sometimes|in:open,closed,merged,all',
+            'repository_id' => 'sometimes|nullable|integer',
+            'q' => 'sometimes|nullable|string|max:255',
+        ]);
+
+        $filters = [
+            'kind' => $validated['kind'] ?? 'all',
+            'state' => $validated['state'] ?? 'open',
+            'repository_id' => $validated['repository_id'] ?? null,
+            'q' => $validated['q'] ?? null,
+        ];
+
+        $user = $request->user();
+        $items = $query->execute($user, $filters);
+
+        // Repositories dropdown — only the ones under the user's own
+        // projects (matches the query's visibility rule). Cheap query;
+        // displayed inline next to the kind/state filters.
+        $repositories = Repository::query()
+            ->whereIn(
+                'project_id',
+                Project::query()->where('owner_user_id', $user->id)->pluck('id'),
+            )
+            ->orderBy('full_name')
+            ->get(['id', 'full_name'])
+            ->map(fn (Repository $repo) => [
+                'id' => $repo->id,
+                'full_name' => $repo->full_name,
+            ])
+            ->all();
+
+        return Inertia::render('WorkItems/Index', [
+            'items' => $items,
+            'repositories' => $repositories,
+            'filters' => $filters,
+        ]);
+    }
+}

--- a/app/Models/GithubPullRequest.php
+++ b/app/Models/GithubPullRequest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\GithubPullRequestState;
+use Database\Factories\GithubPullRequestFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GithubPullRequest extends Model
+{
+    /** @use HasFactory<GithubPullRequestFactory> */
+    use HasFactory;
+
+    protected $table = 'github_pull_requests';
+
+    protected $fillable = [
+        'repository_id',
+        'github_id',
+        'number',
+        'title',
+        'body_preview',
+        'state',
+        'author_login',
+        'base_branch',
+        'head_branch',
+        'draft',
+        'merged',
+        'additions',
+        'deletions',
+        'changed_files',
+        'comments_count',
+        'review_comments_count',
+        'created_at_github',
+        'updated_at_github',
+        'closed_at_github',
+        'merged_at',
+        'synced_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'state' => GithubPullRequestState::class,
+            'draft' => 'boolean',
+            'merged' => 'boolean',
+            'additions' => 'integer',
+            'deletions' => 'integer',
+            'changed_files' => 'integer',
+            'comments_count' => 'integer',
+            'review_comments_count' => 'integer',
+            'created_at_github' => 'datetime',
+            'updated_at_github' => 'datetime',
+            'closed_at_github' => 'datetime',
+            'merged_at' => 'datetime',
+            'synced_at' => 'datetime',
+        ];
+    }
+
+    public function repository(): BelongsTo
+    {
+        return $this->belongsTo(Repository::class);
+    }
+}

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -35,6 +35,8 @@ class Repository extends Model
         'sync_status',
         'issues_sync_status',
         'issues_synced_at',
+        'prs_sync_status',
+        'prs_synced_at',
     ];
 
     protected function casts(): array
@@ -42,6 +44,7 @@ class Repository extends Model
         return [
             'sync_status' => RepositorySyncStatus::class,
             'issues_sync_status' => RepositorySyncStatus::class,
+            'prs_sync_status' => RepositorySyncStatus::class,
             'stars_count' => 'integer',
             'forks_count' => 'integer',
             'open_issues_count' => 'integer',
@@ -49,6 +52,7 @@ class Repository extends Model
             'last_pushed_at' => 'datetime',
             'last_synced_at' => 'datetime',
             'issues_synced_at' => 'datetime',
+            'prs_synced_at' => 'datetime',
         ];
     }
 
@@ -70,5 +74,10 @@ class Repository extends Model
     public function issues(): HasMany
     {
         return $this->hasMany(GithubIssue::class);
+    }
+
+    public function pullRequests(): HasMany
+    {
+        return $this->hasMany(GithubPullRequest::class);
     }
 }

--- a/database/factories/GithubPullRequestFactory.php
+++ b/database/factories/GithubPullRequestFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\GithubPullRequestState;
+use App\Models\GithubPullRequest;
+use App\Models\Repository;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<GithubPullRequest> */
+class GithubPullRequestFactory extends Factory
+{
+    protected $model = GithubPullRequest::class;
+
+    public function definition(): array
+    {
+        $state = fake()->randomElement([
+            GithubPullRequestState::Open,
+            GithubPullRequestState::Open,
+            GithubPullRequestState::Merged,
+            GithubPullRequestState::Closed,
+        ]);
+
+        $createdAt = fake()->dateTimeBetween('-30 days', '-1 day');
+        $updatedAt = fake()->dateTimeBetween($createdAt, 'now');
+        $isMerged = $state === GithubPullRequestState::Merged;
+        $isClosed = $state !== GithubPullRequestState::Open;
+
+        return [
+            'repository_id' => Repository::factory(),
+            'github_id' => fake()->unique()->numberBetween(10_000_000, 99_999_999),
+            'number' => fake()->numberBetween(1, 999),
+            'title' => fake()->sentence(6),
+            'body_preview' => fake()->sentence(20),
+            'state' => $state->value,
+            'author_login' => fake()->userName(),
+            'base_branch' => 'main',
+            'head_branch' => 'feature/'.fake()->slug(2),
+            'draft' => false,
+            'merged' => $isMerged,
+            'additions' => fake()->numberBetween(1, 500),
+            'deletions' => fake()->numberBetween(0, 200),
+            'changed_files' => fake()->numberBetween(1, 30),
+            'comments_count' => fake()->numberBetween(0, 25),
+            'review_comments_count' => fake()->numberBetween(0, 10),
+            'created_at_github' => $createdAt,
+            'updated_at_github' => $updatedAt,
+            'closed_at_github' => $isClosed
+                ? fake()->dateTimeBetween($updatedAt, 'now')
+                : null,
+            'merged_at' => $isMerged
+                ? fake()->dateTimeBetween($updatedAt, 'now')
+                : null,
+            'synced_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/2026_04_29_060542_create_github_pull_requests_table.php
+++ b/database/migrations/2026_04_29_060542_create_github_pull_requests_table.php
@@ -1,0 +1,67 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('github_pull_requests', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('repository_id')
+                ->constrained('repositories')
+                ->cascadeOnDelete();
+
+            // GitHub's globally-unique PR id; `number` is the human #N.
+            $table->unsignedBigInteger('github_id');
+            $table->unsignedInteger('number')->index();
+
+            $table->string('title');
+
+            // Same firm 280-char cap as github_issues.body_preview.
+            $table->text('body_preview')->nullable();
+
+            // Three values only: open|closed|merged. Derived by the
+            // normalizer from GitHub's `state` + `merged` boolean.
+            // The richer derived states (draft, needs_review, …) ride
+            // along with phase-9's review/check sync.
+            $table->string('state', 16)->default('open')->index();
+
+            $table->string('author_login')->nullable();
+
+            // Branch names — base = target, head = source. GitHub
+            // returns these as `base.ref` / `head.ref`.
+            $table->string('base_branch');
+            $table->string('head_branch');
+
+            $table->boolean('draft')->default(false);
+            $table->boolean('merged')->default(false);
+
+            $table->unsignedInteger('additions')->default(0);
+            $table->unsignedInteger('deletions')->default(0);
+            $table->unsignedInteger('changed_files')->default(0);
+
+            $table->unsignedInteger('comments_count')->default(0);
+            $table->unsignedInteger('review_comments_count')->default(0);
+
+            $table->timestamp('created_at_github')->nullable();
+            $table->timestamp('updated_at_github')->nullable()->index();
+            $table->timestamp('closed_at_github')->nullable();
+            $table->timestamp('merged_at')->nullable();
+
+            $table->timestamp('synced_at')->nullable();
+
+            $table->timestamps();
+
+            $table->unique(['repository_id', 'github_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('github_pull_requests');
+    }
+};

--- a/database/migrations/2026_04_29_060543_add_prs_sync_columns_to_repositories_table.php
+++ b/database/migrations/2026_04_29_060543_add_prs_sync_columns_to_repositories_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('repositories', function (Blueprint $table) {
+            // Parallel to spec 015's `issues_sync_status` columns —
+            // PRs sync runs as its own job (`SyncRepositoryPullRequestsJob`)
+            // chained alongside the issues job, so the lifecycle is
+            // observed independently of repo metadata + issues sync.
+            $table->string('prs_sync_status', 16)->default('pending')->after('issues_sync_status');
+            $table->timestamp('prs_synced_at')->nullable()->after('issues_synced_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('repositories', function (Blueprint $table) {
+            $table->dropColumn(['prs_sync_status', 'prs_synced_at']);
+        });
+    }
+};

--- a/resources/js/Components/Sidebar/Sidebar.vue
+++ b/resources/js/Components/Sidebar/Sidebar.vue
@@ -36,7 +36,7 @@ const nav: NavItem[] = [
     { label: 'Overview', icon: LayoutDashboard, routeName: 'overview' },
     { label: 'Projects', icon: FolderKanban, routeName: 'projects.index' },
     { label: 'Repositories', icon: GitBranch, routeName: 'repositories.index' },
-    { label: 'Issues & PRs', icon: GitPullRequest, disabled: true, soonLabel: 'Phase 2' },
+    { label: 'Issues & PRs', icon: GitPullRequest, routeName: 'work-items.index' },
     { label: 'Pipelines', icon: Activity, disabled: true, soonLabel: 'Phase 4' },
     { label: 'Deployments', icon: Rocket, disabled: true, soonLabel: 'Phase 4' },
     { label: 'Hosts', icon: Server, disabled: true, soonLabel: 'Phase 6' },

--- a/resources/js/Pages/Repositories/Show.vue
+++ b/resources/js/Pages/Repositories/Show.vue
@@ -56,7 +56,21 @@ interface IssueRow {
     html_url: string;
 }
 
-interface IssuesSyncShape {
+interface PullRequestRow {
+    id: number;
+    number: number;
+    title: string;
+    state: 'open' | 'closed' | 'merged' | string | null;
+    author_login: string | null;
+    base_branch: string;
+    head_branch: string;
+    draft: boolean;
+    comments_count: number;
+    updated_at_github: string | null;
+    html_url: string;
+}
+
+interface SyncShape {
     status: string | null;
     synced_at: string | null;
 }
@@ -66,10 +80,12 @@ const props = defineProps<{
     canDelete: boolean;
     canSync: boolean;
     issues: IssueRow[];
-    issuesSync: IssuesSyncShape;
+    issuesSync: SyncShape;
+    pullRequests: PullRequestRow[];
+    pullRequestsSync: SyncShape;
 }>();
 
-const tab = ref<'overview' | 'issues'>('overview');
+const tab = ref<'overview' | 'issues' | 'pulls'>('overview');
 
 const syncStatusTone = (status: string | null) =>
     (
@@ -84,6 +100,15 @@ const syncStatusTone = (status: string | null) =>
 const issueStateTone = (state: string | null) =>
     state === 'open' ? 'info' : 'muted';
 
+const prStateTone = (state: string | null) =>
+    (
+        ({
+            open: 'info',
+            merged: 'success',
+            closed: 'muted',
+        }) as const
+    )[state ?? ''] ?? 'muted';
+
 const projectAccentClass = (color: string | null) =>
     (
         ({
@@ -97,7 +122,11 @@ const projectAccentClass = (color: string | null) =>
     )[color ?? ''] ?? 'text-text-muted';
 
 const issuesCount = computed(() => props.issues.length);
-const isSyncing = computed(() => props.issuesSync.status === 'syncing');
+const pullRequestsCount = computed(() => props.pullRequests.length);
+const isIssuesSyncing = computed(() => props.issuesSync.status === 'syncing');
+const isPullRequestsSyncing = computed(
+    () => props.pullRequestsSync.status === 'syncing',
+);
 
 const confirmDelete = () => {
     if (!props.canDelete) return;
@@ -115,6 +144,15 @@ const runIssuesSync = () => {
     if (!props.canSync) return;
     router.post(
         route('repositories.issues.sync', props.repository.full_name),
+        {},
+        { preserveScroll: true },
+    );
+};
+
+const runPullRequestsSync = () => {
+    if (!props.canSync) return;
+    router.post(
+        route('repositories.pulls.sync', props.repository.full_name),
         {},
         { preserveScroll: true },
     );
@@ -297,6 +335,25 @@ const runIssuesSync = () => {
                         {{ issuesCount }}
                     </span>
                 </button>
+                <button
+                    type="button"
+                    :class="[
+                        'inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.22em] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60',
+                        tab === 'pulls'
+                            ? 'border-accent-cyan/60 bg-accent-cyan/15 text-accent-cyan'
+                            : 'border-border-subtle bg-background-panel-hover text-text-secondary hover:text-text-primary',
+                    ]"
+                    @click="tab = 'pulls'"
+                >
+                    <GitPullRequest class="h-3.5 w-3.5" aria-hidden="true" />
+                    Pull Requests
+                    <span
+                        v-if="pullRequestsCount > 0"
+                        class="rounded-full border border-current/40 px-1.5 py-0.5 text-[10px] font-mono"
+                    >
+                        {{ pullRequestsCount }}
+                    </span>
+                </button>
             </nav>
 
             <!-- Overview panel -->
@@ -398,7 +455,7 @@ const runIssuesSync = () => {
             </template>
 
             <!-- Issues panel -->
-            <template v-else>
+            <template v-else-if="tab === 'issues'">
                 <section aria-label="Issues" class="glass-card p-6 sm:p-8">
                     <header
                         class="flex flex-wrap items-center justify-between gap-3 border-b border-border-subtle pb-4"
@@ -425,11 +482,11 @@ const runIssuesSync = () => {
                             v-if="canSync"
                             type="button"
                             class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/15 px-3 py-2 text-sm font-semibold text-accent-cyan transition hover:border-accent-cyan/60 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
-                            :disabled="isSyncing"
+                            :disabled="isIssuesSyncing"
                             @click="runIssuesSync"
                         >
                             <RefreshCcw class="h-4 w-4" aria-hidden="true" />
-                            {{ isSyncing ? 'Syncing…' : 'Run sync' }}
+                            {{ isIssuesSyncing ? 'Syncing…' : 'Run sync' }}
                         </button>
                     </header>
 
@@ -505,6 +562,129 @@ const runIssuesSync = () => {
                             The last issues sync failed.
                         </span>
                         <span v-else>No issues mirrored for this repository.</span>
+                        <span v-if="canSync"> Click <span class="font-mono">Run sync</span> to fetch from GitHub.</span>
+                    </p>
+                </section>
+            </template>
+
+            <!-- Pull Requests panel -->
+            <template v-else>
+                <section aria-label="Pull Requests" class="glass-card p-6 sm:p-8">
+                    <header
+                        class="flex flex-wrap items-center justify-between gap-3 border-b border-border-subtle pb-4"
+                    >
+                        <div class="flex items-center gap-3">
+                            <h3 class="text-sm font-semibold text-text-primary">
+                                Pull requests mirror
+                            </h3>
+                            <StatusBadge
+                                v-if="pullRequestsSync.status"
+                                :tone="syncStatusTone(pullRequestsSync.status)"
+                            >
+                                {{ pullRequestsSync.status }}
+                            </StatusBadge>
+                            <span
+                                v-if="pullRequestsSync.synced_at"
+                                class="text-xs text-text-muted"
+                            >
+                                Last sync
+                                <span class="font-mono text-text-secondary">{{ pullRequestsSync.synced_at }}</span>
+                            </span>
+                        </div>
+                        <button
+                            v-if="canSync"
+                            type="button"
+                            class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/15 px-3 py-2 text-sm font-semibold text-accent-cyan transition hover:border-accent-cyan/60 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                            :disabled="isPullRequestsSyncing"
+                            @click="runPullRequestsSync"
+                        >
+                            <RefreshCcw class="h-4 w-4" aria-hidden="true" />
+                            {{ isPullRequestsSyncing ? 'Syncing…' : 'Run sync' }}
+                        </button>
+                    </header>
+
+                    <ul
+                        v-if="pullRequests.length > 0"
+                        class="mt-2 divide-y divide-border-subtle"
+                    >
+                        <li
+                            v-for="pr in pullRequests"
+                            :key="pr.id"
+                            class="flex flex-col gap-2 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
+                        >
+                            <div class="flex min-w-0 items-start gap-3">
+                                <GitPullRequest
+                                    class="mt-1 h-4 w-4 shrink-0"
+                                    :class="{
+                                        'text-accent-cyan': pr.state === 'open',
+                                        'text-status-success': pr.state === 'merged',
+                                        'text-text-muted':
+                                            pr.state === 'closed' || !pr.state,
+                                    }"
+                                    aria-hidden="true"
+                                />
+                                <div class="flex min-w-0 flex-col gap-1">
+                                    <a
+                                        :href="pr.html_url"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        class="truncate text-sm font-semibold text-text-primary transition hover:text-accent-cyan"
+                                    >
+                                        <span class="font-mono text-text-muted">#{{ pr.number }}</span>
+                                        {{ pr.title }}
+                                    </a>
+                                    <p class="text-xs text-text-muted">
+                                        <span v-if="pr.author_login">
+                                            <span class="font-mono text-text-secondary">@{{ pr.author_login }}</span>
+                                            ·
+                                        </span>
+                                        <span class="font-mono text-text-secondary">
+                                            {{ pr.base_branch }} ← {{ pr.head_branch }}
+                                        </span>
+                                        · Updated {{ pr.updated_at_github ?? '—' }}
+                                    </p>
+                                </div>
+                            </div>
+                            <div
+                                class="flex flex-shrink-0 items-center gap-3 text-xs text-text-muted"
+                            >
+                                <StatusBadge
+                                    v-if="pr.draft"
+                                    tone="muted"
+                                >
+                                    draft
+                                </StatusBadge>
+                                <StatusBadge :tone="prStateTone(pr.state)">
+                                    {{ pr.state }}
+                                </StatusBadge>
+                                <span class="inline-flex items-center gap-1">
+                                    <MessageSquare class="h-3.5 w-3.5" aria-hidden="true" />
+                                    {{ pr.comments_count }}
+                                </span>
+                                <a
+                                    :href="pr.html_url"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="text-text-muted transition hover:text-accent-cyan"
+                                    :aria-label="`Open pull request #${pr.number} on GitHub`"
+                                >
+                                    <ExternalLink class="h-4 w-4" aria-hidden="true" />
+                                </a>
+                            </div>
+                        </li>
+                    </ul>
+
+                    <p
+                        v-else
+                        class="mt-6 rounded-lg border border-dashed border-border-subtle bg-background-panel-hover/30 p-4 text-sm text-text-muted"
+                    >
+                        <span v-if="pullRequestsSync.status === 'pending'">
+                            Pull requests haven't been synced yet.
+                        </span>
+                        <span v-else-if="pullRequestsSync.status === 'failed'">
+                            The last pull requests sync failed.
+                        </span>
+                        <span v-else>No pull requests mirrored for this repository.</span>
                         <span v-if="canSync"> Click <span class="font-mono">Run sync</span> to fetch from GitHub.</span>
                     </p>
                 </section>

--- a/resources/js/Pages/WorkItems/Index.vue
+++ b/resources/js/Pages/WorkItems/Index.vue
@@ -1,0 +1,350 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, router } from '@inertiajs/vue3';
+import {
+    CircleDot,
+    ExternalLink,
+    GitPullRequest,
+    Inbox,
+    MessageSquare,
+    Search,
+} from 'lucide-vue-next';
+import { reactive, watch } from 'vue';
+
+interface RepositoryRef {
+    id: number;
+    full_name: string;
+    name: string;
+}
+
+interface WorkItem {
+    id: string;
+    kind: 'issue' | 'pull_request';
+    number: number;
+    title: string;
+    state: 'open' | 'closed' | 'merged' | string | null;
+    author_login: string | null;
+    comments_count: number;
+    draft?: boolean;
+    updated_at_github: string | null;
+    html_url: string | null;
+    repository: RepositoryRef | null;
+}
+
+interface Filters {
+    kind: 'issues' | 'pulls' | 'all';
+    state: 'open' | 'closed' | 'merged' | 'all';
+    repository_id: number | null;
+    q: string | null;
+}
+
+const props = defineProps<{
+    items: WorkItem[];
+    repositories: { id: number; full_name: string }[];
+    filters: Filters;
+}>();
+
+const local = reactive<Filters>({
+    kind: props.filters.kind,
+    state: props.filters.state,
+    repository_id: props.filters.repository_id,
+    q: props.filters.q,
+});
+
+const itemStateTone = (item: WorkItem) => {
+    if (item.kind === 'pull_request') {
+        return (
+            (
+                ({
+                    open: 'info',
+                    merged: 'success',
+                    closed: 'muted',
+                }) as const
+            )[item.state ?? ''] ?? 'muted'
+        );
+    }
+    return item.state === 'open' ? 'info' : 'muted';
+};
+
+// Push filter changes to the server. `preserveState: false` re-renders
+// the page with fresh `items`; `replace: true` keeps the back button
+// from accumulating filter steps.
+const applyFilters = () => {
+    router.get(
+        route('work-items.index'),
+        {
+            kind: local.kind,
+            state: local.state,
+            repository_id: local.repository_id ?? undefined,
+            q: local.q || undefined,
+        },
+        {
+            preserveState: false,
+            preserveScroll: true,
+            replace: true,
+        },
+    );
+};
+
+// Debounced free-text search: only fire when the user pauses typing,
+// otherwise every keystroke would re-render. The other filters (kind,
+// state, repo) fire immediately on change.
+let searchTimer: ReturnType<typeof setTimeout> | null = null;
+watch(
+    () => local.q,
+    () => {
+        if (searchTimer !== null) clearTimeout(searchTimer);
+        searchTimer = setTimeout(applyFilters, 350);
+    },
+);
+</script>
+
+<template>
+    <Head title="Work Items" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <span
+                    class="text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan"
+                >
+                    Phase 2
+                </span>
+                <h1 class="text-lg font-semibold text-text-primary">
+                    Work Items
+                </h1>
+            </div>
+        </template>
+
+        <div class="space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+            <!-- Filters -->
+            <section
+                aria-label="Filters"
+                class="glass-card flex flex-col gap-4 p-5 sm:flex-row sm:flex-wrap sm:items-end"
+            >
+                <!-- Kind tabs -->
+                <div class="flex flex-col gap-1">
+                    <label
+                        class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                    >
+                        Kind
+                    </label>
+                    <div class="flex gap-1.5">
+                        <button
+                            v-for="opt in [
+                                { value: 'all', label: 'All' },
+                                { value: 'issues', label: 'Issues' },
+                                { value: 'pulls', label: 'Pull Requests' },
+                            ]"
+                            :key="opt.value"
+                            type="button"
+                            :class="[
+                                'inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.2em] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60',
+                                local.kind === opt.value
+                                    ? 'border-accent-cyan/60 bg-accent-cyan/15 text-accent-cyan'
+                                    : 'border-border-subtle bg-background-panel-hover text-text-secondary hover:text-text-primary',
+                            ]"
+                            @click="
+                                local.kind = opt.value as Filters['kind'];
+                                applyFilters();
+                            "
+                        >
+                            {{ opt.label }}
+                        </button>
+                    </div>
+                </div>
+
+                <!-- State -->
+                <div class="flex flex-col gap-1">
+                    <label
+                        for="state-filter"
+                        class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                    >
+                        State
+                    </label>
+                    <select
+                        id="state-filter"
+                        v-model="local.state"
+                        class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                        @change="applyFilters"
+                    >
+                        <option value="open">Open</option>
+                        <option value="closed">Closed</option>
+                        <option value="merged">Merged</option>
+                        <option value="all">All</option>
+                    </select>
+                </div>
+
+                <!-- Repository -->
+                <div class="flex flex-col gap-1">
+                    <label
+                        for="repo-filter"
+                        class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                    >
+                        Repository
+                    </label>
+                    <select
+                        id="repo-filter"
+                        v-model="local.repository_id"
+                        class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                        @change="applyFilters"
+                    >
+                        <option :value="null">All repositories</option>
+                        <option
+                            v-for="repo in repositories"
+                            :key="repo.id"
+                            :value="repo.id"
+                        >
+                            {{ repo.full_name }}
+                        </option>
+                    </select>
+                </div>
+
+                <!-- Search -->
+                <div class="flex flex-1 flex-col gap-1 sm:min-w-[220px]">
+                    <label
+                        for="search-input"
+                        class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                    >
+                        Search
+                    </label>
+                    <div class="relative">
+                        <Search
+                            class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted"
+                            aria-hidden="true"
+                        />
+                        <input
+                            id="search-input"
+                            v-model="local.q"
+                            type="text"
+                            placeholder="Title or #number"
+                            class="w-full rounded-lg border border-border-subtle bg-background-panel-hover py-2 pl-10 pr-3 text-sm text-text-primary placeholder:text-text-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                        />
+                    </div>
+                </div>
+            </section>
+
+            <!-- Item list -->
+            <section
+                aria-label="Items"
+                class="glass-card p-0"
+            >
+                <ul
+                    v-if="items.length > 0"
+                    class="divide-y divide-border-subtle"
+                >
+                    <li
+                        v-for="item in items"
+                        :key="item.id"
+                        class="flex flex-col gap-2 px-6 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
+                    >
+                        <div class="flex min-w-0 items-start gap-3">
+                            <CircleDot
+                                v-if="item.kind === 'issue'"
+                                class="mt-1 h-4 w-4 shrink-0"
+                                :class="
+                                    item.state === 'open'
+                                        ? 'text-accent-cyan'
+                                        : 'text-text-muted'
+                                "
+                                aria-hidden="true"
+                            />
+                            <GitPullRequest
+                                v-else
+                                class="mt-1 h-4 w-4 shrink-0"
+                                :class="{
+                                    'text-accent-cyan': item.state === 'open',
+                                    'text-status-success':
+                                        item.state === 'merged',
+                                    'text-text-muted':
+                                        item.state === 'closed' || !item.state,
+                                }"
+                                aria-hidden="true"
+                            />
+                            <div class="flex min-w-0 flex-col gap-1">
+                                <a
+                                    v-if="item.html_url"
+                                    :href="item.html_url"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="truncate text-sm font-semibold text-text-primary transition hover:text-accent-cyan"
+                                >
+                                    <span class="font-mono text-text-muted">#{{ item.number }}</span>
+                                    {{ item.title }}
+                                </a>
+                                <span
+                                    v-else
+                                    class="truncate text-sm font-semibold text-text-primary"
+                                >
+                                    <span class="font-mono text-text-muted">#{{ item.number }}</span>
+                                    {{ item.title }}
+                                </span>
+                                <p class="text-xs text-text-muted">
+                                    <span
+                                        v-if="item.repository"
+                                        class="font-mono text-text-secondary"
+                                    >
+                                        {{ item.repository.full_name }}
+                                    </span>
+                                    <template v-if="item.author_login">
+                                        ·
+                                        <span class="font-mono text-text-secondary">@{{ item.author_login }}</span>
+                                    </template>
+                                    · Updated {{ item.updated_at_github ?? '—' }}
+                                </p>
+                            </div>
+                        </div>
+                        <div
+                            class="flex flex-shrink-0 items-center gap-3 text-xs text-text-muted"
+                        >
+                            <StatusBadge
+                                v-if="item.kind === 'pull_request' && item.draft"
+                                tone="muted"
+                            >
+                                draft
+                            </StatusBadge>
+                            <StatusBadge :tone="itemStateTone(item)">
+                                {{ item.state }}
+                            </StatusBadge>
+                            <span class="inline-flex items-center gap-1">
+                                <MessageSquare
+                                    class="h-3.5 w-3.5"
+                                    aria-hidden="true"
+                                />
+                                {{ item.comments_count }}
+                            </span>
+                            <a
+                                v-if="item.html_url"
+                                :href="item.html_url"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="text-text-muted transition hover:text-accent-cyan"
+                                :aria-label="`Open ${item.kind === 'pull_request' ? 'pull request' : 'issue'} #${item.number} on GitHub`"
+                            >
+                                <ExternalLink class="h-4 w-4" aria-hidden="true" />
+                            </a>
+                        </div>
+                    </li>
+                </ul>
+
+                <div
+                    v-else
+                    class="flex flex-col items-center gap-3 px-6 py-16 text-center"
+                >
+                    <Inbox
+                        class="h-10 w-10 text-text-muted"
+                        aria-hidden="true"
+                    />
+                    <p class="text-sm font-semibold text-text-primary">
+                        No work items match your filters.
+                    </p>
+                    <p class="text-xs text-text-muted">
+                        Import a repository on a project to start syncing
+                        issues and pull requests, or widen the state filter.
+                    </p>
+                </div>
+            </section>
+        </div>
+    </AppLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,7 +7,9 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ProjectController;
 use App\Http\Controllers\RepositoryController;
 use App\Http\Controllers\RepositoryIssuesSyncController;
+use App\Http\Controllers\RepositoryPullRequestsSyncController;
 use App\Http\Controllers\SettingsController;
+use App\Http\Controllers\WorkItemController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -50,6 +52,14 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/repositories/{repository}/issues/sync', RepositoryIssuesSyncController::class)
         ->where('repository', '[\w.-]+/[\w.-]+')
         ->name('repositories.issues.sync');
+
+    // Spec 016 — manual "Run sync" button on the Repository PRs tab.
+    Route::post('/repositories/{repository}/pulls/sync', RepositoryPullRequestsSyncController::class)
+        ->where('repository', '[\w.-]+/[\w.-]+')
+        ->name('repositories.pulls.sync');
+
+    // Spec 016 — unified Work Items queue (issues + PRs).
+    Route::get('/work-items', WorkItemController::class)->name('work-items.index');
 });
 
 Route::middleware('auth')->group(function () {

--- a/specs/phase-2-github/016-pull-requests-and-work-items.md
+++ b/specs/phase-2-github/016-pull-requests-and-work-items.md
@@ -1,0 +1,208 @@
+---
+spec: pull-requests-and-work-items
+phase: 2-github
+status: in-progress
+owner: yoany
+created: 2026-04-29
+updated: 2026-04-29
+issue: https://github.com/Copxer/nexus/issues/42
+branch: spec/016-pull-requests-and-work-items
+---
+
+# 016 — Pull requests sync + unified Work Items page
+
+## Goal
+Mirror GitHub pull requests for every imported `Repository` into a local `github_pull_requests` table (parallel structure to spec 015's `github_issues`) and ship the unified `/work-items` page that joins issues + PRs into a single engineering work queue. After this spec Phase 2 is complete: a Nexus user can connect GitHub (013), import repos (014), watch issues sync (015), and now watch pull requests sync alongside while browsing the unified queue across all of their repositories.
+
+This spec also adds a per-Repository "Pull Requests" tab (sibling of spec 015's Issues tab) so the Repository show page covers both sides of the issue-and-PR pair. Webhooks for near-real-time updates remain phase 3; review-detail sync (`mergeable`, `review_status`, `checks_status`) remains phase 9 polish.
+
+Roadmap reference: §8.4 GitHub Issues & Pull Requests (`github_pull_requests` schema + UX requirements + `/work-items` page), §27 (`app/Domain/GitHub/Actions/SyncRepositoryPullRequestsAction.php`, `app/Domain/GitHub/Actions/NormalizeGitHubPullRequestAction.php`).
+
+## Scope
+**In scope:**
+
+- **`github_pull_requests` table** with the §8.4 field set, MVP-trimmed:
+    - `id` (PK), `repository_id` (FK → `repositories`, cascade delete), `github_id` (bigint), `number` (int)
+    - `title` (string), `body_preview` (text, truncated at 280 chars — same firm-cap policy as issues)
+    - `state` (enum: `open`/`closed`/`merged`)
+    - `author_login` (string, nullable)
+    - `base_branch` (string), `head_branch` (string)
+    - `draft` (bool), `merged` (bool)
+    - `additions` (uint), `deletions` (uint), `changed_files` (uint)
+    - `comments_count` (uint), `review_comments_count` (uint)
+    - `created_at_github`, `updated_at_github`, `closed_at_github`, `merged_at` (datetime, all nullable except created)
+    - `synced_at` (datetime), `created_at` / `updated_at`
+    - **Compound unique index** `(repository_id, github_id)` for upsert-on-replay.
+    - **Skipped from §8.4 (phase 9)**: `mergeable`, `review_status`, `checks_status`, `review_comments_count` (the derived multi-call ones — `mergeable`/`review_status`/`checks_status` need extra REST calls per PR).
+
+- **`App\Models\GithubPullRequest`** — Eloquent model.
+    - Casts: `draft` + `merged` as `bool`; `state` as `App\Enums\GithubPullRequestState`; the GitHub timestamp columns as `datetime`; integer counts as `integer`.
+    - `repository()` belongs-to.
+    - `$fillable` shaped to the column list.
+
+- **`App\Enums\GithubPullRequestState`** — `Open` / `Closed` / `Merged`. Derived from GitHub's `state` + `merged` boolean by the normalizer (spec 015's enum had only Open/Closed; PRs need the third).
+
+- **Repositories table extension.** New nullable `prs_sync_status` enum column + `prs_synced_at` datetime, mirroring spec 015's issues columns. Lifecycle `pending → syncing → synced/failed`.
+
+- **`App\Domain\GitHub\Actions\NormalizeGitHubPullRequestAction`** — pure mapper from a single GitHub `/pulls` payload to the array we persist. Trims body to 280 chars (no ellipsis suffix, same as issues), pulls `base.ref` / `head.ref` for branch names, derives `state` from `state + merged_at`. Does NOT need to drop anything (the `/pulls` endpoint only returns PRs).
+
+- **`App\Domain\GitHub\Actions\SyncRepositoryPullRequestsAction`** — orchestrates one repository's PRs sync.
+    - Constructor injects `NormalizeGitHubPullRequestAction`.
+    - Takes a `Repository` model + an injected `GitHubClient`.
+    - Calls `GET /repos/{full_name}/pulls?state=all&per_page=100&sort=updated&direction=desc`. (Note: `/pulls` is separate from `/issues` — cleaner than re-using `/issues` and filtering for `pull_request`.)
+    - Same "ignore `since` when local mirror is empty" guard from spec 015's M4 fix. Actually, GitHub's `/pulls` does **not** support `?since=` — so for now we always full-fetch. Pagination is still the locked single-page cap. Document the difference from issues sync inline.
+    - Upsert on `(repository_id, github_id)`.
+    - Returns `int` count of PRs persisted.
+
+- **`App\Domain\GitHub\Jobs\SyncRepositoryPullRequestsJob`** — `ShouldQueue` job, parallel structure to spec 015's `SyncRepositoryIssuesJob`.
+    - Lifecycle `pending → syncing → synced/failed` on the new `prs_sync_status` column.
+    - On 401 reuse the same `expireConnection` plumbing (clear `access_token`, set `expires_at = now()`).
+    - `prs_synced_at` preserved on failure.
+    - `tries = 1` (same lock decision).
+
+- **Hook into `SyncGitHubRepositoryJob`.** After the `SyncRepositoryIssuesJob::dispatch()` we already added in spec 015, also dispatch `SyncRepositoryPullRequestsJob`. Both dispatches sit outside the metadata try/catch (spec 015's M2 fix) and run independently — a failure in one does not roll back the other.
+
+- **`App\Http\Controllers\RepositoryPullRequestsSyncController`** — single-action controller for the manual "Run sync" button on the Repository PRs tab.
+    - `POST /repositories/{repository}/pulls/sync` (route key constraint matches spec 011's two-segment slug).
+    - `ProjectPolicy::update` gate.
+
+- **`App\Domain\GitHub\Queries\PullRequestsForRepositoryQuery`** — parallel to spec 015's `IssuesForRepositoryQuery`. Returns the most-recent 50 by `updated_at_github desc`, shaped for the Repository show page's PRs tab.
+
+- **`App\Domain\GitHub\Queries\WorkItemsForUserQuery`** — the new query backing the `/work-items` page. Joins both `github_issues` + `github_pull_requests` filtered by repos the user can see (phase-1: their own projects' repos), tagged with a `kind: 'issue' | 'pull_request'` discriminator so the page can render either. Returns the most-recent 100 by `updated_at_github desc`. Filterable by `state`, `repository_id`, and `kind` (driven by query string from the page).
+
+- **`App\Http\Controllers\WorkItemController`** — single-action controller for `GET /work-items`.
+    - Validates query string: `kind` ∈ `issues|pulls|all` (default `all`), `state` ∈ `open|closed|merged|all` (default `open`), `repository_id` (nullable int), `q` (nullable string for title/number search).
+    - Calls the query class with those filters.
+    - Returns the page payload + the list of repositories the user can see (for the repo dropdown).
+
+- **Repository show page — Pull Requests tab.** Add a third tab on `Pages/Repositories/Show.vue` (sibling of Overview / Issues from spec 015). Sync status strip + "Run sync" button (POSTs to the new route) + per-row PR list:
+    - Each row: `#{number}` + title + state badge (`Open` cyan / `Closed` muted / `Merged` purple) + `author_login` + `base_branch ← head_branch` + relative `updated_at_github` + a small external link.
+    - Empty state: same pending/failed/empty branching as the Issues tab.
+
+- **`Pages/WorkItems/Index.vue`** — new top-level page. Header with three filter widgets: **kind tabs** (Issues / Pull Requests / All), **state filter** (open/closed/merged/all), **repository dropdown** (all the user's repos), **search input** (title or `#number`). List rows mix issues and PRs visually distinct (icon + state-tone badge). Cap at 100 rows; "Load more" lands later.
+
+- **Routes.** Add to `routes/web.php` under the existing `auth + verified` group:
+    ```php
+    Route::post('/repositories/{repository}/pulls/sync', RepositoryPullRequestsSyncController::class)
+        ->where('repository', '[\w.-]+/[\w.-]+')
+        ->name('repositories.pulls.sync');
+
+    Route::get('/work-items', WorkItemController::class)
+        ->name('work-items.index');
+    ```
+
+- **Sidebar navigation.** Promote the existing `Issues & PRs (Phase 2)` placeholder in `AppLayout`'s primary nav to a real `<Link>` pointing to `/work-items`. (The placeholder is a `<generic>` block today — drop the Phase 2 chip on it and route it.)
+
+- **`GithubPullRequestFactory`** for tests + seeded data parallel to `GithubIssueFactory`.
+
+- **Tests** (PHP feature tests):
+    - `NormalizeGitHubPullRequestActionTest` — happy path, missing optional fields, body trim at 280 chars, derived state matrix (`state=open + merged=false → open`, `state=closed + merged=false → closed`, `state=closed + merged=true → merged`, `state=open + merged=true` should not happen but defaults to `merged` for safety).
+    - `SyncRepositoryPullRequestsActionTest` — `Http::fake()` on `/repos/{full}/pulls`; happy path inserts; second sync upserts; 401 surfaces `GitHubApiException::isUnauthorized() === true`.
+    - `SyncRepositoryPullRequestsJobTest` — lifecycle (`pending → syncing → synced` and `→ failed`); 401 expires the connection; `prs_synced_at` preserved on failure.
+    - `SyncGitHubRepositoryJobTest` — extension test: on the happy path BOTH `SyncRepositoryIssuesJob` AND `SyncRepositoryPullRequestsJob` are dispatched (assert via `Queue::fake()`).
+    - `RepositoryPullRequestsSyncControllerTest` — manual sync dispatches the job for the project owner; non-owner is 403; 404 for unknown repo.
+    - `RepositoryControllerTest` — extension: PRs tab payload shape; the "Run sync" CTA renders only for users with update permission.
+    - `WorkItemControllerTest` — index renders the page for a verified user; query string filters narrow correctly; user only sees rows from their own projects' repos.
+
+- **Update phase trackers** in the same PR (and the post-merge bookkeeping flips 016 to 🟢, completing Phase 2 → 4/4 🟢).
+
+**Out of scope:**
+
+- **Mergeable / review-status / checks-status sync.** All require extra GitHub REST calls per PR (`/pulls/{n}/reviews`, `/pulls/{n}/commits`, etc.). The roadmap §8.4 lists derived statuses (`needs_review`, `approved`, `changes_requested`, `checks_failed`, `merge_conflict`, `ready_to_merge`, `stale`) — those all live on those extra endpoints. Phase 9 polish.
+- **Webhooks** (phase 3).
+- **Multi-page fetch** for either issues or PRs.
+- **Label / assignee / milestone filters** on `/work-items` — only state, repository, kind, and free-text search ship.
+- **Priority calculation + `PriorityBadge`** — §8.4 has a multi-input priority logic (labels, repo importance, age, comments, manual override). That's a phase 9 surface.
+- **Avatar URLs on rows** — spec 014 deliberately did not import GitHub avatars; same here.
+- **Cross-team / multi-tenant scoping** — phase-1 ties everything to a single owner user.
+- **Bulk re-sync** ("Sync all repos"). Phase 9.
+- **Sort dropdown on `/work-items`.** Single locked sort: `updated_at_github desc`.
+- **Issue/PR detail pages.** Both link out to GitHub directly. A later spec adds the local detail view if it earns its keep.
+
+## Plan
+
+1. **Migration + model + enum.** `php artisan make:migration create_github_pull_requests_table` → spec the schema + compound unique. Make the `GithubPullRequest` model with casts/relations. Add `App\Enums\GithubPullRequestState`. Add `prs_sync_status` + `prs_synced_at` columns to `repositories`.
+2. **`NormalizeGitHubPullRequestAction`.** Pure mapper. Branch-derive state from `state` + `merged_at`. Reuse the body-trim + label-shape patterns from spec 015 where applicable.
+3. **`SyncRepositoryPullRequestsAction`.** Wire to `GitHubClient::listPullRequests($fullName)`. Upsert.
+4. **`GitHubClient::listPullRequests`** — new method. Same pinned headers + per-page cap as `listIssues`/`listRepositories`.
+5. **`SyncRepositoryPullRequestsJob`.** Wraps the action; mirror spec 015's job structure exactly (lifecycle, 401, preserve-on-failure timestamp).
+6. **Hook into `SyncGitHubRepositoryJob`.** Dispatch the PRs job alongside the issues job. Both dispatches outside the metadata try/catch.
+7. **`PullRequestsForRepositoryQuery` + `WorkItemsForUserQuery`.** Two new query classes.
+8. **Controllers + routes.** `RepositoryPullRequestsSyncController` (single-action) + `WorkItemController`.
+9. **Repository show page — PRs tab.** Add the third tab + per-row UI matching the Issues tab.
+10. **`Pages/WorkItems/Index.vue`.** New top-level page with kind tabs + state/repo filter dropdowns + search. Ship a focused MVP — table-style list with state badges + GitHub external links.
+11. **Sidebar navigation.** Promote `Issues & PRs` placeholder to a real `<Link>`.
+12. **Tests.** Seven test files per the list. All `Http::fake()` + `Queue::fake()`.
+13. **Manual UX walk** — Playwright at 1440×900: import a stubbed repo (or seed), watch all three sync statuses (repo / issues / PRs) flip; visit Repository show → all three tabs; visit `/work-items` and exercise the filters.
+14. **Pipeline** — Pint, vue-tsc, build, full PHP test run.
+15. **Self-review** with `superpowers:code-reviewer`. Address material findings.
+
+## Acceptance criteria
+- [ ] Migration creates `github_pull_requests` with the field set above and `(repository_id, github_id)` unique index.
+- [ ] Migration extends `repositories` with `prs_sync_status` + `prs_synced_at`.
+- [ ] `NormalizeGitHubPullRequestAction` correctly derives `state` (open / closed / merged) from GitHub's `state` + `merged` fields, trims body to 280 chars, handles missing optional fields gracefully.
+- [ ] `SyncRepositoryPullRequestsAction` upserts on `(repository_id, github_id)`. A second sync against the same payload mutates one row in place.
+- [ ] `SyncRepositoryPullRequestsAction` raises `GitHubApiException::isUnauthorized() === true` on 401; the job's catch path expires the connection (mirroring spec 014/015).
+- [ ] `SyncGitHubRepositoryJob` dispatches BOTH `SyncRepositoryIssuesJob` AND `SyncRepositoryPullRequestsJob` after a successful repo metadata sync (verified via `Queue::fake()::assertPushed`).
+- [ ] `RepositoryPullRequestsSyncController` 200s for the project owner and 403s for non-owners.
+- [ ] Repository show page has a third "Pull Requests" tab; PRs tab renders the synced rows with state badges, branch names, author handles, relative GitHub timestamps, and external links; the "Run sync" button POSTs to the new route.
+- [ ] `prs_synced_at` is preserved across a failed sync.
+- [ ] `/work-items` page renders for a verified user; filters (kind, state, repository, search) narrow correctly; user only sees items from repos under their own projects.
+- [ ] Sidebar `Issues & PRs` link routes to `/work-items` and the "Phase 2" chip is gone.
+- [ ] No `gray-*` / `red-*` / `green-*` / `indigo-*` Tailwind classes.
+- [ ] No real GitHub credentials in CI; `Http::fake()` + `Queue::fake()` only.
+- [ ] Pint + vue-tsc + build clean. CI green.
+- [ ] Self-review pass with `superpowers:code-reviewer`.
+
+## Files touched
+- `database/migrations/<ts>_create_github_pull_requests_table.php` — new.
+- `database/migrations/<ts>_add_prs_sync_columns_to_repositories_table.php` — new.
+- `app/Models/GithubPullRequest.php` — new.
+- `app/Enums/GithubPullRequestState.php` — new.
+- `app/Domain/GitHub/Actions/NormalizeGitHubPullRequestAction.php` — new.
+- `app/Domain/GitHub/Actions/SyncRepositoryPullRequestsAction.php` — new.
+- `app/Domain/GitHub/Jobs/SyncRepositoryPullRequestsJob.php` — new.
+- `app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php` — extended to dispatch the PRs job alongside the issues job.
+- `app/Domain/GitHub/Services/GitHubClient.php` — add `listPullRequests(string $fullName, int $perPage = 100): array`.
+- `app/Domain/GitHub/Queries/PullRequestsForRepositoryQuery.php` — new.
+- `app/Domain/GitHub/Queries/WorkItemsForUserQuery.php` — new.
+- `app/Http/Controllers/RepositoryPullRequestsSyncController.php` — new.
+- `app/Http/Controllers/RepositoryController.php` — extend `show()` to include the PRs payload + sync status.
+- `app/Http/Controllers/WorkItemController.php` — new (single-action, GET).
+- `app/Models/Repository.php` — add `pullRequests()` relation, fillable + casts for the new columns.
+- `routes/web.php` — `repositories.pulls.sync` POST + `work-items.index` GET.
+- `resources/js/Pages/Repositories/Show.vue` — add the PRs tab.
+- `resources/js/Pages/WorkItems/Index.vue` — new.
+- `resources/js/Components/Layouts/AppLayout.vue` (or wherever the primary nav lives) — promote `Issues & PRs` to a real `<Link>` pointing to `/work-items`.
+- `database/factories/GithubPullRequestFactory.php` — new.
+- `tests/Feature/GitHub/NormalizeGitHubPullRequestActionTest.php` — new.
+- `tests/Feature/GitHub/SyncRepositoryPullRequestsActionTest.php` — new.
+- `tests/Feature/GitHub/SyncRepositoryPullRequestsJobTest.php` — new.
+- `tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php` — extension for both-jobs-dispatched.
+- `tests/Feature/GitHub/RepositoryPullRequestsSyncControllerTest.php` — new.
+- `tests/Feature/Repositories/RepositoryControllerTest.php` — extension for PRs tab payload.
+- `tests/Feature/GitHub/WorkItemControllerTest.php` — new.
+
+## Work log
+Dated notes as work progresses.
+
+### 2026-04-29
+- Spec drafted; scope confirmed (8 decisions locked: separate `github_pull_requests` table, three-state enum derived from `state + merged`, chain a third dispatch after spec 015's, single-page `/pulls` fetch with no `since=` param, three-tab Work Items page with kind/state/repo/search filters, single locked sort by `updated_at_github desc`, skip mergeable/review-status/checks-status, sidebar `Issues & PRs` promoted to real link).
+- Opened issue [#42](https://github.com/Copxer/nexus/issues/42) and branch `spec/016-pull-requests-and-work-items` off `main`.
+- Implementation complete: migrations + `GithubPullRequest` model + `GithubPullRequestState` enum + factory, `NormalizeGitHubPullRequestAction`, `GitHubClient::listPullRequests`, `SyncRepositoryPullRequestsAction`, `SyncRepositoryPullRequestsJob`, chain dispatch from `SyncGitHubRepositoryJob` (refactored to a small helper now that two child syncs fan out), `RepositoryPullRequestsSyncController` + route, `PullRequestsForRepositoryQuery`, Repository show page PRs tab, `WorkItemsForUserQuery`, `WorkItemController` + route, `Pages/WorkItems/Index.vue`, sidebar `Issues & PRs` promoted to a real link. 7 test files (5 new + 2 extensions): 171 tests / 773 assertions green. Pint/vue-tsc/build clean.
+- Manual UX walk via Playwright: synced repo with 3 PRs (open / closed / merged) renders the new PRs tab cleanly with branch names + state badges + Run sync button. `/work-items` page renders the unified queue, kind filter narrows to PRs only, state=merged filter shows the 3 merged PRs across both repos. Sidebar `Issues & PRs` link is wired and the "Phase 2" chip is gone.
+
+## Decisions (locked 2026-04-29)
+- **Separate `github_pull_requests` table** parallel to `github_issues`. Cleaner than a unified work-items table; the cross-cutting `WorkItemsForUserQuery` joins them at the read layer.
+- **Three-state enum: `open` / `closed` / `merged`.** Derived from GitHub's `state` + `merged` boolean by the normalizer. Skipping the richer derived states (`draft`, `needs_review`, etc.) — those need review/check sync which is phase 9.
+- **Chain a third dispatch.** `SyncGitHubRepositoryJob` now fires `SyncRepositoryIssuesJob` AND `SyncRepositoryPullRequestsJob` after a successful metadata sync. Independent statuses on the repo row.
+- **`/pulls` endpoint, no `since=` param.** GitHub doesn't support `since=` on `/pulls`; we always full-fetch (capped at 100). Single-page cap is the same locked decision as issues.
+- **Three-tab Work Items page.** Issues / Pull Requests / All. Filters: kind (matches the tabs), state, repository dropdown, free-text title/number search. Single locked sort (most-recent-by-`updated_at_github`).
+- **Skip `mergeable` / `review_status` / `checks_status`.** Each needs an extra REST call per PR. Worth its own phase 9 spec when we add review sync.
+- **Sidebar `Issues & PRs` link.** Promote the existing placeholder to a real `<Link>` pointing to `/work-items`. Drop the "Phase 2" chip.
+- **Mirror spec 015's failure plumbing.** 401 → blank token + `expires_at = now()`; failed sync does NOT bump `prs_synced_at`. Same firm 280-char body cap.
+
+## Open questions / blockers
+
+- **Performance on `WorkItemsForUserQuery`.** Joining issues + PRs at the read layer with limit 100 is fine for phase-1 single-user volume. If a real user has 50+ active repos and each has 100s of items, the 100-row cap may feel small. Pagination is a phase 9 follow-up.
+- **PHP 8.5 + Laravel 13.6 CSRF-in-tests issue.** Pre-existing; same disclaimer.

--- a/tests/Feature/GitHub/NormalizeGitHubPullRequestActionTest.php
+++ b/tests/Feature/GitHub/NormalizeGitHubPullRequestActionTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Domain\GitHub\Actions\NormalizeGitHubPullRequestAction;
+use Tests\TestCase;
+
+class NormalizeGitHubPullRequestActionTest extends TestCase
+{
+    private NormalizeGitHubPullRequestAction $action;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->action = new NormalizeGitHubPullRequestAction;
+    }
+
+    public function test_normalizes_a_full_pr_payload(): void
+    {
+        $payload = [
+            'id' => 999_888,
+            'number' => 17,
+            'title' => 'Add login retry logic',
+            'body' => str_repeat('x', 500),
+            'state' => 'open',
+            'user' => ['login' => 'octocat'],
+            'base' => ['ref' => 'main'],
+            'head' => ['ref' => 'feature/login-retry'],
+            'draft' => false,
+            'merged' => false,
+            'merged_at' => null,
+            'additions' => 42,
+            'deletions' => 7,
+            'changed_files' => 3,
+            'comments' => 4,
+            'review_comments' => 2,
+            'created_at' => '2026-04-10T10:00:00Z',
+            'updated_at' => '2026-04-15T12:00:00Z',
+            'closed_at' => null,
+        ];
+
+        $result = $this->action->execute($payload);
+
+        $this->assertNotNull($result);
+        $this->assertSame(999_888, $result['github_id']);
+        $this->assertSame(17, $result['number']);
+        $this->assertSame('Add login retry logic', $result['title']);
+        $this->assertSame(280, mb_strlen($result['body_preview']));
+        $this->assertSame('open', $result['state']);
+        $this->assertSame('octocat', $result['author_login']);
+        $this->assertSame('main', $result['base_branch']);
+        $this->assertSame('feature/login-retry', $result['head_branch']);
+        $this->assertFalse($result['draft']);
+        $this->assertFalse($result['merged']);
+        $this->assertSame(42, $result['additions']);
+        $this->assertSame(2, $result['review_comments_count']);
+        $this->assertNotNull($result['created_at_github']);
+        $this->assertNull($result['merged_at']);
+    }
+
+    public function test_derives_state_open_when_state_is_open_and_not_merged(): void
+    {
+        $result = $this->action->execute([
+            'id' => 1,
+            'number' => 1,
+            'title' => 'open PR',
+            'state' => 'open',
+            'merged' => false,
+        ]);
+
+        $this->assertSame('open', $result['state']);
+        $this->assertFalse($result['merged']);
+    }
+
+    public function test_derives_state_closed_when_state_is_closed_and_not_merged(): void
+    {
+        $result = $this->action->execute([
+            'id' => 2,
+            'number' => 2,
+            'title' => 'closed PR',
+            'state' => 'closed',
+            'merged' => false,
+            'merged_at' => null,
+        ]);
+
+        $this->assertSame('closed', $result['state']);
+        $this->assertFalse($result['merged']);
+    }
+
+    public function test_derives_state_merged_when_merged_flag_true(): void
+    {
+        $result = $this->action->execute([
+            'id' => 3,
+            'number' => 3,
+            'title' => 'merged via flag',
+            'state' => 'closed',
+            'merged' => true,
+            'merged_at' => '2026-04-20T00:00:00Z',
+        ]);
+
+        $this->assertSame('merged', $result['state']);
+        $this->assertTrue($result['merged']);
+        $this->assertNotNull($result['merged_at']);
+    }
+
+    public function test_derives_state_merged_when_merged_at_set_without_flag(): void
+    {
+        // Some payloads ship `merged_at` non-null without an explicit
+        // `merged: true` field. Trust either signal.
+        $result = $this->action->execute([
+            'id' => 4,
+            'number' => 4,
+            'title' => 'merged via timestamp',
+            'state' => 'closed',
+            'merged_at' => '2026-04-20T00:00:00Z',
+        ]);
+
+        $this->assertSame('merged', $result['state']);
+        $this->assertTrue($result['merged']);
+    }
+
+    public function test_handles_missing_optional_fields_gracefully(): void
+    {
+        $result = $this->action->execute([
+            'id' => 5,
+            'number' => 1,
+            'title' => 'Minimal PR',
+        ]);
+
+        $this->assertNotNull($result);
+        $this->assertSame('open', $result['state']);
+        $this->assertNull($result['author_login']);
+        $this->assertSame('', $result['base_branch']);
+        $this->assertSame('', $result['head_branch']);
+        $this->assertFalse($result['draft']);
+        $this->assertFalse($result['merged']);
+        $this->assertSame(0, $result['additions']);
+        $this->assertNull($result['body_preview']);
+        $this->assertNull($result['merged_at']);
+    }
+
+    public function test_returns_null_when_required_fields_missing(): void
+    {
+        $this->assertNull($this->action->execute(['id' => 7]));
+        $this->assertNull($this->action->execute(['id' => 7, 'number' => 1]));
+        $this->assertNull($this->action->execute(['number' => 1, 'title' => 'No id']));
+    }
+}

--- a/tests/Feature/GitHub/RepositoryPullRequestsSyncControllerTest.php
+++ b/tests/Feature/GitHub/RepositoryPullRequestsSyncControllerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Domain\GitHub\Jobs\SyncRepositoryPullRequestsJob;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class RepositoryPullRequestsSyncControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_can_dispatch_a_re_sync(): void
+    {
+        Queue::fake();
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+        ]);
+
+        $this->actingAs($owner)
+            ->from(route('repositories.show', $repository->full_name))
+            ->post(route('repositories.pulls.sync', $repository->full_name))
+            ->assertRedirect(route('repositories.show', $repository->full_name))
+            ->assertSessionHas('status');
+
+        Queue::assertPushed(
+            SyncRepositoryPullRequestsJob::class,
+            fn (SyncRepositoryPullRequestsJob $job) => $job->repositoryId === $repository->id,
+        );
+    }
+
+    public function test_non_owner_is_forbidden(): void
+    {
+        Queue::fake();
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+        $other = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+        ]);
+
+        $this->actingAs($other)
+            ->post(route('repositories.pulls.sync', $repository->full_name))
+            ->assertForbidden();
+
+        Queue::assertNotPushed(SyncRepositoryPullRequestsJob::class);
+    }
+
+    public function test_unknown_repository_returns_404(): void
+    {
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($owner)
+            ->post(route('repositories.pulls.sync', 'nope/missing'))
+            ->assertNotFound();
+    }
+}

--- a/tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php
+++ b/tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\GitHub;
 
 use App\Domain\GitHub\Jobs\SyncGitHubRepositoryJob;
 use App\Domain\GitHub\Jobs\SyncRepositoryIssuesJob;
+use App\Domain\GitHub\Jobs\SyncRepositoryPullRequestsJob;
 use App\Enums\RepositorySyncStatus;
 use App\Models\GithubConnection;
 use App\Models\Project;
@@ -161,7 +162,7 @@ class SyncGitHubRepositoryJobTest extends TestCase
         $this->assertSame(0, Repository::query()->count());
     }
 
-    public function test_handle_dispatches_issues_sync_on_happy_path(): void
+    public function test_handle_dispatches_both_child_syncs_on_happy_path(): void
     {
         Queue::fake();
         $context = $this->setUpProjectWithConnection();
@@ -182,9 +183,13 @@ class SyncGitHubRepositoryJobTest extends TestCase
             SyncRepositoryIssuesJob::class,
             fn (SyncRepositoryIssuesJob $job) => $job->repositoryId === $context['repository']->id,
         );
+        Queue::assertPushed(
+            SyncRepositoryPullRequestsJob::class,
+            fn (SyncRepositoryPullRequestsJob $job) => $job->repositoryId === $context['repository']->id,
+        );
     }
 
-    public function test_handle_does_not_dispatch_issues_sync_on_failure(): void
+    public function test_handle_does_not_dispatch_child_syncs_on_failure(): void
     {
         Queue::fake();
         $context = $this->setUpProjectWithConnection();
@@ -199,5 +204,6 @@ class SyncGitHubRepositoryJobTest extends TestCase
         (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
 
         Queue::assertNotPushed(SyncRepositoryIssuesJob::class);
+        Queue::assertNotPushed(SyncRepositoryPullRequestsJob::class);
     }
 }

--- a/tests/Feature/GitHub/SyncRepositoryPullRequestsActionTest.php
+++ b/tests/Feature/GitHub/SyncRepositoryPullRequestsActionTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Domain\GitHub\Actions\NormalizeGitHubPullRequestAction;
+use App\Domain\GitHub\Actions\SyncRepositoryPullRequestsAction;
+use App\Domain\GitHub\Exceptions\GitHubApiException;
+use App\Domain\GitHub\Services\GitHubClient;
+use App\Models\GithubConnection;
+use App\Models\GithubPullRequest;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SyncRepositoryPullRequestsActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setUpRepository(): array
+    {
+        $user = User::factory()->create();
+        $connection = GithubConnection::query()->create([
+            'user_id' => $user->id,
+            'github_user_id' => '9001',
+            'github_username' => 'octocat',
+            'access_token' => 'gho_token',
+            'expires_at' => now()->addHours(8),
+            'connected_at' => now(),
+        ]);
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+        ]);
+
+        return ['repository' => $repository, 'connection' => $connection];
+    }
+
+    public function test_inserts_pull_requests_with_derived_state(): void
+    {
+        $context = $this->setUpRepository();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/pulls*' => Http::response([
+                [
+                    'id' => 1,
+                    'number' => 1,
+                    'title' => 'Open PR',
+                    'state' => 'open',
+                    'user' => ['login' => 'alice'],
+                    'base' => ['ref' => 'main'],
+                    'head' => ['ref' => 'topic/a'],
+                    'merged' => false,
+                    'created_at' => '2026-04-01T00:00:00Z',
+                    'updated_at' => '2026-04-15T00:00:00Z',
+                ],
+                [
+                    'id' => 2,
+                    'number' => 2,
+                    'title' => 'Merged PR',
+                    'state' => 'closed',
+                    'merged_at' => '2026-04-20T00:00:00Z',
+                    'base' => ['ref' => 'main'],
+                    'head' => ['ref' => 'topic/b'],
+                    'created_at' => '2026-04-05T00:00:00Z',
+                    'updated_at' => '2026-04-20T00:00:00Z',
+                ],
+                [
+                    'id' => 3,
+                    'number' => 3,
+                    'title' => 'Closed PR',
+                    'state' => 'closed',
+                    'merged' => false,
+                    'merged_at' => null,
+                    'base' => ['ref' => 'main'],
+                    'head' => ['ref' => 'topic/c'],
+                    'created_at' => '2026-04-10T00:00:00Z',
+                    'updated_at' => '2026-04-21T00:00:00Z',
+                ],
+            ]),
+        ]);
+
+        $action = new SyncRepositoryPullRequestsAction(new NormalizeGitHubPullRequestAction);
+        $count = $action->execute(
+            $context['repository'],
+            new GitHubClient($context['connection']),
+        );
+
+        $this->assertSame(3, $count);
+        $this->assertSame(3, GithubPullRequest::query()->count());
+        $this->assertDatabaseHas('github_pull_requests', [
+            'github_id' => 1,
+            'state' => 'open',
+        ]);
+        $this->assertDatabaseHas('github_pull_requests', [
+            'github_id' => 2,
+            'state' => 'merged',
+            'merged' => true,
+        ]);
+        $this->assertDatabaseHas('github_pull_requests', [
+            'github_id' => 3,
+            'state' => 'closed',
+            'merged' => false,
+        ]);
+    }
+
+    public function test_upserts_on_repeated_sync(): void
+    {
+        $context = $this->setUpRepository();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/pulls*' => Http::sequence()
+                ->push([[
+                    'id' => 1,
+                    'number' => 1,
+                    'title' => 'Original title',
+                    'state' => 'open',
+                    'base' => ['ref' => 'main'],
+                    'head' => ['ref' => 'topic/a'],
+                    'comments' => 0,
+                ]])
+                ->push([[
+                    'id' => 1,
+                    'number' => 1,
+                    'title' => 'Updated title',
+                    'state' => 'closed',
+                    'merged_at' => '2026-04-22T00:00:00Z',
+                    'base' => ['ref' => 'main'],
+                    'head' => ['ref' => 'topic/a'],
+                    'comments' => 5,
+                ]]),
+        ]);
+
+        $action = new SyncRepositoryPullRequestsAction(new NormalizeGitHubPullRequestAction);
+        $action->execute($context['repository'], new GitHubClient($context['connection']));
+        $action->execute($context['repository'], new GitHubClient($context['connection']));
+
+        $this->assertSame(1, GithubPullRequest::query()->count());
+        $this->assertDatabaseHas('github_pull_requests', [
+            'github_id' => 1,
+            'title' => 'Updated title',
+            'state' => 'merged',
+            'comments_count' => 5,
+        ]);
+    }
+
+    public function test_raises_unauthorized_exception_on_401(): void
+    {
+        $context = $this->setUpRepository();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/pulls*' => Http::response(
+                ['message' => 'Bad credentials'],
+                401,
+            ),
+        ]);
+
+        $action = new SyncRepositoryPullRequestsAction(new NormalizeGitHubPullRequestAction);
+
+        try {
+            $action->execute($context['repository'], new GitHubClient($context['connection']));
+            $this->fail('Expected GitHubApiException');
+        } catch (GitHubApiException $e) {
+            $this->assertTrue($e->isUnauthorized());
+        }
+    }
+
+    public function test_does_not_send_since_param(): void
+    {
+        // Unlike the issues sync, /pulls does not support `since` —
+        // verify we never send it (otherwise GitHub silently ignores it
+        // and we look like we're filtering when we're not).
+        $context = $this->setUpRepository();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/pulls*' => Http::response([]),
+        ]);
+
+        $action = new SyncRepositoryPullRequestsAction(new NormalizeGitHubPullRequestAction);
+        $action->execute($context['repository'], new GitHubClient($context['connection']));
+
+        Http::assertSent(fn ($request) => ! str_contains($request->url(), 'since='));
+    }
+}

--- a/tests/Feature/GitHub/SyncRepositoryPullRequestsJobTest.php
+++ b/tests/Feature/GitHub/SyncRepositoryPullRequestsJobTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Domain\GitHub\Actions\NormalizeGitHubPullRequestAction;
+use App\Domain\GitHub\Actions\SyncRepositoryPullRequestsAction;
+use App\Domain\GitHub\Jobs\SyncRepositoryPullRequestsJob;
+use App\Enums\RepositorySyncStatus;
+use App\Models\GithubConnection;
+use App\Models\GithubPullRequest;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SyncRepositoryPullRequestsJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setUpProjectWithConnection(): array
+    {
+        $user = User::factory()->create();
+        GithubConnection::query()->create([
+            'user_id' => $user->id,
+            'github_user_id' => '9001',
+            'github_username' => 'octocat',
+            'access_token' => 'gho_token',
+            'expires_at' => now()->addHours(8),
+            'connected_at' => now(),
+        ]);
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+            'prs_sync_status' => RepositorySyncStatus::Pending->value,
+        ]);
+
+        return ['user' => $user, 'repository' => $repository];
+    }
+
+    private function action(): SyncRepositoryPullRequestsAction
+    {
+        return new SyncRepositoryPullRequestsAction(new NormalizeGitHubPullRequestAction);
+    }
+
+    public function test_handle_syncs_prs_and_flips_status_to_synced(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/pulls*' => Http::response([
+                [
+                    'id' => 1,
+                    'number' => 1,
+                    'title' => 'First PR',
+                    'state' => 'open',
+                    'base' => ['ref' => 'main'],
+                    'head' => ['ref' => 'topic/a'],
+                    'created_at' => '2026-04-01T00:00:00Z',
+                    'updated_at' => '2026-04-15T00:00:00Z',
+                ],
+            ]),
+        ]);
+
+        (new SyncRepositoryPullRequestsJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Synced, $repo->prs_sync_status);
+        $this->assertNotNull($repo->prs_synced_at);
+        $this->assertSame(1, GithubPullRequest::query()->count());
+    }
+
+    public function test_handle_marks_failed_and_expires_connection_on_401(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/pulls*' => Http::response(
+                ['message' => 'Bad credentials'],
+                401,
+            ),
+        ]);
+
+        (new SyncRepositoryPullRequestsJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->prs_sync_status);
+
+        $connection = $context['user']->fresh()->githubConnection;
+        $this->assertSame('', $connection->access_token);
+        $this->assertFalse($connection->isAccessTokenValid());
+    }
+
+    public function test_handle_marks_failed_on_generic_error(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/pulls*' => Http::response(
+                ['message' => 'Boom'],
+                500,
+            ),
+        ]);
+
+        (new SyncRepositoryPullRequestsJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->prs_sync_status);
+
+        $connection = $context['user']->fresh()->githubConnection;
+        $this->assertNotSame('', $connection->access_token);
+        $this->assertTrue($connection->isAccessTokenValid());
+    }
+
+    public function test_handle_preserves_prs_synced_at_on_failure(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+        $priorSync = now()->subHours(3);
+        $context['repository']->forceFill(['prs_synced_at' => $priorSync])->save();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/pulls*' => Http::response(
+                ['message' => 'Boom'],
+                500,
+            ),
+        ]);
+
+        (new SyncRepositoryPullRequestsJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->prs_sync_status);
+        $this->assertEquals(
+            $priorSync->toIso8601String(),
+            $repo->prs_synced_at->toIso8601String(),
+        );
+    }
+
+    public function test_handle_marks_failed_when_owner_has_no_connection(): void
+    {
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'prs_sync_status' => RepositorySyncStatus::Pending->value,
+        ]);
+
+        (new SyncRepositoryPullRequestsJob($repository->id))->handle($this->action());
+
+        $this->assertSame(RepositorySyncStatus::Failed, $repository->fresh()->prs_sync_status);
+    }
+
+    public function test_handle_is_a_no_op_when_repository_is_missing(): void
+    {
+        (new SyncRepositoryPullRequestsJob(999_999))->handle($this->action());
+
+        $this->assertSame(0, Repository::query()->count());
+        $this->assertSame(0, GithubPullRequest::query()->count());
+    }
+}

--- a/tests/Feature/GitHub/WorkItemControllerTest.php
+++ b/tests/Feature/GitHub/WorkItemControllerTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Enums\GithubIssueState;
+use App\Enums\GithubPullRequestState;
+use App\Models\GithubIssue;
+use App\Models\GithubPullRequest;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class WorkItemControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setUpUserWithItems(): array
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'nexus/web',
+        ]);
+
+        $openIssue = GithubIssue::factory()->create([
+            'repository_id' => $repository->id,
+            'number' => 1,
+            'title' => 'Open issue',
+            'state' => GithubIssueState::Open->value,
+            'updated_at_github' => now()->subHours(5),
+        ]);
+        $closedIssue = GithubIssue::factory()->create([
+            'repository_id' => $repository->id,
+            'number' => 2,
+            'title' => 'Closed issue',
+            'state' => GithubIssueState::Closed->value,
+            'updated_at_github' => now()->subHours(10),
+        ]);
+        $openPr = GithubPullRequest::factory()->create([
+            'repository_id' => $repository->id,
+            'number' => 3,
+            'title' => 'Open PR',
+            'state' => GithubPullRequestState::Open->value,
+            'merged' => false,
+            'updated_at_github' => now()->subHours(2),
+        ]);
+        $mergedPr = GithubPullRequest::factory()->create([
+            'repository_id' => $repository->id,
+            'number' => 4,
+            'title' => 'Merged PR',
+            'state' => GithubPullRequestState::Merged->value,
+            'merged' => true,
+            'updated_at_github' => now()->subHours(1),
+        ]);
+
+        return compact('user', 'repository', 'openIssue', 'closedIssue', 'openPr', 'mergedPr');
+    }
+
+    public function test_index_renders_for_a_verified_user(): void
+    {
+        $context = $this->setUpUserWithItems();
+
+        $this->actingAs($context['user'])
+            ->get(route('work-items.index'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('WorkItems/Index')
+                    ->has('items')
+                    ->has('repositories', 1)
+                    ->has('filters')
+                    ->where('filters.kind', 'all')
+                    ->where('filters.state', 'open')
+            );
+    }
+
+    public function test_default_filter_returns_only_open_items(): void
+    {
+        $context = $this->setUpUserWithItems();
+
+        $this->actingAs($context['user'])
+            ->get(route('work-items.index'))
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('items', 2) // open issue + open PR
+                    ->where('items.0.state', 'open')
+                    ->where('items.1.state', 'open')
+            );
+    }
+
+    public function test_kind_filter_pulls_narrows_to_pull_requests(): void
+    {
+        $context = $this->setUpUserWithItems();
+
+        $this->actingAs($context['user'])
+            ->get(route('work-items.index', ['kind' => 'pulls', 'state' => 'all']))
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('items', 2) // open + merged PRs
+                    ->where('items.0.kind', 'pull_request')
+                    ->where('items.1.kind', 'pull_request')
+            );
+    }
+
+    public function test_kind_filter_issues_narrows_to_issues(): void
+    {
+        $context = $this->setUpUserWithItems();
+
+        $this->actingAs($context['user'])
+            ->get(route('work-items.index', ['kind' => 'issues', 'state' => 'all']))
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('items', 2)
+                    ->where('items.0.kind', 'issue')
+                    ->where('items.1.kind', 'issue')
+            );
+    }
+
+    public function test_state_filter_merged_returns_only_prs(): void
+    {
+        $context = $this->setUpUserWithItems();
+
+        $this->actingAs($context['user'])
+            ->get(route('work-items.index', ['state' => 'merged']))
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('items', 1)
+                    ->where('items.0.kind', 'pull_request')
+                    ->where('items.0.state', 'merged')
+            );
+    }
+
+    public function test_search_filters_by_title_substring(): void
+    {
+        $context = $this->setUpUserWithItems();
+
+        $this->actingAs($context['user'])
+            ->get(route('work-items.index', ['state' => 'all', 'q' => 'Merged']))
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('items', 1)
+                    ->where('items.0.title', 'Merged PR')
+            );
+    }
+
+    public function test_search_filters_by_pound_number(): void
+    {
+        $context = $this->setUpUserWithItems();
+
+        $this->actingAs($context['user'])
+            ->get(route('work-items.index', ['state' => 'all', 'q' => '#3']))
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('items', 1)
+                    ->where('items.0.number', 3)
+            );
+    }
+
+    public function test_user_does_not_see_items_from_other_users_repos(): void
+    {
+        $context = $this->setUpUserWithItems();
+
+        $otherUser = User::factory()->create(['email_verified_at' => now()]);
+        $otherProject = Project::factory()->create(['owner_user_id' => $otherUser->id]);
+        $otherRepo = Repository::factory()->create([
+            'project_id' => $otherProject->id,
+            'full_name' => 'other/repo',
+        ]);
+        GithubIssue::factory()->create([
+            'repository_id' => $otherRepo->id,
+            'state' => GithubIssueState::Open->value,
+        ]);
+
+        $this->actingAs($context['user'])
+            ->get(route('work-items.index', ['state' => 'all']))
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('items', 4) // only context user's 4 items
+            );
+    }
+
+    public function test_repository_filter_scopes_to_one_repo(): void
+    {
+        $context = $this->setUpUserWithItems();
+        $secondRepo = Repository::factory()->create([
+            'project_id' => $context['repository']->project_id,
+            'full_name' => 'nexus/api',
+        ]);
+        GithubIssue::factory()->create([
+            'repository_id' => $secondRepo->id,
+            'state' => GithubIssueState::Open->value,
+        ]);
+
+        $this->actingAs($context['user'])
+            ->get(route('work-items.index', [
+                'state' => 'all',
+                'repository_id' => $context['repository']->id,
+            ]))
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('items', 4) // only original repo's items
+            );
+    }
+
+    public function test_invalid_filter_values_are_rejected(): void
+    {
+        $context = $this->setUpUserWithItems();
+
+        $this->actingAs($context['user'])
+            ->get(route('work-items.index', ['kind' => 'garbage']))
+            ->assertSessionHasErrors('kind');
+    }
+
+    public function test_unauthenticated_user_is_redirected_to_login(): void
+    {
+        $this->get(route('work-items.index'))->assertRedirect(route('login'));
+    }
+}

--- a/tests/Feature/Repositories/RepositoryControllerTest.php
+++ b/tests/Feature/Repositories/RepositoryControllerTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\Repositories;
 
 use App\Enums\GithubIssueState;
+use App\Enums\GithubPullRequestState;
 use App\Models\GithubIssue;
+use App\Models\GithubPullRequest;
 use App\Models\Project;
 use App\Models\Repository;
 use App\Models\User;
@@ -83,6 +85,39 @@ class RepositoryControllerTest extends TestCase
                     ->where('issues.0.number', 42)
                     ->where('issues.0.title', 'Login bug')
                     ->where('issues.0.state', 'open')
+            );
+    }
+
+    public function test_show_returns_pull_requests_in_the_payload(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repo = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'nexus-org/nexus-web',
+        ]);
+        GithubPullRequest::factory()->create([
+            'repository_id' => $repo->id,
+            'number' => 7,
+            'title' => 'Refactor auth',
+            'state' => GithubPullRequestState::Open->value,
+            'base_branch' => 'main',
+            'head_branch' => 'topic/auth',
+            'merged' => false,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('repositories.show', $repo))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('pullRequests', 1)
+                    ->where('pullRequests.0.number', 7)
+                    ->where('pullRequests.0.title', 'Refactor auth')
+                    ->where('pullRequests.0.state', 'open')
+                    ->where('pullRequests.0.base_branch', 'main')
+                    ->where('pullRequests.0.head_branch', 'topic/auth')
+                    ->has('pullRequestsSync')
             );
     }
 


### PR DESCRIPTION
Closes #42

Spec: \`specs/phase-2-github/016-pull-requests-and-work-items.md\`

Closing this spec finishes Phase 2 (4/4 🟢).

## Summary

- Mirrors GitHub pull requests into a new \`github_pull_requests\` table with \`(repository_id, github_id)\` compound unique index. Adds \`prs_sync_status\` + \`prs_synced_at\` columns to \`repositories\` so the PRs lifecycle is observed independently of repo metadata + issues sync.
- Three-state \`GithubPullRequestState\` enum (\`open\` / \`closed\` / \`merged\`) derived by \`NormalizeGitHubPullRequestAction\` from GitHub's \`state\` + \`merged\` flag (or non-null \`merged_at\`). Skipped roadmap §8.4 fields that need extra REST calls per PR (\`mergeable\`, \`review_status\`, \`checks_status\`) — they're phase-9 polish.
- New \`SyncRepositoryPullRequestsAction\` + \`SyncRepositoryPullRequestsJob\` mirror spec 015's issues sync structure (\`pending → syncing → synced/failed\` lifecycle, on 401 expire the connection per spec 014's pattern, \`prs_synced_at\` preserved on failure). \`/pulls\` doesn't support \`since=\` so the action always full-fetches (capped at 100).
- \`SyncGitHubRepositoryJob\` now fans out to BOTH \`SyncRepositoryIssuesJob\` AND \`SyncRepositoryPullRequestsJob\` after a successful metadata sync. Refactored through a small \`dispatchChildSync()\` helper so a queue blip in one dispatch can't suppress the other.
- New \`RepositoryPullRequestsSyncController\` for the manual "Run sync" button (POST \`/repositories/{repository}/pulls/sync\`, \`ProjectPolicy::update\` gated). Repository show page gains a third "Pull Requests" tab parallel to spec 015's Issues tab — state badges (open / merged / closed → info / success / muted), branch names (base ← head), draft chip, comments, GitHub external links.
- New \`/work-items\` page joining issues + PRs into a unified queue. Filters: kind tabs (All / Issues / Pull Requests), state dropdown, repository dropdown, debounced free-text search (title or \`#number\`). Single locked sort by \`updated_at_github desc\`, capped at 100 rows. \`WorkItemsForUserQuery\` scopes to repos under the user's own projects.
- Sidebar \`Issues & PRs\` placeholder promoted to a real \`<Link>\`; "Phase 2" chip removed.
- Manual UX walk via Playwright: PRs tab renders mixed states correctly; \`/work-items\` page renders mixed list with kind/state filters narrowing as expected.

## Test plan

- [x] Migration creates \`github_pull_requests\` with §8.4 field set (MVP-trimmed) + \`(repository_id, github_id)\` unique index.
- [x] Migration extends \`repositories\` with \`prs_sync_status\` + \`prs_synced_at\`.
- [x] \`NormalizeGitHubPullRequestAction\` correctly derives \`state\` (open/closed/merged) from GitHub's \`state\` + \`merged\` fields (full matrix tested), trims body to 280 chars, handles missing optional fields gracefully.
- [x] \`SyncRepositoryPullRequestsAction\` upserts on \`(repository_id, github_id)\`. Never sends \`since\` query param.
- [x] 401 surfaces \`GitHubApiException::isUnauthorized()\`; the job's catch path expires the connection.
- [x] \`SyncGitHubRepositoryJob\` dispatches BOTH child syncs after a successful metadata sync; NEITHER on failure.
- [x] \`RepositoryPullRequestsSyncController\` 200s for owner, 403 for non-owner, 404 for unknown repo.
- [x] Repository show page Pull Requests tab: state badges, branches, author, comments, external links, Run sync button.
- [x] \`prs_synced_at\` is preserved across a failed sync.
- [x] \`/work-items\` page: kind/state/repository/search filters narrow correctly. User only sees rows from their own projects' repos. Invalid filter values rejected. Unauthenticated user redirected to login.
- [x] Sidebar \`Issues & PRs\` link routes to \`/work-items\` (Phase 2 chip gone).
- [x] No \`gray-*\` / \`red-*\` / \`green-*\` / \`indigo-*\` Tailwind classes.
- [x] No real GitHub credentials in CI; \`Http::fake()\` + \`Queue::fake()\` only.
- [x] Pint + vue-tsc + build clean. 171 tests / 773 assertions green locally.
- [x] Self-review pass with \`superpowers:code-reviewer\`.

## Self-review notes

Ran \`superpowers:code-reviewer\` on the diff. **No material findings** — every locked decision honored end-to-end (three-state derivation, chained dispatch with isolation between child syncs, \`since\`-omission, single locked sort, ProjectPolicy gates, scope-by-owner_user_id). Specifics the reviewer verified:

- \`deriveState\` correctly collapses \`state + merged + merged_at\` (covers the \`state=open + merged=true\` weirdo case → \`merged\`).
- \`SyncGitHubRepositoryJob.dispatchChildSync\` wraps each child dispatch in its own try/catch; both happy-path-dispatches and failure-no-dispatch paths tested.
- \`WorkItemsForUserQuery::visibleRepositoryIds\` filters via \`whereHas('project', owner_user_id = $user->id)\` — no leak across users; \`repository_id\` filter rejects ids not in scope; \`state=merged\` for issues short-circuits to empty (issues are never merged); \`parseNumberSearch\` handles \`#42\` and \`42\` interchangeably; per-side LIMIT 100 then merge + LIMIT 100 is correct (the freshest 100 overall is always a subset of top-100 ∪ top-100).
- \`Pages/WorkItems/Index.vue\` uses \`{{ }}\` interpolation everywhere user-controlled — Vue auto-escapes, no XSS surface. \`replace: true\` on filter changes keeps history clean.
- All locked acceptance-criteria tests are present and aligned.

Stylistic items the reviewer flagged for future (none fixed in this branch):
- \`@param int|null\` on \`WorkItemsForUserQuery\` is technically inaccurate since query strings arrive as \`string\`. Works due to PHP/Eloquent loose comparison; fix the docblock or cast once if it earns its keep.
- A \`GithubUrl::pull/issue\` helper would dedupe the GitHub URL pattern across three query classes — wait until a fourth caller appears.
- \`base_branch\`/\`head_branch\` empty-string defaults could render an awkward " ← " on a malformed payload. Real GitHub \`/pulls\` payloads always include both refs; the migration's NOT NULL constraint forced the empty default. Acceptable.