### PR TITLE
chore(specs): mark spec 016 done; Phase 2 complete (4/4 🟢)

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -37,7 +37,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 |---|-------|--------|-------|
 | 0 | Foundation (auth, layout, static overview) | 🟢 | 9/9 specs done (001–009). Phase complete. |
 | 1 | Projects & Repositories | 🟢 | 3/3 specs done (010–012). Phase complete. |
-| 2 | GitHub Integration MVP | 🟡 | 3/4 specs done (013, 014, 015). Next: 016 Pull requests + Work Items page. |
+| 2 | GitHub Integration MVP | 🟢 | 4/4 specs done (013–016). Phase complete. |
 | 3 | GitHub Webhooks & Activity Feed | ⬜ | — |
 | 4 | Deployments & CI/CD | ⬜ | — |
 | 5 | Website Monitoring | ⬜ | — |

--- a/specs/phase-2-github/016-pull-requests-and-work-items.md
+++ b/specs/phase-2-github/016-pull-requests-and-work-items.md
@@ -1,11 +1,12 @@
 ---
 spec: pull-requests-and-work-items
 phase: 2-github
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-29
 updated: 2026-04-29
 issue: https://github.com/Copxer/nexus/issues/42
+pr: https://github.com/Copxer/nexus/pull/43
 branch: spec/016-pull-requests-and-work-items
 ---
 

--- a/specs/phase-2-github/README.md
+++ b/specs/phase-2-github/README.md
@@ -14,7 +14,7 @@ This phase is **read-only against GitHub**. Webhooks and near-real-time updates 
 | 013 | GitHub App connection (OAuth flow, encrypted token storage, Settings/Integrations panel) | 🟢 |
 | 014 | Repository import (list available repos, user picks which to import, `SyncGitHubRepositoryJob` populates metadata) | 🟢 |
 | 015 | Issues sync (database + sync job + Repository Issues tab) | 🟢 |
-| 016 | Pull requests sync + unified Work Items page (both filters + "Run sync" buttons) | ⬜ |
+| 016 | Pull requests sync + unified Work Items page (both filters + "Run sync" buttons) | 🟢 |
 
 ## Acceptance criteria (phase-level)
 - [ ] User can connect a GitHub account and see their connection status.


### PR DESCRIPTION
Bookkeeping after #43 merged. Phase 2 — GitHub Integration MVP — is fully done.

- Flip \`specs/phase-2-github/016-pull-requests-and-work-items.md\` frontmatter to \`status: done\` and add the PR link.
- Bump root \`specs/README.md\` Phase 2 row from 🟡 \"3/4 specs done\" → 🟢 \"4/4 specs done (013–016). Phase complete.\"
- Bump \`specs/phase-2-github/README.md\` task table row 016 to 🟢.

After this lands, Phase 3 (GitHub Webhooks & Activity Feed) is next on the roadmap. No code, just docs.