### PR TITLE
Spec 017 — Webhook ingestion + activity events

### DIFF
--- a/app/Domain/Activity/Actions/CreateActivityEventAction.php
+++ b/app/Domain/Activity/Actions/CreateActivityEventAction.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Domain\Activity\Actions;
+
+use App\Enums\ActivitySeverity;
+use App\Models\ActivityEvent;
+use Illuminate\Support\Carbon;
+use InvalidArgumentException;
+
+/**
+ * Single entry point for inserting an `activity_events` row. All
+ * webhook handlers (and, eventually, non-webhook origins like deploy
+ * pipelines or alerts) funnel through here so spec 019 can hook
+ * broadcasting once and have it cover every source.
+ *
+ * Mandatory fields: `event_type`, `title`, `occurred_at`. Everything
+ * else is optional.
+ */
+class CreateActivityEventAction
+{
+    /**
+     * @param  array{
+     *     event_type: string,
+     *     title: string,
+     *     occurred_at: Carbon,
+     *     repository_id?: int|null,
+     *     actor_login?: string|null,
+     *     source?: string,
+     *     severity?: ActivitySeverity|string,
+     *     description?: string|null,
+     *     metadata?: array<string, mixed>,
+     * }  $attrs
+     */
+    public function execute(array $attrs): ActivityEvent
+    {
+        $eventType = trim($attrs['event_type'] ?? '');
+        $title = trim($attrs['title'] ?? '');
+        $occurredAt = $attrs['occurred_at'] ?? null;
+
+        if ($eventType === '') {
+            throw new InvalidArgumentException('event_type is required.');
+        }
+        if ($title === '') {
+            throw new InvalidArgumentException('title is required.');
+        }
+        if (! $occurredAt instanceof Carbon) {
+            throw new InvalidArgumentException('occurred_at must be a Carbon instance.');
+        }
+
+        $severity = $attrs['severity'] ?? ActivitySeverity::Info;
+        if ($severity instanceof ActivitySeverity) {
+            $severity = $severity->value;
+        }
+
+        return ActivityEvent::query()->create([
+            'repository_id' => $attrs['repository_id'] ?? null,
+            'actor_login' => $attrs['actor_login'] ?? null,
+            'source' => $attrs['source'] ?? 'github',
+            'event_type' => $eventType,
+            'severity' => $severity,
+            'title' => $title,
+            'description' => $attrs['description'] ?? null,
+            'metadata' => $attrs['metadata'] ?? [],
+            'occurred_at' => $occurredAt,
+        ]);
+    }
+}

--- a/app/Domain/GitHub/Actions/VerifyGitHubWebhookSignatureAction.php
+++ b/app/Domain/GitHub/Actions/VerifyGitHubWebhookSignatureAction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Domain\GitHub\Actions;
+
+/**
+ * Verify a GitHub webhook's `X-Hub-Signature-256` header against the
+ * raw request body using a shared secret + HMAC-SHA-256.
+ *
+ *   GitHub sends:  X-Hub-Signature-256: sha256=<hex digest>
+ *   We compute:    sha256=hash_hmac('sha256', $rawBody, $secret)
+ *   Compare:       hash_equals(...) — timing-safe.
+ *
+ * Caller is the webhook controller. On `false` the controller MUST
+ * return 401 with no DB write — that's the only thing standing between
+ * an unauthenticated POST and a row in `github_webhook_deliveries`.
+ *
+ * The shared secret lives in `config('services.github.webhook_secret')`.
+ * If the secret is missing/empty we fail closed (`false`) — there's no
+ * "open" mode where unsigned requests are accepted.
+ */
+class VerifyGitHubWebhookSignatureAction
+{
+    public function execute(string $rawBody, ?string $signatureHeader, string $secret): bool
+    {
+        if ($secret === '' || $signatureHeader === null || $signatureHeader === '') {
+            return false;
+        }
+
+        $expected = 'sha256='.hash_hmac('sha256', $rawBody, $secret);
+
+        return hash_equals($expected, $signatureHeader);
+    }
+}

--- a/app/Domain/GitHub/Jobs/ProcessGitHubWebhookJob.php
+++ b/app/Domain/GitHub/Jobs/ProcessGitHubWebhookJob.php
@@ -7,7 +7,6 @@ use App\Domain\GitHub\WebhookHandlers\PullRequestWebhookHandler;
 use App\Enums\WebhookDeliveryStatus;
 use App\Models\WebhookDelivery;
 use Illuminate\Bus\Queueable;
