### PR TITLE
chore(specs): mark spec 017 done; Phase 3 at 1/3 🟡

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 0 | Foundation (auth, layout, static overview) | 🟢 | 9/9 specs done. |
 | 1 | Projects & Repositories | 🟢 | 3/3 specs done. |
 | 2 | GitHub Integration MVP | 🟢 | 4/4 specs done — connection, repository import + sync, issues sync, PRs + unified Work Items page. |
-| 3 | GitHub Webhooks & Activity Feed | 🟡 | 0/3 specs merged. 017 webhooks + activity events in PR review; 018 Activity Feed UI + 019 Reverb broadcasting next. |
+| 3 | GitHub Webhooks & Activity Feed | 🟡 | 1/3 specs done (017). Next: 018 Activity Feed UI. |
 | 4 | Deployments & CI/CD | ⬜ | — |
 | 5 | Website Monitoring | ⬜ | — |
 | 6 | Docker Host Agent MVP | ⬜ | — |
@@ -44,8 +44,8 @@ After Phase 2:
 - Manual "Run sync" buttons everywhere a sync job exists.
 - Controller flash messages (`->with('status'|'error', …)`) render as a dismissable top banner in `AppLayout`, so failed actions (OAuth callbacks, sync triggers) surface to the user instead of failing silently. Silent OAuth callback branches also `Log::warning` for postmortem.
 
-After Phase 3 (in flight at PR #46 — not yet merged):
-- Spec 017 — GitHub webhook ingestion endpoint at `POST /webhooks/github`. Verifies `X-Hub-Signature-256` (HMAC-SHA-256, timing-safe), stores deliveries idempotently, dispatches an async job, routes to per-event handlers. `issues` and `pull_request` events update the local mirrors and create `activity_events` rows. Backend only — UI for the activity feed lands in spec 018.
+After Phase 3 (in progress):
+- Spec 017 (done) — GitHub webhook ingestion endpoint at `POST /webhooks/github`. Verifies `X-Hub-Signature-256` (HMAC-SHA-256, timing-safe), stores deliveries idempotently, dispatches an async job, routes to per-event handlers. `issues` and `pull_request` events update the local mirrors and create `activity_events` rows. Backend only — UI for the activity feed lands in spec 018.
 
 ## Local development
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -38,7 +38,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 0 | Foundation (auth, layout, static overview) | 🟢 | 9/9 specs done (001–009). Phase complete. |
 | 1 | Projects & Repositories | 🟢 | 3/3 specs done (010–012). Phase complete. |
 | 2 | GitHub Integration MVP | 🟢 | 4/4 specs done (013–016). Phase complete. |
-| 3 | GitHub Webhooks & Activity Feed | ⬜ | 0/3 specs (017 webhooks+activity events, 018 Activity Feed UI, 019 real-time broadcasting). Next: 017. |
+| 3 | GitHub Webhooks & Activity Feed | 🟡 | 1/3 specs done (017). Next: 018 Activity Feed UI. |
 | 4 | Deployments & CI/CD | ⬜ | — |
 | 5 | Website Monitoring | ⬜ | — |
 | 6 | Docker Host Agent MVP | ⬜ | — |

--- a/specs/phase-3-webhooks-activity/017-webhook-ingestion-and-activity-events.md
+++ b/specs/phase-3-webhooks-activity/017-webhook-ingestion-and-activity-events.md
@@ -1,11 +1,12 @@
 ---
 spec: webhook-ingestion-and-activity-events
 phase: 3-webhooks-activity
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-29
 updated: 2026-04-29
 issue: https://github.com/Copxer/nexus/issues/45
+pr: https://github.com/Copxer/nexus/pull/46
 branch: spec/017-webhook-ingestion-and-activity-events
 ---
 

--- a/specs/phase-3-webhooks-activity/README.md
+++ b/specs/phase-3-webhooks-activity/README.md
@@ -9,7 +9,7 @@ Make GitHub updates near real-time. After this phase, importing a repo wires a G
 
 | # | Task | Status |
 |---|------|--------|
-| 017 | GitHub webhook ingestion + activity events (receiver, signature verification, delivery storage, `issues` + `pull_request` handlers, `activity_events` table + `CreateActivityEventAction`) | ⬜ |
+| 017 | GitHub webhook ingestion + activity events (receiver, signature verification, delivery storage, `issues` + `pull_request` handlers, `activity_events` table + `CreateActivityEventAction`) | 🟢 |
 | 018 | Activity Feed UI (replace AppLayout right-rail mock with real activity, `ActivityFeed.vue` + `ActivityFeedItem.vue`, page-load fresh) | ⬜ |
 | 019 | Real-time broadcasting via Reverb (Echo wiring, `ActivityEventCreated` broadcast, extend handler set to `workflow_run`/`push`/`release`) | ⬜ |
 


### PR DESCRIPTION
Bookkeeping after #46 merged.

- Flip \`specs/phase-3-webhooks-activity/017-webhook-ingestion-and-activity-events.md\` frontmatter to \`status: done\` and add the PR link.
- Bump root \`specs/README.md\` Phase 3 row from ⬜ to 🟡 \"1/3 specs done (017). Next: 018 Activity Feed UI.\"
- Bump \`specs/phase-3-webhooks-activity/README.md\` task table row 017 to 🟢.
- Update root \`README.md\` Phase 3 row to match the spec tracker, and bump the "What works today" entry from "in flight at PR #46" to "(done)".

No code, just docs.