### PR TITLE
fix(inertia): surface controller flash messages + log silent OAuth branches

### DIFF
--- a/app/Http/Controllers/GithubConnectionController.php
+++ b/app/Http/Controllers/GithubConnectionController.php
@@ -6,6 +6,7 @@ use App\Domain\GitHub\Actions\PersistGithubConnectionAction;
 use App\Domain\GitHub\Services\GitHubOAuthService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use RuntimeException;
 
@@ -38,6 +39,11 @@ class GithubConnectionController extends Controller
         // state — if the user denied or GitHub returned an error, we
         // shouldn't burn the state token (so a retry can still validate).
         if ($request->query('error')) {
+            Log::warning('GitHub OAuth callback returned an error', [
+                'error' => $request->query('error'),
+                'error_description' => $request->query('error_description'),
+            ]);
+
             return redirect()->route('settings.index')->with(
                 'error',
                 'GitHub connection cancelled or rejected: '.$request->query('error_description', $request->query('error')),
@@ -52,6 +58,11 @@ class GithubConnectionController extends Controller
             || $providedState === null
             || ! hash_equals((string) $expectedState, (string) $providedState)
         ) {
+            Log::warning('GitHub OAuth state mismatch', [
+                'has_expected' => $expectedState !== null,
+                'has_provided' => $providedState !== null,
+            ]);
+
             return redirect()->route('settings.index')->with(
                 'error',
                 'GitHub connection rejected — state mismatch. Please try again.',
@@ -61,6 +72,8 @@ class GithubConnectionController extends Controller
         $code = $request->query('code');
 
         if (! is_string($code) || $code === '') {
+            Log::warning('GitHub OAuth callback missing code');
+
             return redirect()->route('settings.index')->with(
                 'error',
                 'GitHub did not return an authorization code.',
@@ -71,6 +84,11 @@ class GithubConnectionController extends Controller
             $tokenPayload = $oauth->exchangeCode($code);
             $userPayload = $oauth->fetchUser((string) $tokenPayload['access_token']);
         } catch (RuntimeException $e) {
+            Log::warning('GitHub OAuth handshake failed', [
+                'message' => $e->getMessage(),
+                'previous' => $e->getPrevious()?->getMessage(),
+            ]);
+
             return redirect()->route('settings.index')->with(
                 'error',
                 $e->getMessage(),

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -34,6 +34,14 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $request->user(),
             ],
+            // Surfaces `->with('status', …)` and `->with('error', …)`
+            // flashes from controllers (e.g. the OAuth callback) so the
+            // page layout can render a banner. Without this, controllers
+            // that flash silently look broken to the user.
+            'flash' => [
+                'status' => fn () => $request->session()->get('status'),
+                'error' => fn () => $request->session()->get('error'),
+            ],
         ];
     }
 }

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -4,7 +4,9 @@ import CommandPalette from '@/Components/CommandPalette/CommandPalette.vue';
 import Sidebar from '@/Components/Sidebar/Sidebar.vue';
 import TopBar from '@/Components/TopBar/TopBar.vue';
 import type { ActivityEvent } from '@/types';
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { router, usePage } from '@inertiajs/vue3';
+import { AlertTriangle, CheckCircle2, X } from 'lucide-vue-next';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 
 withDefaults(
     defineProps<{
@@ -23,6 +25,31 @@ withDefaults(
 const sidebarOpen = ref(false);
 const activityRailOpen = ref(false);
 const paletteOpen = ref(false);
+
+// Surface controller `->with('status'|'error', …)` flashes as a top
+// banner. Pulled from the shared Inertia prop set in
+// HandleInertiaRequests::share(). We snapshot to local refs on each
+// page navigation so dismissing the banner via the X is sticky for the
+// current page (and the next nav clears it, regardless).
+const page = usePage();
+const flashStatus = ref<string | null>(null);
+const flashError = ref<string | null>(null);
+
+const syncFlash = () => {
+    const flash = (page.props.flash ?? {}) as {
+        status?: string | null;
+        error?: string | null;
+    };
+    flashStatus.value = flash.status ?? null;
+    flashError.value = flash.error ?? null;
+};
+
+syncFlash();
+router.on('navigate', syncFlash);
+
+const hasFlash = computed(
+    () => flashStatus.value !== null || flashError.value !== null,
+);
 
 // Lock body scroll while a drawer or the palette is open. Reset on unmount
 // in case the user navigates away mid-overlay.
@@ -134,6 +161,54 @@ onBeforeUnmount(() => {
                     <slot name="title" />
                 </template>
             </TopBar>
+
+            <!-- Flash banner — surfaces controller `with('status'|'error')`
+                 messages so OAuth callbacks, sync triggers, and link
+                 actions don't fail silently. -->
+            <div
+                v-if="hasFlash"
+                class="px-4 pt-3 sm:px-6 lg:px-8"
+                role="status"
+                aria-live="polite"
+            >
+                <div
+                    v-if="flashError"
+                    class="flex items-start gap-3 rounded-lg border border-status-danger/40 bg-status-danger/10 p-3 text-sm text-status-danger"
+                >
+                    <AlertTriangle
+                        class="mt-0.5 h-4 w-4 shrink-0"
+                        aria-hidden="true"
+                    />
+                    <p class="flex-1 leading-snug">{{ flashError }}</p>
+                    <button
+                        type="button"
+                        class="rounded p-0.5 text-status-danger/70 transition hover:text-status-danger focus:outline-none focus-visible:ring-2 focus-visible:ring-status-danger/60"
+                        aria-label="Dismiss error"
+                        @click="flashError = null"
+                    >
+                        <X class="h-4 w-4" aria-hidden="true" />
+                    </button>
+                </div>
+                <div
+                    v-if="flashStatus"
+                    class="mt-2 flex items-start gap-3 rounded-lg border border-status-success/40 bg-status-success/10 p-3 text-sm text-status-success"
+                    :class="{ 'mt-0': !flashError }"
+                >
+                    <CheckCircle2
+                        class="mt-0.5 h-4 w-4 shrink-0"
+                        aria-hidden="true"
+                    />
+                    <p class="flex-1 leading-snug">{{ flashStatus }}</p>
+                    <button
+                        type="button"
+                        class="rounded p-0.5 text-status-success/70 transition hover:text-status-success focus:outline-none focus-visible:ring-2 focus-visible:ring-status-success/60"
+                        aria-label="Dismiss notification"
+                        @click="flashStatus = null"
+                    >
+                        <X class="h-4 w-4" aria-hidden="true" />
+                    </button>
+                </div>
+            </div>
 
             <main class="flex min-w-0 flex-1">
                 <div class="min-w-0 flex-1 overflow-x-hidden">


### PR DESCRIPTION
## Symptom

Connecting GitHub from \`/settings\` bounced through \`/integrations/github/connect\` → GitHub authorize → \`/integrations/github/callback\` and back to \`/settings\` with no visible feedback. \`github_connections\` row was never created. No log entry. The OAuth callback was hitting one of its silent flash branches (GitHub-side error, state mismatch, missing code, or a RuntimeException from token exchange / user fetch).

## Root cause

\`HandleInertiaRequests::share()\` did not expose flash messages to Inertia pages, and the AppLayout had no banner component to render them. The controller's \`->with('error', …)\` calls landed in the session bag where Inertia couldn't see them. Pre-existing gap from spec 013.

## Fix

- \`HandleInertiaRequests::share()\` exposes \`flash.status\` and \`flash.error\` shared props.
- \`AppLayout\` renders a dismissable top banner (success tone for status, danger tone for error) above \`<main>\`.
- \`GithubConnectionController::callback\` now emits a \`Log::warning\` on each silent error branch with the relevant context (GitHub-side error code, state-presence flags, exception message + previous). Future OAuth failures will be diagnosable from \`storage/logs/laravel.log\`.

## Test plan

- [x] Pint clean.
- [x] \`npm run build\` clean (vue-tsc passes the new banner template).
- [x] Manual repro: trigger an OAuth callback failure → flash banner renders on \`/settings\`; X button dismisses; navigation clears.
- [x] Existing local-only PHP 8.5 CSRF flake (33 unrelated 419 fails on the \`destroy\` paths) is unchanged. CI on PHP 8.4 will be green.

## Why now

User hit this debugging the GitHub OAuth flow today. Without this fix any future OAuth failure (callback URL mismatch, expired code, scope rejection, token exchange error) is silently lost. Same gap would have hit spec 014 / 015 / 016 manual-sync flows the moment a user encountered an error there.