-use Illuminate\Container\Container;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
@@ -86,8 +85,8 @@ class ProcessGitHubWebhookJob implements ShouldQueue
     private function routeToHandler(WebhookDelivery $delivery): WebhookDeliveryStatus
     {
         $handler = match ($delivery->event) {
-            'issues' => Container::getInstance()->make(IssuesWebhookHandler::class),
-            'pull_request' => Container::getInstance()->make(PullRequestWebhookHandler::class),
+            'issues' => app(IssuesWebhookHandler::class),
+            'pull_request' => app(PullRequestWebhookHandler::class),
             default => null,
         };
 

--- a/app/Domain/GitHub/Jobs/ProcessGitHubWebhookJob.php
+++ b/app/Domain/GitHub/Jobs/ProcessGitHubWebhookJob.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Domain\GitHub\Jobs;
+
+use App\Domain\GitHub\WebhookHandlers\IssuesWebhookHandler;
+use App\Domain\GitHub\WebhookHandlers\PullRequestWebhookHandler;
+use App\Enums\WebhookDeliveryStatus;
+use App\Models\WebhookDelivery;
+use Illuminate\Bus\Queueable;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Process a single `github_webhook_deliveries` row by routing the
+ * stored payload to its event handler.
+ *
+ *   received → processed (handler ran successfully + returned `Processed`)
+ *   received → skipped   (no handler for this event, or handler returned
+ *                         `Skipped` because we don't have the local repo
+ *                         yet — common when GitHub fires before import)
+ *   received → failed    (handler threw; `error_message` carries the reason)
+ *
+ * Each handler is the small, single-purpose concrete class — see
+ * `App\Domain\GitHub\WebhookHandlers\*`. Returning a status enum lets
+ * us distinguish "we ran but the inputs weren't ready" (Skipped) from
+ * "we ran successfully" (Processed) without tunneling exceptions.
+ *
+ * `tries = 1` matches spec 014/015/016 sync jobs. Replay is via the
+ * delivery row's stored payload (a future spec adds a "Re-process"
+ * action on top of that).
+ */
+class ProcessGitHubWebhookJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    public function __construct(public readonly int $deliveryId) {}
+
+    public function handle(): void
+    {
+        $delivery = WebhookDelivery::query()->find($this->deliveryId);
+
+        if ($delivery === null) {
+            // Row deleted between dispatch and run. No-op.
+            return;
+        }
+
+        try {
+            $status = $this->routeToHandler($delivery);
+
+            $delivery->forceFill([
+                'status' => $status->value,
+                'processed_at' => now(),
+            ])->save();
+        } catch (Throwable $e) {
+            Log::error('GitHub webhook processing failed', [
+                'delivery_id' => $delivery->id,
+                'event' => $delivery->event,
+                'action' => $delivery->action,
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+
+            $delivery->forceFill([
+                'status' => WebhookDeliveryStatus::Failed->value,
+                'error_message' => $e->getMessage(),
+                'processed_at' => now(),
+            ])->save();
+        }
+    }
+
+    /**
+     * Dispatch to the handler matching `delivery.event`. Unknown events
+     * land as `Skipped` per §8.5 ("Log unknown events. Do not fail
+     * silently") — we DO log, but we don't fail.
+     */
+    private function routeToHandler(WebhookDelivery $delivery): WebhookDeliveryStatus
+    {
+        $handler = match ($delivery->event) {
+            'issues' => Container::getInstance()->make(IssuesWebhookHandler::class),
+            'pull_request' => Container::getInstance()->make(PullRequestWebhookHandler::class),
+            default => null,
+        };
+
+        if ($handler === null) {
+            Log::info('GitHub webhook event has no handler', [
+                'delivery_id' => $delivery->id,
+                'event' => $delivery->event,
+                'action' => $delivery->action,
+            ]);
+
+            $delivery->forceFill([
+                'error_message' => "No handler registered for event `{$delivery->event}`.",
+            ])->save();
+
+            return WebhookDeliveryStatus::Skipped;
+        }
+
+        return $handler->handle($delivery);
+    }
+}

--- a/app/Domain/GitHub/WebhookHandlers/IssuesWebhookHandler.php
+++ b/app/Domain/GitHub/WebhookHandlers/IssuesWebhookHandler.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Domain\GitHub\WebhookHandlers;
+
+use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Domain\GitHub\Actions\NormalizeGitHubIssueAction;
+use App\Enums\ActivitySeverity;
+use App\Enums\WebhookDeliveryStatus;
+use App\Models\GithubIssue;
+use App\Models\Repository;
+use App\Models\WebhookDelivery;
+use Illuminate\Support\Carbon;
+
+/**
+ * Handle GitHub `issues` event deliveries.
+ *
+ *   - opened    → upsert + `issue.created` activity (info)
+ *   - closed    → upsert + `issue.closed` activity (success)
+ *   - reopened  → upsert + `issue.reopened` activity (info)
+ *   - edited    → upsert + `issue.updated` activity (info)
+ *   - other     → skipped (logged via the delivery row's error_message)
+ *
+ * Returns `Skipped` (not `Failed`) when:
+ *   - the action isn't one of the four above
+ *   - the payload turns out to be a PR (the `issues` event still fires
+ *     for PRs as a side-effect; the normalizer drops them)
+ *   - the repo isn't imported into Nexus yet (we don't have a row to
+ *     attach the issue to)
+ */
+class IssuesWebhookHandler
+{
+    private const HANDLED_ACTIONS = [
+        'opened' => ['type' => 'issue.created', 'severity' => ActivitySeverity::Info],
+        'closed' => ['type' => 'issue.closed', 'severity' => ActivitySeverity::Success],
+        'reopened' => ['type' => 'issue.reopened', 'severity' => ActivitySeverity::Info],
+        'edited' => ['type' => 'issue.updated', 'severity' => ActivitySeverity::Info],
+    ];
+
+    public function __construct(
+        private readonly NormalizeGitHubIssueAction $normalizer,
+        private readonly CreateActivityEventAction $createActivity,
+    ) {}
+
+    public function handle(WebhookDelivery $delivery): WebhookDeliveryStatus
+    {
+        $payload = $delivery->payload_json ?? [];
+        $action = (string) ($payload['action'] ?? '');
+        $issuePayload = $payload['issue'] ?? null;
+
+        $rule = self::HANDLED_ACTIONS[$action] ?? null;
+
+        if ($rule === null || ! is_array($issuePayload)) {
+            $delivery->forceFill([
+                'error_message' => "Unhandled `issues` action `{$action}` or missing payload.",
+            ])->save();
+
+            return WebhookDeliveryStatus::Skipped;
+        }
+
+        // The `issues` event still fires for PR-as-issue payloads. The
+        // normalizer returns null on those — that's the drop point.
+        $normalized = $this->normalizer->execute($issuePayload);
+
+        if ($normalized === null) {
+            $delivery->forceFill([
+                'error_message' => 'Payload looks like a pull request, not an issue.',
+            ])->save();
+
+            return WebhookDeliveryStatus::Skipped;
+        }
+
+        $repository = $this->resolveRepository($delivery);
+
+        if ($repository === null) {
+            $delivery->forceFill([
+                'error_message' => 'Repository not imported into Nexus.',
+            ])->save();
+
+            return WebhookDeliveryStatus::Skipped;
+        }
+
+        GithubIssue::query()->updateOrCreate(
+            [
+                'repository_id' => $repository->id,
+                'github_id' => $normalized['github_id'],
+            ],
+            [
+                ...$normalized,
+                'synced_at' => now(),
+            ],
+        );
+
+        $sender = $payload['sender']['login'] ?? null;
+
+        $this->createActivity->execute([
+            'event_type' => $rule['type'],
+            'severity' => $rule['severity'],
+            'title' => "#{$normalized['number']} {$normalized['title']}",
+            'description' => $repository->full_name,
+            'occurred_at' => $this->occurredAt($issuePayload, $action),
+            'repository_id' => $repository->id,
+            'actor_login' => $sender,
+            'metadata' => [
+                'issue_number' => $normalized['number'],
+                'github_id' => $normalized['github_id'],
+                'action' => $action,
+            ],
+        ]);
+
+        return WebhookDeliveryStatus::Processed;
+    }
+
+    private function resolveRepository(WebhookDelivery $delivery): ?Repository
+    {
+        $fullName = $delivery->repository_full_name;
+
+        if ($fullName === null || $fullName === '') {
+            return null;
+        }
+
+        return Repository::query()->where('full_name', $fullName)->first();
+    }
+
+    /**
+     * Pick the most accurate timestamp for the activity event. For
+     * `closed` we want `closed_at`; for everything else `updated_at`
+     * is a better fit than `now()` (preserves the actual GitHub-side
+     * moment if there's a sync lag).
+     */
+    private function occurredAt(array $issuePayload, string $action): Carbon
+    {
+        $field = $action === 'closed' ? 'closed_at' : 'updated_at';
+        $iso = $issuePayload[$field] ?? null;
+
+        if ($iso !== null && $iso !== '') {
+            return Carbon::parse($iso);
+        }
+
+        return now();
+    }
+}

--- a/app/Domain/GitHub/WebhookHandlers/PullRequestWebhookHandler.php
+++ b/app/Domain/GitHub/WebhookHandlers/PullRequestWebhookHandler.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Domain\GitHub\WebhookHandlers;
+
+use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Domain\GitHub\Actions\NormalizeGitHubPullRequestAction;
+use App\Enums\ActivitySeverity;
+use App\Enums\WebhookDeliveryStatus;
+use App\Models\GithubPullRequest;
+use App\Models\Repository;
+use App\Models\WebhookDelivery;
+use Illuminate\Support\Carbon;
+
+/**
+ * Handle GitHub `pull_request` event deliveries.
+ *
+ * Action mapping (the `closed` action splits on `merged`):
+ *   - opened           → `pull_request.opened`           (info)
+ *   - reopened         → `pull_request.reopened`         (info)
+ *   - closed + merged  → `pull_request.merged`           (success)
+ *   - closed (no merge)→ `pull_request.closed`           (info)
+ *   - review_requested → `pull_request.review_requested` (info)
+ *   - other            → skipped
+ *
+ * Returns `Skipped` (not `Failed`) when:
+ *   - the action isn't recognized
+ *   - the repo isn't imported into Nexus yet
+ */
+class PullRequestWebhookHandler
+{
+    public function __construct(
+        private readonly NormalizeGitHubPullRequestAction $normalizer,
+        private readonly CreateActivityEventAction $createActivity,
+    ) {}
+
+    public function handle(WebhookDelivery $delivery): WebhookDeliveryStatus
+    {
+        $payload = $delivery->payload_json ?? [];
+        $action = (string) ($payload['action'] ?? '');
+        $prPayload = $payload['pull_request'] ?? null;
+
+        if (! is_array($prPayload)) {
+            $delivery->forceFill([
+                'error_message' => "Missing `pull_request` block on `{$action}` event.",
+            ])->save();
+
+            return WebhookDeliveryStatus::Skipped;
+        }
+
+        $rule = $this->resolveRule($action, $prPayload);
+
+        if ($rule === null) {
+            $delivery->forceFill([
+                'error_message' => "Unhandled `pull_request` action `{$action}`.",
+            ])->save();
+
+            return WebhookDeliveryStatus::Skipped;
+        }
+
+        $normalized = $this->normalizer->execute($prPayload);
+
+        if ($normalized === null) {
+            $delivery->forceFill([
+                'error_message' => 'Pull request payload missing required fields.',
+            ])->save();
+
+            return WebhookDeliveryStatus::Skipped;
+        }
+
+        $repository = $this->resolveRepository($delivery);
+
+        if ($repository === null) {
+            $delivery->forceFill([
+                'error_message' => 'Repository not imported into Nexus.',
+            ])->save();
+
+            return WebhookDeliveryStatus::Skipped;
+        }
+
+        GithubPullRequest::query()->updateOrCreate(
+            [
+                'repository_id' => $repository->id,
+                'github_id' => $normalized['github_id'],
+            ],
+            [
+                ...$normalized,
+                'synced_at' => now(),
+            ],
+        );
+
+        $sender = $payload['sender']['login'] ?? null;
+
+        $this->createActivity->execute([
+            'event_type' => $rule['type'],
+            'severity' => $rule['severity'],
+            'title' => "#{$normalized['number']} {$normalized['title']}",
+            'description' => $repository->full_name,
+            'occurred_at' => $this->occurredAt($prPayload, $action, $normalized['merged']),
+            'repository_id' => $repository->id,
+            'actor_login' => $sender,
+            'metadata' => [
+                'pull_request_number' => $normalized['number'],
+                'github_id' => $normalized['github_id'],
+                'action' => $action,
+                'merged' => $normalized['merged'],
+            ],
+        ]);
+
+        return WebhookDeliveryStatus::Processed;
+    }
+
+    /**
+     * @param  array<string, mixed>  $prPayload
+     * @return array{type: string, severity: ActivitySeverity}|null
+     */
+    private function resolveRule(string $action, array $prPayload): ?array
+    {
+        return match ($action) {
+            'opened' => ['type' => 'pull_request.opened', 'severity' => ActivitySeverity::Info],
+            'reopened' => ['type' => 'pull_request.reopened', 'severity' => ActivitySeverity::Info],
+            'review_requested' => ['type' => 'pull_request.review_requested', 'severity' => ActivitySeverity::Info],
+            'closed' => $this->resolveClosedRule($prPayload),
+            default => null,
+        };
+    }
+
+    /**
+     * `closed` splits on whether the PR was merged. GitHub sets
+     * `merged: true` (and `merged_at`) when it was; both null/false
+     * when it was just closed.
+     *
+     * @param  array<string, mixed>  $prPayload
+     * @return array{type: string, severity: ActivitySeverity}
+     */
+    private function resolveClosedRule(array $prPayload): array
+    {
+        $merged = (bool) ($prPayload['merged'] ?? false)
+            || (! empty($prPayload['merged_at']));
+
+        return $merged
+            ? ['type' => 'pull_request.merged', 'severity' => ActivitySeverity::Success]
+            : ['type' => 'pull_request.closed', 'severity' => ActivitySeverity::Info];
+    }
+
+    private function resolveRepository(WebhookDelivery $delivery): ?Repository
+    {
+        $fullName = $delivery->repository_full_name;
+
+        if ($fullName === null || $fullName === '') {
+            return null;
+        }
+
+        return Repository::query()->where('full_name', $fullName)->first();
+    }
+
+    private function occurredAt(array $prPayload, string $action, bool $merged): Carbon
+    {
+        $field = match (true) {
+            $action === 'closed' && $merged => 'merged_at',
+            $action === 'closed' => 'closed_at',
+            default => 'updated_at',
+        };
+
+        $iso = $prPayload[$field] ?? null;
+
+        if ($iso !== null && $iso !== '') {
+            return Carbon::parse($iso);
+        }
+
+        return now();
+    }
+}

--- a/app/Enums/ActivitySeverity.php
+++ b/app/Enums/ActivitySeverity.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Severity tones for activity events. Maps directly onto the
+ * `StatusBadge` / dashboard tone vocabulary so the UI can color
+ * events without an extra translation layer.
+ */
+enum ActivitySeverity: string
+{
+    case Info = 'info';
+    case Success = 'success';
+    case Warning = 'warning';
+    case Danger = 'danger';
+
+    public function badgeTone(): string
+    {
+        return $this->value;
+    }
+}

--- a/app/Enums/WebhookDeliveryStatus.php
+++ b/app/Enums/WebhookDeliveryStatus.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Lifecycle of a GitHub webhook delivery row.
+ *
+ *  - `received` — controller stored the row + dispatched the job
+ *  - `processed` — handler ran successfully
+ *  - `failed`    — handler threw; `error_message` carries the reason
+ *  - `skipped`   — event type or action we don't know how to handle
+ *                  (per §8.5 "Log unknown events. Do not fail silently")
+ */
+enum WebhookDeliveryStatus: string
+{
+    case Received = 'received';
+    case Processed = 'processed';
+    case Failed = 'failed';
+    case Skipped = 'skipped';
+
+    public function badgeTone(): string
+    {
+        return match ($this) {
+            self::Received => 'info',
+            self::Processed => 'success',
+            self::Failed => 'danger',
+            self::Skipped => 'muted',
+        };
+    }
+}

--- a/app/Http/Controllers/Webhooks/GitHubWebhookController.php
+++ b/app/Http/Controllers/Webhooks/GitHubWebhookController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers\Webhooks;
+
+use App\Domain\GitHub\Actions\VerifyGitHubWebhookSignatureAction;
+use App\Domain\GitHub\Jobs\ProcessGitHubWebhookJob;
+use App\Enums\WebhookDeliveryStatus;
+use App\Models\WebhookDelivery;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+/**
+ * Receives GitHub webhook POSTs at `/webhooks/github`.
+ *
+ *   1. Verify signature against the raw body. Bad signature → 401, no
+ *      DB write. (An attacker who could fill `github_webhook_deliveries`
+ *      with garbage rows still couldn't trigger handlers, but we
+ *      refuse the row anyway so the audit trail isn't polluted.)
+ *   2. Idempotency: GitHub retries on timeout. We unique-index on
+ *      `github_delivery_id`; a second arrival with the same id is
+ *      acknowledged 200 with no second insert and no second dispatch.
+ *   3. Insert a fresh row in `received` state, dispatch the processing
+ *      job, return 200. Heavy lifting happens async (per §8.5
+ *      "Do not process webhook synchronously").
+ */
+class GitHubWebhookController
+{
+    public function __invoke(
+        Request $request,
+        VerifyGitHubWebhookSignatureAction $verifier,
+    ): Response {
+        $rawBody = $request->getContent();
+        $signature = $request->header('X-Hub-Signature-256');
+        $secret = (string) config('services.github.webhook_secret', '');
+
+        if (! $verifier->execute($rawBody, $signature, $secret)) {
+            return response('Invalid signature', 401);
+        }
+
+        $deliveryId = (string) $request->header('X-GitHub-Delivery', '');
+        $event = (string) $request->header('X-GitHub-Event', '');
+
+        if ($deliveryId === '' || $event === '') {
+            return response('Missing GitHub headers', 400);
+        }
+
+        // Idempotent replay of the same delivery is a no-op.
+        $existing = WebhookDelivery::query()
+            ->where('github_delivery_id', $deliveryId)
+            ->first();
+
+        if ($existing !== null) {
+            return response('OK', 200);
+        }
+
+        $payload = json_decode($rawBody, true) ?? [];
+
+        $delivery = WebhookDelivery::query()->create([
+            'github_delivery_id' => $deliveryId,
+            'event' => $event,
+            'action' => $payload['action'] ?? null,
+            'repository_full_name' => $payload['repository']['full_name'] ?? null,
+            'payload_json' => $payload,
+            'signature' => (string) $signature,
+            'status' => WebhookDeliveryStatus::Received->value,
+            'received_at' => now(),
+        ]);
+
+        ProcessGitHubWebhookJob::dispatch($delivery->id);
+
+        return response('OK', 200);
+    }
+}

--- a/app/Http/Controllers/Webhooks/GitHubWebhookController.php
+++ b/app/Http/Controllers/Webhooks/GitHubWebhookController.php
@@ -6,6 +6,7 @@ use App\Domain\GitHub\Actions\VerifyGitHubWebhookSignatureAction;
 use App\Domain\GitHub\Jobs\ProcessGitHubWebhookJob;
 use App\Enums\WebhookDeliveryStatus;
 use App\Models\WebhookDelivery;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 
@@ -34,7 +35,9 @@ class GitHubWebhookController
         $secret = (string) config('services.github.webhook_secret', '');
 
         if (! $verifier->execute($rawBody, $signature, $secret)) {
-            return response('Invalid signature', 401);
+            // Empty body on 401 — don't echo anything (not even a
+            // generic message) to a request we couldn't authenticate.
+            return response('', 401);
         }
 
         $deliveryId = (string) $request->header('X-GitHub-Delivery', '');
@@ -55,16 +58,25 @@ class GitHubWebhookController
 
         $payload = json_decode($rawBody, true) ?? [];
 
-        $delivery = WebhookDelivery::query()->create([
-            'github_delivery_id' => $deliveryId,
-            'event' => $event,
-            'action' => $payload['action'] ?? null,
-            'repository_full_name' => $payload['repository']['full_name'] ?? null,
-            'payload_json' => $payload,
-            'signature' => (string) $signature,
-            'status' => WebhookDeliveryStatus::Received->value,
-            'received_at' => now(),
-        ]);
+        try {
+            $delivery = WebhookDelivery::query()->create([
+                'github_delivery_id' => $deliveryId,
+                'event' => $event,
+                'action' => $payload['action'] ?? null,
+                'repository_full_name' => $payload['repository']['full_name'] ?? null,
+                'payload_json' => $payload,
+                'signature' => (string) $signature,
+                'status' => WebhookDeliveryStatus::Received->value,
+                'received_at' => now(),
+            ]);
+        } catch (UniqueConstraintViolationException) {
+            // Race window: between the lookup-by-delivery_id above and
+            // this insert, a concurrent retry may have raced us. The
+            // unique index is the source of truth — treat the loser as
+            // a duplicate and acknowledge 200, matching the idempotency
+            // contract.
+            return response('OK', 200);
+        }
 
         ProcessGitHubWebhookJob::dispatch($delivery->id);
 

--- a/app/Models/ActivityEvent.php
+++ b/app/Models/ActivityEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ActivitySeverity;
+use Database\Factories\ActivityEventFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ActivityEvent extends Model
+{
+    /** @use HasFactory<ActivityEventFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'repository_id',
+        'actor_login',
+        'source',
+        'event_type',
+        'severity',
+        'title',
+        'description',
+        'metadata',
+        'occurred_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'severity' => ActivitySeverity::class,
+            'metadata' => 'array',
+            'occurred_at' => 'datetime',
+        ];
+    }
+
+    public function repository(): BelongsTo
+    {
+        return $this->belongsTo(Repository::class);
+    }
+}

--- a/app/Models/WebhookDelivery.php
+++ b/app/Models/WebhookDelivery.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\WebhookDeliveryStatus;
+use Database\Factories\WebhookDeliveryFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class WebhookDelivery extends Model
+{
+    /** @use HasFactory<WebhookDeliveryFactory> */
+    use HasFactory;
+
+    protected $table = 'github_webhook_deliveries';
+
+    protected $fillable = [
+        'github_delivery_id',
+        'event',
+        'action',
+        'repository_full_name',
+        'payload_json',
+        'signature',
+        'status',
+        'error_message',
+        'received_at',
+        'processed_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => WebhookDeliveryStatus::class,
+            'payload_json' => 'array',
+            'received_at' => 'datetime',
+            'processed_at' => 'datetime',
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -19,7 +19,14 @@ return Application::configure(basePath: dirname(__DIR__))
             AddLinkHeadersForPreloadedAssets::class,
         ]);
 
-        //
+        // GitHub webhooks don't carry session cookies / CSRF tokens —
+        // they're authenticated via `X-Hub-Signature-256` (verified in
+        // GitHubWebhookController). Excluding here prevents Laravel from
+        // 419'ing the unauthenticated POST before our signature check
+        // runs.
+        $middleware->preventRequestForgery(except: [
+            'webhooks/github',
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/config/services.php
+++ b/config/services.php
@@ -46,6 +46,11 @@ return [
         // read access to public + private repository metadata + issues +
         // PRs. Adjust when feature scope expands.
         'scopes' => ['read:user', 'repo'],
+        // Shared secret configured on the GitHub App webhook. Used to
+        // verify `X-Hub-Signature-256` on incoming deliveries (spec 017).
+        // Empty string fails closed — no signed request is ever accepted
+        // without this set.
+        'webhook_secret' => env('GITHUB_WEBHOOK_SECRET', ''),
     ],
 
 ];

--- a/database/factories/ActivityEventFactory.php
+++ b/database/factories/ActivityEventFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ActivitySeverity;
+use App\Models\ActivityEvent;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<ActivityEvent> */
+class ActivityEventFactory extends Factory
+{
+    protected $model = ActivityEvent::class;
+
+    public function definition(): array
+    {
+        return [
+            'repository_id' => null,
+            'actor_login' => fake()->userName(),
+            'source' => 'github',
+            'event_type' => 'issue.created',
+            'severity' => ActivitySeverity::Info->value,
+            'title' => fake()->sentence(6),
+            'description' => null,
+            'metadata' => [],
+            'occurred_at' => now(),
+        ];
+    }
+}

--- a/database/factories/WebhookDeliveryFactory.php
+++ b/database/factories/WebhookDeliveryFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\WebhookDeliveryStatus;
+use App\Models\WebhookDelivery;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<WebhookDelivery> */
+class WebhookDeliveryFactory extends Factory
+{
+    protected $model = WebhookDelivery::class;
+
+    public function definition(): array
+    {
+        return [
+            'github_delivery_id' => Str::uuid()->toString(),
+            'event' => 'issues',
+            'action' => 'opened',
+            'repository_full_name' => 'octocat/hello-world',
+            'payload_json' => ['action' => 'opened'],
+            'signature' => 'sha256='.fake()->sha256(),
+            'status' => WebhookDeliveryStatus::Received->value,
+            'error_message' => null,
+            'received_at' => now(),
+            'processed_at' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_04_29_064251_create_github_webhook_deliveries_table.php
+++ b/database/migrations/2026_04_29_064251_create_github_webhook_deliveries_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('github_webhook_deliveries', function (Blueprint $table) {
+            $table->id();
+
+            // GitHub's `X-GitHub-Delivery` header — opaque UUID-ish
+            // string. Unique so a retry of the same delivery is detected
+            // and not double-processed (GitHub retries on timeout).
+            $table->string('github_delivery_id')->unique();
+
+            // Top-level event name from the `X-GitHub-Event` header
+            // (e.g. `issues`, `pull_request`).
+            $table->string('event', 64);
+
+            // The payload's `action` field (e.g. `opened`, `closed`).
+            // Nullable because some events don't carry one (`push`).
+            $table->string('action', 64)->nullable();
+
+            // Surfaced for filtering / debugging without parsing the
+            // payload. Nullable because the `repository` block is
+            // missing on a few event types (`ping`, organization-level).
+            $table->string('repository_full_name')->nullable()->index();
+
+            // Raw JSON payload for replay + audit. Stored verbatim so
+            // we can re-process if a handler bug is fixed later.
+            $table->json('payload_json');
+
+            // Raw `X-Hub-Signature-256` header for forensic replay. We
+            // don't re-verify on read; this is just an audit trail.
+            $table->string('signature');
+
+            $table->string('status', 16)->default('received')->index();
+
+            $table->text('error_message')->nullable();
+
+            $table->timestamp('received_at');
+            $table->timestamp('processed_at')->nullable();
+
+            $table->timestamps();
+
+            $table->index(['event', 'action']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('github_webhook_deliveries');
+    }
+};

--- a/database/migrations/2026_04_29_064252_create_activity_events_table.php
+++ b/database/migrations/2026_04_29_064252_create_activity_events_table.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('activity_events', function (Blueprint $table) {
+            $table->id();
+
+            // Nullable: `repository` events fire before any local row
+            // exists (e.g. spec 019's `repository.created` handler may
+            // log activity for a repo Nexus doesn't track yet).
+            // `nullOnDelete` keeps the audit trail when a repo is
+            // unlinked from a project later.
+            $table->foreignId('repository_id')
+                ->nullable()
+                ->constrained('repositories')
+                ->nullOnDelete();
+
+            // GitHub username of whoever triggered the event. We don't
+            // resolve to a local User row — phase-1 doesn't have a
+            // `github_username -> user_id` map (spec 013 stores the
+            // current user's username on the connection, but the actor
+            // may be someone outside the team).
+            $table->string('actor_login')->nullable();
+
+            // Where the event came from. `github` for now; phase 4+
+            // will add `nexus`, `monitoring`, `alerts`, etc.
+            $table->string('source', 32)->default('github');
+
+            // Dot-namespaced event type, e.g. `issue.created`,
+            // `pull_request.merged`. Indexed because the activity
+            // feed query filters by it.
+            $table->string('event_type', 64)->index();
+
+            $table->string('severity', 16)->default('info')->index();
+
+            $table->string('title');
+
+            $table->text('description')->nullable();
+
+            // Per-event-type structured data — issue/PR number, branch
+            // names, workflow run id, etc. Schema deliberately loose
+            // here; per-handler shape lives in the handler.
+            $table->json('metadata')->nullable();
+
+            // When GitHub says it happened (or now() for nexus-source
+            // events). Indexed because the recent-activity query sorts
+            // by it descending.
+            $table->timestamp('occurred_at')->index();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_events');
+    }
+};

--- a/database/migrations/2026_04_29_064252_create_activity_events_table.php
+++ b/database/migrations/2026_04_29_064252_create_activity_events_table.php
@@ -25,8 +25,10 @@ return new class extends Migration
             // resolve to a local User row — phase-1 doesn't have a
             // `github_username -> user_id` map (spec 013 stores the
             // current user's username on the connection, but the actor
-            // may be someone outside the team).
-            $table->string('actor_login')->nullable();
+            // may be someone outside the team). Capped at 64 chars to
+            // match GitHub's max-39 + headroom; signed payload could
+            // otherwise carry up to varchar 255 of garbage.
+            $table->string('actor_login', 64)->nullable();
 
             // Where the event came from. `github` for now; phase 4+
             // will add `nexus`, `monitoring`, `alerts`, etc.

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\RepositoryController;
 use App\Http\Controllers\RepositoryIssuesSyncController;
 use App\Http\Controllers\RepositoryPullRequestsSyncController;
 use App\Http\Controllers\SettingsController;
+use App\Http\Controllers\Webhooks\GitHubWebhookController;
 use App\Http\Controllers\WorkItemController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -61,6 +62,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
     // Spec 016 — unified Work Items queue (issues + PRs).
     Route::get('/work-items', WorkItemController::class)->name('work-items.index');
 });
+
+// Spec 017 — GitHub webhooks (no auth/CSRF; signature-verified inside).
+Route::post('/webhooks/github', GitHubWebhookController::class)
+    ->name('webhooks.github');
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');

--- a/specs/README.md
+++ b/specs/README.md
@@ -38,7 +38,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 0 | Foundation (auth, layout, static overview) | 🟢 | 9/9 specs done (001–009). Phase complete. |
 | 1 | Projects & Repositories | 🟢 | 3/3 specs done (010–012). Phase complete. |
 | 2 | GitHub Integration MVP | 🟢 | 4/4 specs done (013–016). Phase complete. |
-| 3 | GitHub Webhooks & Activity Feed | ⬜ | — |
+| 3 | GitHub Webhooks & Activity Feed | ⬜ | 0/3 specs (017 webhooks+activity events, 018 Activity Feed UI, 019 real-time broadcasting). Next: 017. |
 | 4 | Deployments & CI/CD | ⬜ | — |
 | 5 | Website Monitoring | ⬜ | — |
 | 6 | Docker Host Agent MVP | ⬜ | — |

--- a/specs/phase-3-webhooks-activity/017-webhook-ingestion-and-activity-events.md
+++ b/specs/phase-3-webhooks-activity/017-webhook-ingestion-and-activity-events.md
@@ -1,0 +1,184 @@
+---
+spec: webhook-ingestion-and-activity-events
+phase: 3-webhooks-activity
+status: in-progress
+owner: yoany
+created: 2026-04-29
+updated: 2026-04-29
+issue: https://github.com/Copxer/nexus/issues/45
+branch: spec/017-webhook-ingestion-and-activity-events
+---
+
+# 017 — Webhook ingestion + activity events
+
+## Goal
+Stand up the GitHub webhook ingestion stack end-to-end: a signed `POST /webhooks/github` endpoint, signature verification (rejecting bad signatures with 401 + zero-side-effects), idempotent storage in `github_webhook_deliveries`, and an async `ProcessGitHubWebhookJob` that routes to event-specific handlers. Initial handler set covers `issues` and `pull_request` — they update the spec 015/016 local mirrors and create `activity_events` rows so the user-visible activity stream has data to render in spec 018. No UI changes in this spec; everything is testable via signed fixture payloads and DB assertions.
+
+This spec ships the **backend half** of phase 3. Spec 018 lights up the visible feed, spec 019 layers Reverb broadcasting + extends the handler set to `workflow_run`, `push`, `release`, etc.
+
+Roadmap reference: §8.5 GitHub Webhooks (signature verification, `github_webhook_deliveries` schema, processing flow), §8.10 Activity Feed (`activity_events` schema + event types).
+
+## Scope
+**In scope:**
+
+- **`github_webhook_deliveries` table** matching §8.5 exactly:
+    - `id` (PK), `github_delivery_id` (string, unique — GitHub's `X-GitHub-Delivery` header), `event` (string, e.g. `issues`/`pull_request`), `action` (string nullable, e.g. `opened`/`closed` from the payload's `action` field), `repository_full_name` (string, nullable), `payload_json` (json), `signature` (string), `status` (enum: `received`/`processed`/`failed`/`skipped`), `error_message` (text, nullable), `received_at` (datetime), `processed_at` (datetime, nullable), standard `created_at`/`updated_at`.
+    - **Compound** index on `(event, action)` for future filtering, plus the `github_delivery_id` unique index for idempotency.
+
+- **`activity_events` table** matching §8.10's field set with phase-1 simplifications:
+    - `id`, `repository_id` (nullable FK → `repositories`, set null on delete), `actor_login` (string, nullable — the GitHub user who triggered it), `source` (string, default `github`), `event_type` (string, e.g. `issue.created`/`pull_request.merged`), `severity` (enum: `info`/`success`/`warning`/`danger`, default `info`), `title` (string), `description` (text, nullable), `metadata` (json, default `{}`), `occurred_at` (datetime), standard timestamps.
+    - **Skipped from §8.10 (multi-tenant deferral)**: `team_id`, `project_id`, `actor_user_id`. Phase-1 ties everything to a single owner via `repository_id → project → owner`. Multi-team scoping ships when teams ship.
+    - Index on `occurred_at desc` for the recent-activity query.
+
+- **`App\Models\WebhookDelivery`** — Eloquent model.
+    - Casts: `payload` (alias for `payload_json`) as `array`, timestamps as `datetime`, `status` as a string-backed `WebhookDeliveryStatus` enum.
+    - `repository()` belongs-to (resolved by `repository_full_name` on demand inside handlers — no FK because deliveries can arrive before the repo is imported).
+
+- **`App\Models\ActivityEvent`** — Eloquent model with casts and `repository()` relation.
+
+- **`App\Enums\WebhookDeliveryStatus`** (`Received`, `Processed`, `Failed`, `Skipped`) and **`App\Enums\ActivitySeverity`** (`Info`, `Success`, `Warning`, `Danger`) with `badgeTone()` helpers consistent with existing enums.
+
+- **`App\Domain\GitHub\Actions\VerifyGitHubWebhookSignatureAction`**:
+    - Reads the configured webhook secret from `config('services.github.webhook_secret')`.
+    - Computes `'sha256=' . hash_hmac('sha256', $rawBody, $secret)` and compares to the `X-Hub-Signature-256` header using `hash_equals` (timing-safe).
+    - Returns `bool`. Caller (controller) uses this to gate everything: bad signature → 401, no DB write.
+
+- **`App\Http\Controllers\Webhooks\GitHubWebhookController`** — single-action controller.
+    - `POST /webhooks/github` (no auth middleware — GitHub doesn't carry session cookies — but CSRF must be excluded for this route).
+    - Reads raw request body via `$request->getContent()` (NOT `$request->all()`, because Laravel's JSON parsing rejects malformed bodies before signature verification).
+    - Calls `VerifyGitHubWebhookSignatureAction`. If it returns false → return 401 with no body. **No row inserted on bad signature** — that's the spec acceptance criterion.
+    - Idempotency: look up `github_webhook_deliveries` by `github_delivery_id`. If a row already exists, return 200 with no further work (GitHub retries on timeout — we must not double-process).
+    - Otherwise insert a fresh row with `status = received`, dispatch `ProcessGitHubWebhookJob::dispatch($delivery->id)`, return 200.
+    - Doesn't process synchronously — the controller must always return quickly per §8.5.
+
+- **CSRF exclusion.** Add `webhooks/github` to the `VerifyCsrfToken` middleware's `$except` array (or use Laravel 11's modern `bootstrap/app.php` config).
+
+- **`App\Domain\GitHub\Jobs\ProcessGitHubWebhookJob`** — `ShouldQueue` job.
+    - Constructor: `int $deliveryId`.
+    - `handle()`: load the delivery row; route by `event` to the matching handler (`IssuesWebhookHandler` for `issues`, `PullRequestWebhookHandler` for `pull_request`); on success flip `status = processed` + stamp `processed_at`; on caught exception flip to `failed` and store `error_message`; for unhandled events flip to `skipped` (per §8.5 "Log unknown events. Do not fail silently").
+
+- **`App\Domain\GitHub\WebhookHandlers\IssuesWebhookHandler`**:
+    - Reads the payload's `repository.full_name`. If we don't have a local `Repository` row for it, mark the delivery `skipped` with a message — the user hasn't imported this repo into Nexus yet, so we don't have a place to attach the issue.
+    - Maps `action` → `event_type`: `opened → issue.created`, `closed → issue.closed`, `reopened → issue.reopened`, `edited → issue.updated`. Other actions skip.
+    - Re-uses spec 015's `NormalizeGitHubIssueAction` to map `payload.issue` → upsert into `github_issues`. Drops PRs (the issues webhook still fires for PRs as side-effect).
+    - Calls `CreateActivityEventAction` with the appropriate severity (`info` for opened/reopened/updated, `success` for closed).
+
+- **`App\Domain\GitHub\WebhookHandlers\PullRequestWebhookHandler`**:
+    - Reads `repository.full_name`; same skip logic if not imported.
+    - Maps `action` → `event_type`: `opened → pull_request.opened`, `closed + merged === true → pull_request.merged`, `closed + merged === false → pull_request.closed`, `reopened → pull_request.reopened`, `review_requested → pull_request.review_requested`. Other actions skip.
+    - Re-uses spec 016's `NormalizeGitHubPullRequestAction` to upsert into `github_pull_requests`.
+    - Severity: `info` for opened/reopened/review_requested, `success` for merged, `muted` semantic for closed-without-merge → use `info`. (Phase 9 polish can add a `closed-not-merged` severity tone if it earns its keep.)
+
+- **`App\Domain\Activity\Actions\CreateActivityEventAction`**:
+    - Single `execute(array $attrs): ActivityEvent`. Centralized so spec 019 can hook broadcasting in one place + so non-webhook origins (manual sync? import? — phase 9) can reuse it.
+    - Validates `event_type` is non-empty + `occurred_at` is a Carbon. Otherwise just persists.
+
+- **Routes.** `routes/web.php` adds:
+    ```php
+    Route::post('/webhooks/github', GitHubWebhookController::class)
+        ->name('webhooks.github');
+    ```
+    No middleware group — webhook bypasses auth + verified.
+
+- **Config.** `config/services.php` gains a `github.webhook_secret` key reading `env('GITHUB_WEBHOOK_SECRET')`. `.env.example` adds the variable with documentation.
+
+- **No GitHub-side webhook subscription registration in this spec.** That's a separate concern (the GitHub App settings already let you point a webhook URL at the server; for local development you point ngrok at your dev machine). Phase 9 might automate the per-repo subscription via the Apps API.
+
+- **Tests** (PHP feature tests):
+    - `VerifyGitHubWebhookSignatureActionTest` — valid signature returns true; tampered body returns false; missing secret returns false; constant-time comparison verified by happy-path equality.
+    - `GitHubWebhookControllerTest` — bad signature 401 + zero rows inserted; valid signature 200 + delivery row stored + job dispatched (`Queue::fake()`); duplicate `X-GitHub-Delivery` returns 200 with no second insert + no second dispatch.
+    - `ProcessGitHubWebhookJobTest` — `issues.opened` payload runs the issues handler, upserts the row, creates an `issue.created` activity event; `pull_request.opened` analogous; unknown event flips delivery to `skipped` with no activity events; handler exception flips delivery to `failed` with the error_message captured.
+    - `IssuesWebhookHandlerTest` — opened/closed/reopened/edited mapping correct; PR-shaped issues payload (the `pull_request` key set on issue) skipped; unknown action skipped; no local Repository → skipped with message.
+    - `PullRequestWebhookHandlerTest` — opened/closed-not-merged/closed-merged/reopened/review_requested mapping correct; unknown action skipped.
+    - `CreateActivityEventActionTest` — happy-path persists with normalized fields; missing required fields throw.
+
+- **Update phase trackers** in the same PR (post-merge bookkeeping flips 017 to 🟢, Phase 3 1/3 🟡).
+
+**Out of scope:**
+
+- Activity Feed UI. Spec 018 — components + AppLayout right-rail wiring + dedicated activity page (if it earns its keep).
+- Real-time broadcasting via Reverb. Spec 019 — `ActivityEventCreated` event + Echo client + frontend subscription.
+- Handlers for `workflow_run`, `push`, `release`, `check_run`, `check_suite`, `deployment`, `deployment_status`, `repository`, `pull_request_review`. Spec 019 extends the handler set once the broadcast layer is in place so the now-live feed has more event types flowing through.
+- Per-repo webhook subscription registration via the GitHub Apps API. Manual webhook URL config on the GitHub App is sufficient for phase 1.
+- Webhook delivery retry / replay UI. The `failed` state captures the audit trail; surfacing it visually is a phase 9 polish.
+- `team_id` / `project_id` / `actor_user_id` columns on `activity_events`. Phase-1 ties activity to a single owner via `repository_id → project → owner`; multi-team scoping ships later.
+- Webhook delivery rate-limiting / DDoS protection. Phase-1 single-user dev doesn't need it.
+
+## Plan
+
+1. **Migrations.** `create_github_webhook_deliveries_table` + `create_activity_events_table`. Both with the §8.5 / §8.10 fields plus the indexes called out above.
+2. **Models + enums.** `WebhookDelivery`, `ActivityEvent`, `WebhookDeliveryStatus`, `ActivitySeverity`. Factories for both models.
+3. **`VerifyGitHubWebhookSignatureAction`.** Pure HMAC-SHA-256 + `hash_equals`. No DI other than the secret string.
+4. **Config** + `.env.example` entry.
+5. **`CreateActivityEventAction`.** One method, validated insert.
+6. **`GitHubWebhookController` + route + CSRF exclusion.** Raw-body read, signature gate, idempotency check, dispatch.
+7. **`ProcessGitHubWebhookJob`.** Routing switch by `event`. `tries = 1` consistent with spec 014/015/016 jobs. Status flips at the end of each branch.
+8. **`IssuesWebhookHandler` + `PullRequestWebhookHandler`.** Reuse the spec 015/016 normalizers — they're already pure mappers from a single GitHub payload to an upsert array.
+9. **Tests.** Six test files. Use Laravel's `$this->withoutMiddleware(VerifyCsrfToken::class)` is NOT needed — the route is excluded; we can post directly. Build a small `signedPayload($body, $secret)` test helper that returns `['Content-Type' => 'application/json', 'X-Hub-Signature-256' => 'sha256=' . hash_hmac('sha256', $body, $secret), 'X-GitHub-Delivery' => Str::uuid(), 'X-GitHub-Event' => $event]`.
+10. **Pipeline** — Pint, vue-tsc, build, full PHP test run.
+11. **Self-review** with `superpowers:code-reviewer`.
+
+## Acceptance criteria
+- [ ] Migration creates `github_webhook_deliveries` (with `github_delivery_id` unique + `(event, action)` index) and `activity_events` (with `occurred_at` index, nullable `repository_id` FK).
+- [ ] `VerifyGitHubWebhookSignatureAction` returns `false` for tampered bodies and `true` for legitimate ones; uses `hash_equals` (timing-safe).
+- [ ] `POST /webhooks/github` returns 401 + does NOT insert a delivery row when the signature is invalid.
+- [ ] Valid signature → delivery row inserted with `status = received`, `ProcessGitHubWebhookJob` dispatched (verified via `Queue::fake()`), 200 returned.
+- [ ] Duplicate `X-GitHub-Delivery` header → second request returns 200 with no second insert and no second dispatch.
+- [ ] `ProcessGitHubWebhookJob` flips status to `processed` on success, `failed` on caught exception (with `error_message`), `skipped` on unhandled event.
+- [ ] `issues.opened` payload upserts the local `github_issues` row AND creates an `issue.created` activity event.
+- [ ] `pull_request.opened` upserts `github_pull_requests` AND creates a `pull_request.opened` activity event.
+- [ ] `pull_request.closed` with `merged=true` creates a `pull_request.merged` activity event (severity `success`); `merged=false` creates `pull_request.closed` (severity `info`).
+- [ ] PR-shaped `issues` webhook payloads (with `pull_request` key) are dropped at the handler level, not double-processed.
+- [ ] Webhook for a repo not yet imported into Nexus marks the delivery `skipped` with a clear `error_message` (NOT `failed`).
+- [ ] Pint + vue-tsc + build clean. CI green.
+- [ ] Self-review pass with `superpowers:code-reviewer`.
+
+## Files touched
+- `database/migrations/<ts>_create_github_webhook_deliveries_table.php` — new.
+- `database/migrations/<ts>_create_activity_events_table.php` — new.
+- `app/Models/WebhookDelivery.php` — new.
+- `app/Models/ActivityEvent.php` — new.
+- `app/Enums/WebhookDeliveryStatus.php` — new.
+- `app/Enums/ActivitySeverity.php` — new.
+- `app/Domain/GitHub/Actions/VerifyGitHubWebhookSignatureAction.php` — new.
+- `app/Domain/GitHub/Jobs/ProcessGitHubWebhookJob.php` — new.
+- `app/Domain/GitHub/WebhookHandlers/IssuesWebhookHandler.php` — new.
+- `app/Domain/GitHub/WebhookHandlers/PullRequestWebhookHandler.php` — new.
+- `app/Domain/Activity/Actions/CreateActivityEventAction.php` — new.
+- `app/Http/Controllers/Webhooks/GitHubWebhookController.php` — new.
+- `bootstrap/app.php` — extend the CSRF `$except` config to skip `webhooks/github`.
+- `config/services.php` — add `github.webhook_secret`.
+- `.env.example` — `GITHUB_WEBHOOK_SECRET`.
+- `routes/web.php` — `Route::post('/webhooks/github', …)`.
+- `database/factories/WebhookDeliveryFactory.php` — new.
+- `database/factories/ActivityEventFactory.php` — new.
+- `tests/Feature/GitHub/Webhooks/VerifyGitHubWebhookSignatureActionTest.php` — new.
+- `tests/Feature/GitHub/Webhooks/GitHubWebhookControllerTest.php` — new.
+- `tests/Feature/GitHub/Webhooks/ProcessGitHubWebhookJobTest.php` — new.
+- `tests/Feature/GitHub/Webhooks/IssuesWebhookHandlerTest.php` — new.
+- `tests/Feature/GitHub/Webhooks/PullRequestWebhookHandlerTest.php` — new.
+- `tests/Feature/Activity/CreateActivityEventActionTest.php` — new.
+
+## Work log
+Dated notes as work progresses.
+
+### 2026-04-29
+- Spec drafted; scope confirmed (decisions locked: phase-1 simplifications on `activity_events` (skip team_id/project_id/actor_user_id), initial handler set issues + pull_request only, idempotency via X-GitHub-Delivery unique, bad signature → 401 + zero side effects, unhandled events → `skipped` not `failed`, no GitHub Apps API automation for webhook subscription, `tries = 1` for the processing job).
+- Opened issue [#45](https://github.com/Copxer/nexus/issues/45) and branch `spec/017-webhook-ingestion-and-activity-events` off `main`.
+- Implementation complete: migrations + `WebhookDelivery` + `ActivityEvent` models + `WebhookDeliveryStatus` + `ActivitySeverity` enums + factories, `VerifyGitHubWebhookSignatureAction`, `CreateActivityEventAction`, `GitHubWebhookController` + route + `bootstrap/app.php` CSRF exclusion (using Laravel 13's `preventRequestForgery`), `ProcessGitHubWebhookJob` with handler routing, `IssuesWebhookHandler` + `PullRequestWebhookHandler`. 6 new test files: 204 tests / 847 assertions green. Pint/build clean.
+- No manual UX walk — this spec is backend-only by design (spec 018 lights up the visible feed).
+
+## Decisions (locked 2026-04-29)
+- **Activity-events phase-1 simplification.** Skip `team_id` / `project_id` / `actor_user_id`; phase-1 derives ownership via `repository_id → project → owner`. Multi-tenant lands later.
+- **Initial handler set: `issues` + `pull_request` only.** Enough to satisfy phase 3's acceptance criteria. Spec 019 extends to `workflow_run`, `push`, etc. once Reverb is wired.
+- **Idempotency via `X-GitHub-Delivery` unique.** GitHub retries on timeout; the unique index + lookup-before-insert path handles it.
+- **Bad signature: 401 + zero side effects.** No row inserted for unauthenticated requests so an attacker can't fill the deliveries table.
+- **Unhandled events → `skipped`.** Per §8.5 "Log unknown events. Do not fail silently." `failed` is reserved for handler exceptions.
+- **No webhook-subscription automation.** The GitHub App admin manually points a webhook URL at the dev/prod server. Per-repo subscription via Apps API is phase 9 polish if it earns its keep.
+- **`tries = 1` for `ProcessGitHubWebhookJob`.** Mirror the existing sync jobs; if processing fails it lands in the `failed` state on the delivery row and stays there. Replay UI is phase 9.
+
+## Open questions / blockers
+
+- **CSRF exclusion in Laravel 11/13.** Modern Laravel uses `bootstrap/app.php` `withMiddleware()` config. Need to confirm the syntax for adding to `$except` for the webhooks route.
+- **Raw-body access in tests.** `$this->postJson()` runs the body through Laravel's JSON parser. Use `$this->call('POST', $url, [], [], [], $headers, $rawBody)` or `$this->postJson()` with the full payload — verify the controller reads the right thing in tests.
+- **PHP 8.5 + Laravel 13.6 CSRF-in-tests issue.** Pre-existing; webhook route is CSRF-excluded so this should not bite.

--- a/specs/phase-3-webhooks-activity/README.md
+++ b/specs/phase-3-webhooks-activity/README.md
@@ -1,0 +1,23 @@
+# Phase 3 — GitHub Webhooks & Activity Feed
+
+Source: [roadmap §19 Phase 3](../../nexus_control_center_roadmap.md), §8.5 Webhooks, §8.10 Activity Feed.
+
+## Phase goal
+Make GitHub updates near real-time. After this phase, importing a repo wires a GitHub App webhook subscription so issue/PR/workflow events flow into Nexus without polling. Each event lands as a row in `github_webhook_deliveries` (raw audit trail) and creates one or more `activity_events` rows (the Nexus-side semantic event stream). The AppLayout right-rail and a dedicated activity page render those events; the same events broadcast over Reverb so the UI reflects them without reload.
+
+## Tasks
+
+| # | Task | Status |
+|---|------|--------|
+| 017 | GitHub webhook ingestion + activity events (receiver, signature verification, delivery storage, `issues` + `pull_request` handlers, `activity_events` table + `CreateActivityEventAction`) | ⬜ |
+| 018 | Activity Feed UI (replace AppLayout right-rail mock with real activity, `ActivityFeed.vue` + `ActivityFeedItem.vue`, page-load fresh) | ⬜ |
+| 019 | Real-time broadcasting via Reverb (Echo wiring, `ActivityEventCreated` broadcast, extend handler set to `workflow_run`/`push`/`release`) | ⬜ |
+
+## Acceptance criteria (phase-level)
+- [ ] GitHub webhook endpoint at `POST /webhooks/github` accepts signed payloads.
+- [ ] Invalid `X-Hub-Signature-256` signatures are rejected with 401 and never stored.
+- [ ] Duplicate deliveries (same `X-GitHub-Delivery` header) are detected and not double-processed.
+- [ ] Issue and PR webhook events update the local `github_issues` / `github_pull_requests` rows and create matching `activity_events`.
+- [ ] Activity Feed UI surfaces real events on the AppLayout right-rail (and on a dedicated activity page if 018 ships one).
+- [ ] UI updates in real time when new events land — no manual refresh needed.
+- [ ] No real GitHub credentials in CI; tests use signed fixture payloads + `Queue::fake()`.

--- a/tests/Feature/Activity/CreateActivityEventActionTest.php
+++ b/tests/Feature/Activity/CreateActivityEventActionTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature\Activity;
+
+use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Enums\ActivitySeverity;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+class CreateActivityEventActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private CreateActivityEventAction $action;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->action = new CreateActivityEventAction;
+    }
+
+    public function test_creates_a_row_with_normalized_fields(): void
+    {
+        $event = $this->action->execute([
+            'event_type' => 'issue.created',
+            'title' => 'New login bug',
+            'occurred_at' => Carbon::parse('2026-04-15T12:00:00Z'),
+            'severity' => ActivitySeverity::Info,
+            'actor_login' => 'alice',
+            'metadata' => ['issue_number' => 42],
+        ]);
+
+        $this->assertDatabaseHas('activity_events', [
+            'id' => $event->id,
+            'event_type' => 'issue.created',
+            'title' => 'New login bug',
+            'severity' => 'info',
+            'source' => 'github',
+            'actor_login' => 'alice',
+        ]);
+        $this->assertSame(['issue_number' => 42], $event->fresh()->metadata);
+    }
+
+    public function test_accepts_string_severity(): void
+    {
+        $event = $this->action->execute([
+            'event_type' => 'issue.closed',
+            'title' => 'Closed',
+            'occurred_at' => now(),
+            'severity' => 'success',
+        ]);
+
+        $this->assertSame('success', $event->severity->value);
+    }
+
+    public function test_defaults_optional_fields(): void
+    {
+        $event = $this->action->execute([
+            'event_type' => 'issue.created',
+            'title' => 'Bare-bones',
+            'occurred_at' => now(),
+        ]);
+
+        $this->assertSame('info', $event->severity->value);
+        $this->assertSame('github', $event->source);
+        $this->assertSame([], $event->metadata);
+        $this->assertNull($event->actor_login);
+        $this->assertNull($event->repository_id);
+    }
+
+    public function test_throws_when_event_type_is_missing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->action->execute([
+            'title' => 'No event type',
+            'occurred_at' => now(),
+        ]);
+    }
+
+    public function test_throws_when_title_is_missing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->action->execute([
+            'event_type' => 'issue.created',
+            'occurred_at' => now(),
+        ]);
+    }
+
+    public function test_throws_when_occurred_at_is_not_a_carbon(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->action->execute([
+            'event_type' => 'issue.created',
+            'title' => 'No timestamp',
+            'occurred_at' => '2026-04-15T12:00:00Z',
+        ]);
+    }
+}

--- a/tests/Feature/GitHub/Webhooks/GitHubWebhookControllerTest.php
+++ b/tests/Feature/GitHub/Webhooks/GitHubWebhookControllerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature\GitHub\Webhooks;
+
+use App\Domain\GitHub\Jobs\ProcessGitHubWebhookJob;
+use App\Models\WebhookDelivery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+class GitHubWebhookControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const SECRET = 'whsec_test_secret';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['services.github.webhook_secret' => self::SECRET]);
+    }
+
+    private function signedPost(string $body, array $headers): TestResponse
+    {
+        return $this->call(
+            'POST',
+            route('webhooks.github'),
+            [],
+            [],
+            [],
+            $this->serverHeaders($headers),
+            $body,
+        );
+    }
+
+    /** Convert simple header keys to Symfony's `HTTP_*` form. */
+    private function serverHeaders(array $headers): array
+    {
+        $out = [];
+        foreach ($headers as $name => $value) {
+            $key = 'HTTP_'.strtoupper(str_replace('-', '_', $name));
+            $out[$key] = $value;
+        }
+        $out['CONTENT_TYPE'] = 'application/json';
+
+        return $out;
+    }
+
+    private function sign(string $body): string
+    {
+        return 'sha256='.hash_hmac('sha256', $body, self::SECRET);
+    }
+
+    public function test_invalid_signature_returns_401_and_does_not_insert_a_row(): void
+    {
+        Queue::fake();
+        $body = json_encode(['action' => 'opened']);
+
+        $response = $this->signedPost($body, [
+            'X-GitHub-Event' => 'issues',
+            'X-GitHub-Delivery' => 'delivery-1',
+            'X-Hub-Signature-256' => 'sha256=deadbeef',
+        ]);
+
+        $response->assertStatus(401);
+        $this->assertSame(0, WebhookDelivery::query()->count());
+        Queue::assertNotPushed(ProcessGitHubWebhookJob::class);
+    }
+
+    public function test_missing_signature_header_is_rejected(): void
+    {
+        $body = json_encode(['action' => 'opened']);
+
+        $this->signedPost($body, [
+            'X-GitHub-Event' => 'issues',
+            'X-GitHub-Delivery' => 'delivery-1',
+        ])->assertStatus(401);
+
+        $this->assertSame(0, WebhookDelivery::query()->count());
+    }
+
+    public function test_valid_signature_inserts_row_and_dispatches_job(): void
+    {
+        Queue::fake();
+        $body = json_encode([
+            'action' => 'opened',
+            'repository' => ['full_name' => 'octocat/hello-world'],
+            'issue' => ['id' => 1, 'number' => 1, 'title' => 'Bug'],
+        ]);
+
+        $this->signedPost($body, [
+            'X-GitHub-Event' => 'issues',
+            'X-GitHub-Delivery' => 'delivery-A',
+            'X-Hub-Signature-256' => $this->sign($body),
+        ])->assertStatus(200);
+
+        $this->assertSame(1, WebhookDelivery::query()->count());
+        $this->assertDatabaseHas('github_webhook_deliveries', [
+            'github_delivery_id' => 'delivery-A',
+            'event' => 'issues',
+            'action' => 'opened',
+            'repository_full_name' => 'octocat/hello-world',
+            'status' => 'received',
+        ]);
+        Queue::assertPushed(ProcessGitHubWebhookJob::class, 1);
+    }
+
+    public function test_duplicate_delivery_id_is_idempotent(): void
+    {
+        Queue::fake();
+        $body = json_encode([
+            'action' => 'opened',
+            'repository' => ['full_name' => 'octocat/hello-world'],
+        ]);
+        $headers = [
+            'X-GitHub-Event' => 'issues',
+            'X-GitHub-Delivery' => 'delivery-DUP',
+            'X-Hub-Signature-256' => $this->sign($body),
+        ];
+
+        $this->signedPost($body, $headers)->assertStatus(200);
+        $this->signedPost($body, $headers)->assertStatus(200);
+
+        $this->assertSame(1, WebhookDelivery::query()->count());
+        Queue::assertPushed(ProcessGitHubWebhookJob::class, 1);
+    }
+
+    public function test_missing_event_or_delivery_header_is_rejected(): void
+    {
+        $body = json_encode(['action' => 'opened']);
+
+        $this->signedPost($body, [
+            'X-GitHub-Event' => 'issues',
+            'X-Hub-Signature-256' => $this->sign($body),
+        ])->assertStatus(400);
+
+        $this->signedPost($body, [
+            'X-GitHub-Delivery' => 'delivery-X',
+            'X-Hub-Signature-256' => $this->sign($body),
+        ])->assertStatus(400);
+
+        $this->assertSame(0, WebhookDelivery::query()->count());
+    }
+}

--- a/tests/Feature/GitHub/Webhooks/GitHubWebhookControllerTest.php
+++ b/tests/Feature/GitHub/Webhooks/GitHubWebhookControllerTest.php
@@ -64,6 +64,8 @@ class GitHubWebhookControllerTest extends TestCase
         ]);
 
         $response->assertStatus(401);
+        // Don't echo anything to a request we couldn't authenticate.
+        $this->assertSame('', $response->getContent());
         $this->assertSame(0, WebhookDelivery::query()->count());
         Queue::assertNotPushed(ProcessGitHubWebhookJob::class);
     }

--- a/tests/Feature/GitHub/Webhooks/IssuesWebhookHandlerTest.php
+++ b/tests/Feature/GitHub/Webhooks/IssuesWebhookHandlerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Tests\Feature\GitHub\Webhooks;
+
+use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Domain\GitHub\Actions\NormalizeGitHubIssueAction;
+use App\Domain\GitHub\WebhookHandlers\IssuesWebhookHandler;
+use App\Enums\WebhookDeliveryStatus;
+use App\Models\ActivityEvent;
+use App\Models\GithubIssue;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\WebhookDelivery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IssuesWebhookHandlerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function handler(): IssuesWebhookHandler
+    {
+        return new IssuesWebhookHandler(
+            new NormalizeGitHubIssueAction,
+            new CreateActivityEventAction,
+        );
+    }
+
+    private function deliveryFor(string $action, array $issueOverrides = [], string $fullName = 'octocat/hello-world'): WebhookDelivery
+    {
+        return WebhookDelivery::factory()->create([
+            'event' => 'issues',
+            'action' => $action,
+            'repository_full_name' => $fullName,
+            'payload_json' => [
+                'action' => $action,
+                'repository' => ['full_name' => $fullName],
+                'issue' => array_merge([
+                    'id' => 7,
+                    'number' => 42,
+                    'title' => 'Test issue',
+                    'state' => 'open',
+                    'user' => ['login' => 'alice'],
+                    'updated_at' => '2026-04-15T12:00:00Z',
+                    'closed_at' => null,
+                ], $issueOverrides),
+                'sender' => ['login' => 'alice'],
+            ],
+        ]);
+    }
+
+    private function importedRepository(string $fullName = 'octocat/hello-world'): Repository
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        return Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => $fullName,
+        ]);
+    }
+
+    public function test_opened_creates_issue_and_info_activity(): void
+    {
+        $repository = $this->importedRepository();
+        $delivery = $this->deliveryFor('opened');
+
+        $status = $this->handler()->handle($delivery);
+
+        $this->assertSame(WebhookDeliveryStatus::Processed, $status);
+        $this->assertSame(1, GithubIssue::query()->count());
+        $this->assertDatabaseHas('activity_events', [
+            'event_type' => 'issue.created',
+            'severity' => 'info',
+            'repository_id' => $repository->id,
+        ]);
+    }
+
+    public function test_closed_creates_success_activity(): void
+    {
+        $this->importedRepository();
+        $delivery = $this->deliveryFor('closed', [
+            'state' => 'closed',
+            'closed_at' => '2026-04-20T00:00:00Z',
+        ]);
+
+        $this->handler()->handle($delivery);
+
+        $this->assertDatabaseHas('activity_events', [
+            'event_type' => 'issue.closed',
+            'severity' => 'success',
+        ]);
+    }
+
+    public function test_reopened_and_edited_create_info_activities(): void
+    {
+        $this->importedRepository();
+
+        $this->handler()->handle($this->deliveryFor('reopened'));
+        $this->handler()->handle($this->deliveryFor('edited'));
+
+        $this->assertDatabaseHas('activity_events', ['event_type' => 'issue.reopened']);
+        $this->assertDatabaseHas('activity_events', ['event_type' => 'issue.updated']);
+    }
+
+    public function test_unknown_action_is_skipped(): void
+    {
+        $this->importedRepository();
+        $delivery = $this->deliveryFor('locked');
+
+        $status = $this->handler()->handle($delivery);
+
+        $this->assertSame(WebhookDeliveryStatus::Skipped, $status);
+        $this->assertSame(0, ActivityEvent::query()->count());
+        $this->assertNotNull($delivery->fresh()->error_message);
+    }
+
+    public function test_pull_request_shaped_payload_is_skipped(): void
+    {
+        $this->importedRepository();
+        $delivery = $this->deliveryFor('opened', [
+            'pull_request' => ['url' => 'https://api.github.com/...'],
+        ]);
+
+        $status = $this->handler()->handle($delivery);
+
+        $this->assertSame(WebhookDeliveryStatus::Skipped, $status);
+        $this->assertSame(0, ActivityEvent::query()->count());
+    }
+
+    public function test_unimported_repository_is_skipped(): void
+    {
+        // No Repository row exists for this full_name.
+        $delivery = $this->deliveryFor('opened', [], 'someone/notimported');
+
+        $status = $this->handler()->handle($delivery);
+
+        $this->assertSame(WebhookDeliveryStatus::Skipped, $status);
+        $this->assertSame(0, ActivityEvent::query()->count());
+        $this->assertSame(
+            'Repository not imported into Nexus.',
+            $delivery->fresh()->error_message,
+        );
+    }
+}

--- a/tests/Feature/GitHub/Webhooks/ProcessGitHubWebhookJobTest.php
+++ b/tests/Feature/GitHub/Webhooks/ProcessGitHubWebhookJobTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Tests\Feature\GitHub\Webhooks;
+
+use App\Domain\GitHub\Jobs\ProcessGitHubWebhookJob;
+use App\Domain\GitHub\WebhookHandlers\IssuesWebhookHandler;
+use App\Enums\WebhookDeliveryStatus;
+use App\Models\ActivityEvent;
+use App\Models\GithubIssue;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\WebhookDelivery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class ProcessGitHubWebhookJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function repository(string $fullName = 'octocat/hello-world'): Repository
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        return Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => $fullName,
+        ]);
+    }
+
+    public function test_handles_issues_opened_payload(): void
+    {
+        $repository = $this->repository();
+
+        $delivery = WebhookDelivery::factory()->create([
+            'event' => 'issues',
+            'action' => 'opened',
+            'repository_full_name' => $repository->full_name,
+            'status' => WebhookDeliveryStatus::Received->value,
+            'payload_json' => [
+                'action' => 'opened',
+                'repository' => ['full_name' => $repository->full_name],
+                'issue' => [
+                    'id' => 1234,
+                    'number' => 7,
+                    'title' => 'Login fails',
+                    'state' => 'open',
+                    'user' => ['login' => 'alice'],
+                    'created_at' => '2026-04-01T00:00:00Z',
+                    'updated_at' => '2026-04-15T00:00:00Z',
+                ],
+                'sender' => ['login' => 'alice'],
+            ],
+        ]);
+
+        (new ProcessGitHubWebhookJob($delivery->id))->handle();
+
+        $this->assertSame(
+            WebhookDeliveryStatus::Processed,
+            $delivery->fresh()->status,
+        );
+        $this->assertSame(1, GithubIssue::query()->count());
+        $this->assertDatabaseHas('activity_events', [
+            'event_type' => 'issue.created',
+            'severity' => 'info',
+            'actor_login' => 'alice',
+            'repository_id' => $repository->id,
+        ]);
+    }
+
+    public function test_handles_pull_request_merged_payload(): void
+    {
+        $repository = $this->repository();
+
+        $delivery = WebhookDelivery::factory()->create([
+            'event' => 'pull_request',
+            'action' => 'closed',
+            'repository_full_name' => $repository->full_name,
+            'status' => WebhookDeliveryStatus::Received->value,
+            'payload_json' => [
+                'action' => 'closed',
+                'repository' => ['full_name' => $repository->full_name],
+                'pull_request' => [
+                    'id' => 9999,
+                    'number' => 12,
+                    'title' => 'Add caching',
+                    'state' => 'closed',
+                    'merged' => true,
+                    'merged_at' => '2026-04-20T00:00:00Z',
+                    'base' => ['ref' => 'main'],
+                    'head' => ['ref' => 'topic/cache'],
+                ],
+                'sender' => ['login' => 'bob'],
+            ],
+        ]);
+
+        (new ProcessGitHubWebhookJob($delivery->id))->handle();
+
+        $this->assertSame(WebhookDeliveryStatus::Processed, $delivery->fresh()->status);
+        $this->assertDatabaseHas('github_pull_requests', [
+            'github_id' => 9999,
+            'state' => 'merged',
+        ]);
+        $this->assertDatabaseHas('activity_events', [
+            'event_type' => 'pull_request.merged',
+            'severity' => 'success',
+            'actor_login' => 'bob',
+        ]);
+    }
+
+    public function test_unhandled_event_is_skipped_and_does_not_create_activity(): void
+    {
+        Log::spy();
+        $delivery = WebhookDelivery::factory()->create([
+            'event' => 'milestone',
+            'action' => 'created',
+            'status' => WebhookDeliveryStatus::Received->value,
+            'payload_json' => ['action' => 'created'],
+        ]);
+
+        (new ProcessGitHubWebhookJob($delivery->id))->handle();
+
+        $this->assertSame(WebhookDeliveryStatus::Skipped, $delivery->fresh()->status);
+        $this->assertNotNull($delivery->fresh()->processed_at);
+        $this->assertSame(0, ActivityEvent::query()->count());
+        Log::shouldHaveReceived('info')->atLeast()->once();
+    }
+
+    public function test_handler_exception_flips_to_failed_with_error_message(): void
+    {
+        // Force an exception path: an `issues` event with a non-array
+        // `issue` block trips the normalizer and the handler returns
+        // Skipped — that's the polite path. Here we want the
+        // exception-caught path. Easiest reproduction: omit the
+        // `payload_json` array on the row so $delivery->payload_json
+        // is null and the handler's array spread blows up.
+        $delivery = WebhookDelivery::factory()->create([
+            'event' => 'issues',
+            'action' => 'opened',
+            'repository_full_name' => 'whoever/whatever',
+            'status' => WebhookDeliveryStatus::Received->value,
+            // Force the JSON cast to be empty array, then we'll mutate
+            // raw to break it. Eloquent's `array` cast tolerates null;
+            // simpler: rely on missing repository to take the Skipped
+            // branch and assert that path instead. We test the actual
+            // exception-path via the job's `try { … } catch` by
+            // breaking the handler resolution itself — we'll override
+            // the container binding.
+        ]);
+
+        // Re-bind the handler to throw on `handle`.
+        $this->app->bind(
+            IssuesWebhookHandler::class,
+            fn () => new class
+            {
+                public function handle($delivery)
+                {
+                    throw new \RuntimeException(
+                        "Synthetic boom on delivery #{$delivery->id}",
+                    );
+                }
+            },
+        );
+
+        (new ProcessGitHubWebhookJob($delivery->id))->handle();
+
+        $fresh = $delivery->fresh();
+        $this->assertSame(WebhookDeliveryStatus::Failed, $fresh->status);
+        $this->assertStringStartsWith('Synthetic boom', $fresh->error_message);
+        $this->assertNotNull($fresh->processed_at);
+    }
+
+    public function test_handle_is_a_no_op_when_delivery_is_missing(): void
+    {
+        (new ProcessGitHubWebhookJob(999_999))->handle();
+
+        $this->assertSame(0, WebhookDelivery::query()->count());
+        $this->assertSame(0, ActivityEvent::query()->count());
+    }
+}

--- a/tests/Feature/GitHub/Webhooks/ProcessGitHubWebhookJobTest.php
+++ b/tests/Feature/GitHub/Webhooks/ProcessGitHubWebhookJobTest.php
@@ -130,24 +130,14 @@ class ProcessGitHubWebhookJobTest extends TestCase
 
     public function test_handler_exception_flips_to_failed_with_error_message(): void
     {
-        // Force an exception path: an `issues` event with a non-array
-        // `issue` block trips the normalizer and the handler returns
-        // Skipped — that's the polite path. Here we want the
-        // exception-caught path. Easiest reproduction: omit the
-        // `payload_json` array on the row so $delivery->payload_json
-        // is null and the handler's array spread blows up.
+        // Re-bind the issues handler to throw — exercises the job's
+        // catch path that flips status to `failed` and captures the
+        // exception message into `error_message`.
         $delivery = WebhookDelivery::factory()->create([
             'event' => 'issues',
             'action' => 'opened',
             'repository_full_name' => 'whoever/whatever',
             'status' => WebhookDeliveryStatus::Received->value,
-            // Force the JSON cast to be empty array, then we'll mutate
-            // raw to break it. Eloquent's `array` cast tolerates null;
-            // simpler: rely on missing repository to take the Skipped
-            // branch and assert that path instead. We test the actual
-            // exception-path via the job's `try { … } catch` by
-            // breaking the handler resolution itself — we'll override
-            // the container binding.
         ]);
 
         // Re-bind the handler to throw on `handle`.

--- a/tests/Feature/GitHub/Webhooks/PullRequestWebhookHandlerTest.php
+++ b/tests/Feature/GitHub/Webhooks/PullRequestWebhookHandlerTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Feature\GitHub\Webhooks;
+
+use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Domain\GitHub\Actions\NormalizeGitHubPullRequestAction;
+use App\Domain\GitHub\WebhookHandlers\PullRequestWebhookHandler;
+use App\Enums\WebhookDeliveryStatus;
+use App\Models\GithubPullRequest;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\WebhookDelivery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PullRequestWebhookHandlerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function handler(): PullRequestWebhookHandler
+    {
+        return new PullRequestWebhookHandler(
+            new NormalizeGitHubPullRequestAction,
+            new CreateActivityEventAction,
+        );
+    }
+
+    private function importedRepository(string $fullName = 'octocat/hello-world'): Repository
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        return Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => $fullName,
+        ]);
+    }
+
+    private function deliveryFor(string $action, array $prOverrides = [], string $fullName = 'octocat/hello-world'): WebhookDelivery
+    {
+        return WebhookDelivery::factory()->create([
+            'event' => 'pull_request',
+            'action' => $action,
+            'repository_full_name' => $fullName,
+            'payload_json' => [
+                'action' => $action,
+                'repository' => ['full_name' => $fullName],
+                'pull_request' => array_merge([
+                    'id' => 9999,
+                    'number' => 12,
+                    'title' => 'Add caching',
+                    'state' => 'open',
+                    'merged' => false,
+                    'merged_at' => null,
+                    'base' => ['ref' => 'main'],
+                    'head' => ['ref' => 'topic/cache'],
+                    'updated_at' => '2026-04-15T00:00:00Z',
+                ], $prOverrides),
+                'sender' => ['login' => 'bob'],
+            ],
+        ]);
+    }
+
+    public function test_opened_creates_pr_and_info_activity(): void
+    {
+        $repository = $this->importedRepository();
+        $delivery = $this->deliveryFor('opened');
+
+        $status = $this->handler()->handle($delivery);
+
+        $this->assertSame(WebhookDeliveryStatus::Processed, $status);
+        $this->assertSame(1, GithubPullRequest::query()->count());
+        $this->assertDatabaseHas('activity_events', [
+            'event_type' => 'pull_request.opened',
+            'severity' => 'info',
+            'repository_id' => $repository->id,
+        ]);
+    }
+
+    public function test_closed_with_merged_creates_merged_activity(): void
+    {
+        $this->importedRepository();
+        $delivery = $this->deliveryFor('closed', [
+            'state' => 'closed',
+            'merged' => true,
+            'merged_at' => '2026-04-20T00:00:00Z',
+        ]);
+
+        $this->handler()->handle($delivery);
+
+        $this->assertDatabaseHas('activity_events', [
+            'event_type' => 'pull_request.merged',
+            'severity' => 'success',
+        ]);
+        $this->assertDatabaseHas('github_pull_requests', [
+            'state' => 'merged',
+            'merged' => true,
+        ]);
+    }
+
+    public function test_closed_without_merge_creates_closed_activity(): void
+    {
+        $this->importedRepository();
+        $delivery = $this->deliveryFor('closed', [
+            'state' => 'closed',
+            'merged' => false,
+            'closed_at' => '2026-04-20T00:00:00Z',
+        ]);
+
+        $this->handler()->handle($delivery);
+
+        $this->assertDatabaseHas('activity_events', [
+            'event_type' => 'pull_request.closed',
+            'severity' => 'info',
+        ]);
+        $this->assertDatabaseHas('github_pull_requests', [
+            'state' => 'closed',
+            'merged' => false,
+        ]);
+    }
+
+    public function test_reopened_and_review_requested_create_info_activities(): void
+    {
+        $this->importedRepository();
+
+        $this->handler()->handle($this->deliveryFor('reopened'));
+        $this->handler()->handle($this->deliveryFor('review_requested'));
+
+        $this->assertDatabaseHas('activity_events', ['event_type' => 'pull_request.reopened']);
+        $this->assertDatabaseHas('activity_events', ['event_type' => 'pull_request.review_requested']);
+    }
+
+    public function test_unknown_action_is_skipped(): void
+    {
+        $this->importedRepository();
+        $delivery = $this->deliveryFor('synchronize');
+
+        $status = $this->handler()->handle($delivery);
+
+        $this->assertSame(WebhookDeliveryStatus::Skipped, $status);
+        $this->assertNotNull($delivery->fresh()->error_message);
+    }
+
+    public function test_unimported_repository_is_skipped(): void
+    {
+        $delivery = $this->deliveryFor('opened', [], 'someone/notimported');
+
+        $status = $this->handler()->handle($delivery);
+
+        $this->assertSame(WebhookDeliveryStatus::Skipped, $status);
+        $this->assertSame(
+            'Repository not imported into Nexus.',
+            $delivery->fresh()->error_message,
+        );
+    }
+}

--- a/tests/Feature/GitHub/Webhooks/VerifyGitHubWebhookSignatureActionTest.php
+++ b/tests/Feature/GitHub/Webhooks/VerifyGitHubWebhookSignatureActionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\GitHub\Webhooks;
+
+use App\Domain\GitHub\Actions\VerifyGitHubWebhookSignatureAction;
+use Tests\TestCase;
+
+class VerifyGitHubWebhookSignatureActionTest extends TestCase
+{
+    private VerifyGitHubWebhookSignatureAction $action;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->action = new VerifyGitHubWebhookSignatureAction;
+    }
+
+    public function test_returns_true_for_a_correctly_signed_body(): void
+    {
+        $body = '{"action":"opened"}';
+        $secret = 'whsec_dev_secret';
+        $signature = 'sha256='.hash_hmac('sha256', $body, $secret);
+
+        $this->assertTrue($this->action->execute($body, $signature, $secret));
+    }
+
+    public function test_returns_false_for_a_tampered_body(): void
+    {
+        $secret = 'whsec_dev_secret';
+        $signature = 'sha256='.hash_hmac('sha256', '{"action":"opened"}', $secret);
+
+        // Same secret + signature, different body → must reject.
+        $this->assertFalse(
+            $this->action->execute('{"action":"closed"}', $signature, $secret),
+        );
+    }
+
+    public function test_returns_false_when_secret_is_empty(): void
+    {
+        $body = '{"action":"opened"}';
+        $signature = 'sha256='.hash_hmac('sha256', $body, '');
+
+        // Even if the math checks out, an empty secret means the app
+        // isn't configured — fail closed.
+        $this->assertFalse($this->action->execute($body, $signature, ''));
+    }
+
+    public function test_returns_false_when_signature_header_is_missing(): void
+    {
+        $this->assertFalse(
+            $this->action->execute('{"action":"opened"}', null, 'whsec_dev_secret'),
+        );
+    }
+
+    public function test_returns_false_when_signature_header_is_empty(): void
+    {
+        $this->assertFalse(
+            $this->action->execute('{"action":"opened"}', '', 'whsec_dev_secret'),
+        );
+    }
+}


### PR DESCRIPTION
Closes #45

Spec: \`specs/phase-3-webhooks-activity/017-webhook-ingestion-and-activity-events.md\`

First spec of Phase 3 — backend-only. Spec 018 will surface the visible feed; spec 019 will add Reverb broadcasting + extend the handler set.

## Summary

- New \`github_webhook_deliveries\` table (X-GitHub-Delivery unique for idempotency, (event, action) compound index for filtering) + \`activity_events\` table with §8.10 fields, phase-1 simplified (skip team_id/project_id/actor_user_id; ownership derived via repository_id → project → owner).
- New \`WebhookDeliveryStatus\` (received/processed/failed/skipped) and \`ActivitySeverity\` (info/success/warning/danger) enums.
- \`VerifyGitHubWebhookSignatureAction\` — pure HMAC-SHA-256 + \`hash_equals\` (timing-safe). Empty secret OR empty signature header fails closed.
- \`CreateActivityEventAction\` — single funnel for all activity origins (webhooks today; spec 019 hooks broadcasting here once).
- \`GitHubWebhookController\` — verify signature (bad → 401 with empty body, no DB write), idempotency check by X-GitHub-Delivery, insert delivery row, dispatch job. Catches \`UniqueConstraintViolationException\` on the post-lookup create() so a concurrent-retry race acks 200 instead of 500-ing.
- \`bootstrap/app.php\` excludes \`webhooks/github\` from CSRF via Laravel 13's \`preventRequestForgery()\`.
- \`ProcessGitHubWebhookJob\` — routes by event to \`IssuesWebhookHandler\` / \`PullRequestWebhookHandler\`. Returns \`WebhookDeliveryStatus\` to distinguish processed (handler ran) from skipped (no handler / inputs not ready) without tunneling exceptions. Handler exception → \`failed\` + \`error_message\` captured. Logs unknown events per §8.5.
- \`IssuesWebhookHandler\` — opened/closed/reopened/edited mapping; drops PR-shaped issues payloads via the existing normalizer; skips if repo not yet imported.
- \`PullRequestWebhookHandler\` — opened/reopened/review_requested + closed splitting on \`merged\` into \`pull_request.merged\` (success) vs \`pull_request.closed\` (info).

## Test plan

- [x] Migration creates \`github_webhook_deliveries\` (with \`github_delivery_id\` unique + \`(event, action)\` index) and \`activity_events\` (with \`occurred_at\` index, nullable \`repository_id\` FK).
- [x] \`VerifyGitHubWebhookSignatureAction\` returns false for tampered bodies; uses \`hash_equals\`.
- [x] \`POST /webhooks/github\` returns 401 with empty body + does NOT insert a row when signature is invalid.
- [x] Valid signature → row inserted + job dispatched, 200 returned.
- [x] Duplicate \`X-GitHub-Delivery\` → second request 200, no second insert, no second dispatch. Concurrent-retry race that loses on the unique index also acks 200 (caught \`UniqueConstraintViolationException\`).
- [x] \`ProcessGitHubWebhookJob\`: status flips to processed/failed/skipped per the lifecycle.
- [x] \`issues.opened\` upserts \`github_issues\` AND creates \`issue.created\` activity event.
- [x] \`pull_request.opened\`/\`closed+merged\`/\`closed\` map to correct activity events with appropriate severity.
- [x] PR-shaped \`issues\` payloads dropped at handler level.
- [x] Webhook for un-imported repo marks delivery \`skipped\` with clear \`error_message\`.
- [x] No real GitHub credentials in CI; tests use signed fixture payloads + \`Queue::fake()\`.
- [x] Pint + build clean. 204 tests / 848 assertions green locally.
- [x] Self-review pass with \`superpowers:code-reviewer\`.

## Self-review notes

Ran \`superpowers:code-reviewer\` on the diff. Material findings addressed:

- **M1 — concurrent-retry race could 500.** The lookup-then-create pattern had a small window between idempotency check and insert. A concurrent retry could land both inside that window and one would hit the unique index. Wrapped \`create()\` in try/catch on \`UniqueConstraintViolationException\`; the loser now acks 200 to match the idempotency contract.
- **M5 — 401 body contradicted spec.** Spec said "no body"; controller was returning "Invalid signature". Honored the spec — empty body. Test asserts \`response->getContent() === ''\`.
- **M3 — \`actor_login\` column width.** GitHub usernames cap at 39 chars but the default varchar 255 let a hostile-but-signed payload write 255-char garbage. Tightened to varchar 64 with headroom.
- **M6 — stale comment in the exception-path test.** Stripped; the rebind-the-handler approach was correct, the abandoned-reproduction-strategy comment block confused readers.
- **Stylistic — \`Container::getInstance()->make()\` → \`app()\`.** Same effect, more idiomatic Laravel; container test re-bindings still work.

Reviewer also flagged stylistic items deferred to spec 018/019:
- \`description\` is currently \`repository.full_name\` which duplicates the relation. Spec 018 will repurpose it (probably to a body excerpt).
- \`metadata\` keys are \`issue_number\` vs \`pull_request_number\`. Spec 018 may want a unified \`subject_number\`.
- \`resolveRepository()\` duplicated across handlers. Pull into a trait when spec 019's third handler arrives.