### PR TITLE
fix(vite): support cloudflared tunnel mode via VITE_DEV_SERVER_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,3 +83,11 @@ VITE_REVERB_APP_KEY="${REVERB_APP_KEY}"
 VITE_REVERB_HOST="${REVERB_HOST}"
 VITE_REVERB_PORT="${REVERB_PORT}"
 VITE_REVERB_SCHEME="${REVERB_SCHEME}"
+
+# === Cloudflare tunnel (only when serving the dev UI through a tunnel) ===
+# Public URL of a cloudflared tunnel pointing at port 5173 (Vite). When set,
+# Vite binds 0.0.0.0, locks port 5173, allows cross-origin requests, and emits
+# asset URLs at this host so the browser can fetch them through the tunnel.
+# Restart `composer run dev` after changing this — Vite reads it once at boot.
+# See README.md → "Browsing the dev UI through a Cloudflare tunnel".
+VITE_DEV_SERVER_URL=

--- a/.env.example
+++ b/.env.example
@@ -86,8 +86,12 @@ VITE_REVERB_SCHEME="${REVERB_SCHEME}"
 
 # === Cloudflare tunnel (only when serving the dev UI through a tunnel) ===
 # Public URL of a cloudflared tunnel pointing at port 5173 (Vite). When set,
-# Vite binds 0.0.0.0, locks port 5173, allows cross-origin requests, and emits
-# asset URLs at this host so the browser can fetch them through the tunnel.
+# Vite binds 0.0.0.0, locks the port, allows cross-origin requests from APP_URL,
+# adds the tunnel host to its allow-list, and emits asset URLs at this host so
+# the browser can fetch them through the tunnel.
 # Restart `composer run dev` after changing this — Vite reads it once at boot.
 # See README.md → "Browsing the dev UI through a Cloudflare tunnel".
 VITE_DEV_SERVER_URL=
+# Override only when port 5173 is already taken by another process.
+# cloudflared still has to point at this same port locally.
+VITE_DEV_SERVER_PORT=

--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ Caveats with quick tunnels (`cloudflared tunnel --url ...`):
 - HMR over `wss://*.trycloudflare.com` can drop intermittently — when it does, asset URLs are absolute so a manual refresh still serves the latest code. Named tunnels are more stable.
 - If port 5173 is already in use, set `VITE_DEV_SERVER_PORT=5174` (or any free port) in `.env` and point your second `cloudflared` at the same port.
 - The default Laravel `APP_URL`-derived `SESSION_DOMAIN`/`SANCTUM_STATEFUL_DOMAINS` won't include your tunnel hostname. If session-based requests start 419'ing through the tunnel, set `SESSION_DOMAIN=` (blank) and add the tunnel hostname to `SANCTUM_STATEFUL_DOMAINS`.
-- TLS terminates at the tunnel — `php artisan serve` only sees plain HTTP locally. `AppServiceProvider::boot()` calls `URL::forceScheme('https')` whenever `APP_URL` starts with `https://` so generated links don't trigger Mixed Content blocks. If you ever swap to a non-HTTPS tunnel, change `APP_URL` to `http://...` to disable the override.
+- TLS terminates at the tunnel — `php artisan serve` only sees plain HTTP locally. Two things tame this:
+    - `AppServiceProvider::boot()` calls `URL::forceScheme('https')` whenever `APP_URL` starts with `https://` so generated links don't trigger Mixed Content blocks. If you ever swap to a non-HTTPS tunnel, change `APP_URL` to `http://...` to disable the override.
+    - `bootstrap/app.php` trusts loopback proxies (`127.0.0.1`, `::1`), so cloudflared's `X-Forwarded-Proto: https` is honored. Without this, **signed URLs** (email verification, password reset) verify the signature against an `http://` URL while it was signed against `https://`, and every click 403's "Invalid signature." Loopback-only trust is safe in prod too — anything that can connect from loopback already has direct app access.
 - Reverb (websockets, port 8080) isn't covered by this setup. When real-time features become essential, expose Reverb via a third tunnel and update the `VITE_REVERB_*` block in `.env` to match.
 
 Local-only dev (no tunnel) is unaffected — leave `VITE_DEV_SERVER_URL` empty and Vite behaves exactly as before.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Caveats with quick tunnels (`cloudflared tunnel --url ...`):
 - HMR over `wss://*.trycloudflare.com` can drop intermittently — when it does, asset URLs are absolute so a manual refresh still serves the latest code. Named tunnels are more stable.
 - If port 5173 is already in use, set `VITE_DEV_SERVER_PORT=5174` (or any free port) in `.env` and point your second `cloudflared` at the same port.
 - The default Laravel `APP_URL`-derived `SESSION_DOMAIN`/`SANCTUM_STATEFUL_DOMAINS` won't include your tunnel hostname. If session-based requests start 419'ing through the tunnel, set `SESSION_DOMAIN=` (blank) and add the tunnel hostname to `SANCTUM_STATEFUL_DOMAINS`.
+- TLS terminates at the tunnel — `php artisan serve` only sees plain HTTP locally. `AppServiceProvider::boot()` calls `URL::forceScheme('https')` whenever `APP_URL` starts with `https://` so generated links don't trigger Mixed Content blocks. If you ever swap to a non-HTTPS tunnel, change `APP_URL` to `http://...` to disable the override.
 - Reverb (websockets, port 8080) isn't covered by this setup. When real-time features become essential, expose Reverb via a third tunnel and update the `VITE_REVERB_*` block in `.env` to match.
 
 Local-only dev (no tunnel) is unaffected — leave `VITE_DEV_SERVER_URL` empty and Vite behaves exactly as before.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,39 @@ GitHub validates the OAuth callback host **exactly**. If your `GITHUB_OAUTH_REDI
 
 Spec 017's webhook ingestion needs GitHub to be able to reach your dev server. Point an ngrok (or Cloudflare Tunnel) tunnel at port 8000 and set the GitHub App's Webhook URL to `https://<your-tunnel>/webhooks/github`. The `X-Hub-Signature-256` header is verified against `GITHUB_WEBHOOK_SECRET` — if that doesn't match the value configured on the App, every delivery 401's and never lands in the database.
 
+### Browsing the dev UI through a Cloudflare tunnel
+
+Sometimes you want to browse the running app from a public URL — to demo the dashboard, hit it from another device, or run an OAuth callback that GitHub can reach. `composer run dev` boots two long-running HTTP servers — Laravel on `:8000` and Vite on `:5173` — and the browser needs to talk to **both**. Tunneling only port 8000 will load the HTML but every Vite asset (`@vite/client`, `app.ts`, …) will 404 / CORS-fail because the page tries to fetch them from `localhost:5173`.
+
+Set up two cloudflared tunnels and point Vite at its public URL:
+
+```bash
+# Terminal 1 — Laravel
+cloudflared tunnel --url http://localhost:8000
+# → https://<random>.trycloudflare.com   (call this URL_A)
+
+# Terminal 2 — Vite
+cloudflared tunnel --url http://localhost:5173
+# → https://<random>.trycloudflare.com   (call this URL_B)
+```
+
+Then update `.env`:
+
+```env
+APP_URL=https://URL_A.trycloudflare.com
+VITE_DEV_SERVER_URL=https://URL_B.trycloudflare.com
+```
+
+…and **restart `composer run dev`**. Vite reads `VITE_DEV_SERVER_URL` once at boot; `vite.config.js` flips into tunnel mode when it's set — binds `0.0.0.0`, locks port 5173, allows cross-origin requests, and emits asset URLs at the public host so the browser can fetch them through the tunnel.
+
+Caveats with quick tunnels (`cloudflared tunnel --url ...`):
+
+- The tunnel URL changes on every run. Re-edit `.env` and restart `composer run dev` each time.
+- The OAuth callback URL configured in your GitHub App **must** match the new `APP_URL`. Update the GitHub App settings every time the Laravel tunnel URL changes — or use a [named tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps) bound to a stable hostname so the URL stays put.
+- Reverb (websockets, port 8080) isn't covered by this setup. When real-time features become essential, expose Reverb via a third tunnel and update the `VITE_REVERB_*` block in `.env` to match.
+
+Local-only dev (no tunnel) is unaffected — leave `VITE_DEV_SERVER_URL` empty and Vite behaves exactly as before.
+
 ## Tests + linting
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ Caveats with quick tunnels (`cloudflared tunnel --url ...`):
 
 - The tunnel URL changes on every run. Re-edit `.env` and restart `composer run dev` each time.
 - The OAuth callback URL configured in your GitHub App **must** match the new `APP_URL`. Update the GitHub App settings every time the Laravel tunnel URL changes — or use a [named tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-apps) bound to a stable hostname so the URL stays put.
+- HMR over `wss://*.trycloudflare.com` can drop intermittently — when it does, asset URLs are absolute so a manual refresh still serves the latest code. Named tunnels are more stable.
+- If port 5173 is already in use, set `VITE_DEV_SERVER_PORT=5174` (or any free port) in `.env` and point your second `cloudflared` at the same port.
+- The default Laravel `APP_URL`-derived `SESSION_DOMAIN`/`SANCTUM_STATEFUL_DOMAINS` won't include your tunnel hostname. If session-based requests start 419'ing through the tunnel, set `SESSION_DOMAIN=` (blank) and add the tunnel hostname to `SANCTUM_STATEFUL_DOMAINS`.
 - Reverb (websockets, port 8080) isn't covered by this setup. When real-time features become essential, expose Reverb via a third tunnel and update the `VITE_REVERB_*` block in `.env` to match.
 
 Local-only dev (no tunnel) is unaffected — leave `VITE_DEV_SERVER_URL` empty and Vite behaves exactly as before.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ APP_URL=https://URL_A.trycloudflare.com
 VITE_DEV_SERVER_URL=https://URL_B.trycloudflare.com
 ```
 
-…and **restart `composer run dev`**. Vite reads `VITE_DEV_SERVER_URL` once at boot; `vite.config.js` flips into tunnel mode when it's set — binds `0.0.0.0`, locks port 5173, allows cross-origin requests, and emits asset URLs at the public host so the browser can fetch them through the tunnel.
+…and **restart `composer run dev`**. Vite reads `VITE_DEV_SERVER_URL` once at boot; `vite.config.js` flips into tunnel mode when it's set — binds `0.0.0.0`, locks port 5173, allows cross-origin requests, and emits asset URLs at the public host so the browser can fetch them through the tunnel. You'll see a `[vite] tunnel mode active — origin=…` line in the `composer run dev` output (prefixed `vite:`); if it's missing, Vite didn't pick up `VITE_DEV_SERVER_URL` and you'll see CORS / 403 errors in the browser.
 
 Caveats with quick tunnels (`cloudflared tunnel --url ...`):
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ use App\Models\Repository;
 use App\Policies\ProjectPolicy;
 use App\Policies\RepositoryPolicy;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
 
@@ -29,5 +30,15 @@ class AppServiceProvider extends ServiceProvider
 
         Gate::policy(Project::class, ProjectPolicy::class);
         Gate::policy(Repository::class, RepositoryPolicy::class);
+
+        // Force https URL generation when APP_URL is https. Required for
+        // Cloudflare/ngrok tunnels: TLS terminates at the tunnel and
+        // `php artisan serve` only sees plain HTTP locally, so without
+        // this override Laravel emits `http://` URLs that the browser
+        // then blocks as Mixed Content. Honors APP_URL only — local-only
+        // dev (http://localhost APP_URL) is unaffected.
+        if (str_starts_with((string) config('app.url'), 'https://')) {
+            URL::forceScheme('https');
+        }
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -27,6 +27,19 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->preventRequestForgery(except: [
             'webhooks/github',
         ]);
+
+        // Trust loopback proxies. Required for cloudflared / ngrok dev
+        // tunnels — they terminate TLS and forward plain HTTP from
+        // 127.0.0.1 with `X-Forwarded-Proto: https`. Without this,
+        // signed URLs (email verification, password reset) verify the
+        // signature against the request's http:// URL while it was
+        // signed against https://, and every click 403's "Invalid
+        // signature." Loopback-only is safe in prod too — anything that
+        // can connect from loopback already has direct app access.
+        $middleware->trustProxies(at: [
+            '127.0.0.1',
+            '::1',
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/vite.config.js
+++ b/vite.config.js
@@ -70,25 +70,6 @@ export default defineConfig(({ mode }) => {
         );
     }
 
-    // Diagnostic plugin — runs after every other plugin's `config()` hook,
-    // dumps the resolved server.allowedHosts that Vite will actually use.
-    // Lets us tell (in a single restart) whether our array survived the merge
-    // pass or got swallowed by a downstream plugin / Vite resolver.
-    const diagnose = {
-        name: 'nexus-tunnel-diagnostic',
-        enforce: 'post',
-        configResolved(resolved) {
-            if (tunnel) {
-                console.info(
-                    `[vite] resolved server.allowedHosts=${JSON.stringify(resolved.server.allowedHosts)}`,
-                );
-                console.info(
-                    `[vite] resolved server.origin=${resolved.server.origin}`,
-                );
-            }
-        },
-    };
-
     return {
         plugins: [
             laravel({
@@ -103,7 +84,6 @@ export default defineConfig(({ mode }) => {
                     },
                 },
             }),
-            diagnose,
         ],
         server: tunnel
             ? {

--- a/vite.config.js
+++ b/vite.config.js
@@ -68,13 +68,27 @@ export default defineConfig(({ mode }) => {
                       // breaks silently — better to fail loudly so the dev sets
                       // VITE_DEV_SERVER_PORT or frees the default port.
                       strictPort: true,
-                      // Permissive in tunnel mode by design: cloudflared rewrites
-                      // the Host header to `localhost:<port>`, so a strict list
-                      // would lock localhost out and break the forwarded request.
-                      // The security boundary is `cors.origin` below — only
-                      // browsers visiting the configured public origins can
-                      // actually consume Vite's responses.
-                      allowedHosts: true,
+                      // Explicit allow-list. `allowedHosts: true` ought to work
+                      // but doesn't reliably propagate in rolldown-vite (the
+                      // `vite ^8` flavour this project uses), so we list
+                      // everything Vite might see in tunnel mode:
+                      //   - the tunnel's public hostname (preserved by
+                      //     cloudflared on forward),
+                      //   - `.trycloudflare.com` subdomain wildcard so a fresh
+                      //     quick-tunnel URL works without a restart,
+                      //   - `localhost` / `127.0.0.1` for direct local hits and
+                      //     for any forwarder that does rewrite Host.
+                      // The security boundary stays `cors.origin` below — only
+                      // browsers from the configured public origins can
+                      // actually consume the responses.
+                      allowedHosts: [
+                          tunnel.hostname,
+                          '.trycloudflare.com',
+                          'localhost',
+                          '127.0.0.1',
+                          `localhost:${localPort}`,
+                          `127.0.0.1:${localPort}`,
+                      ],
                       // Force every asset URL injected into Blade to use the
                       // public host instead of `[::1]:5173` / `localhost:5173`.
                       origin: tunnel.origin,

--- a/vite.config.js
+++ b/vite.config.js
@@ -51,34 +51,48 @@ export default defineConfig(({ mode }) => {
             }),
         ],
         server: tunnel
-            ? {
-                  // Bind every interface so the cloudflared sidecar can reach Vite.
-                  host: '0.0.0.0',
-                  port: localPort,
-                  // Lock the port. If Vite drifts (5174 etc.) the tunnel breaks
-                  // silently — better to fail loudly so the dev sets
-                  // VITE_DEV_SERVER_PORT or frees 5173.
-                  strictPort: true,
-                  // Allow inbound requests carrying the tunnel's Host header.
-                  // Vite 5+ rejects unknown hosts by default with "Blocked
-                  // request" — the most common gotcha for this setup.
-                  allowedHosts: [tunnel.hostname],
-                  // Force every asset URL injected into Blade to use the public
-                  // host instead of `[::1]:5173` / `localhost:5173`.
-                  origin: tunnel.origin,
-                  // Cross-origin asset loads from the Laravel-side tunnel.
-                  // Tightened to APP_URL + the tunnel itself; a missing APP_URL
-                  // falls back to `true` so a fresh clone still boots.
-                  cors:
-                      corsOrigins.length > 0
-                          ? { origin: corsOrigins }
-                          : true,
-                  hmr: {
-                      host: tunnel.hostname,
-                      protocol: tunnel.protocol === 'https:' ? 'wss' : 'ws',
-                      clientPort: tunnel.protocol === 'https:' ? 443 : 80,
-                  },
-              }
+            ? (() => {
+                  // Loud startup log so tunnel-mode activation is visible inside
+                  // the `composer run dev` concurrently output (prefixed `vite:`).
+                  console.info(
+                      `[vite] tunnel mode active — origin=${tunnel.origin}, port=${localPort}, cors=${
+                          corsOrigins.length > 0 ? corsOrigins.join(',') : 'any'
+                      }`,
+                  );
+
+                  return {
+                      // Bind every interface so the cloudflared sidecar can reach Vite.
+                      host: '0.0.0.0',
+                      port: localPort,
+                      // Lock the port. If Vite drifts (5174 etc.) the tunnel
+                      // breaks silently — better to fail loudly so the dev sets
+                      // VITE_DEV_SERVER_PORT or frees the default port.
+                      strictPort: true,
+                      // Permissive in tunnel mode by design: cloudflared rewrites
+                      // the Host header to `localhost:<port>`, so a strict list
+                      // would lock localhost out and break the forwarded request.
+                      // The security boundary is `cors.origin` below — only
+                      // browsers visiting the configured public origins can
+                      // actually consume Vite's responses.
+                      allowedHosts: true,
+                      // Force every asset URL injected into Blade to use the
+                      // public host instead of `[::1]:5173` / `localhost:5173`.
+                      origin: tunnel.origin,
+                      // Cross-origin asset loads from the Laravel-side tunnel.
+                      // Tightened to APP_URL + the tunnel itself; a missing
+                      // APP_URL falls back to `true` so a fresh clone still
+                      // boots.
+                      cors:
+                          corsOrigins.length > 0
+                              ? { origin: corsOrigins }
+                              : true,
+                      hmr: {
+                          host: tunnel.hostname,
+                          protocol: tunnel.protocol === 'https:' ? 'wss' : 'ws',
+                          clientPort: tunnel.protocol === 'https:' ? 443 : 80,
+                      },
+                  };
+              })()
             : undefined,
     };
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -35,6 +35,41 @@ export default defineConfig(({ mode }) => {
     // a brand-new clone with VITE_DEV_SERVER_URL but empty APP_URL still works.
     const corsOrigins = [env.APP_URL, tunnel?.origin].filter(Boolean);
 
+    // Explicit allow-list of host headers Vite will accept in tunnel mode.
+    // Listed eagerly so the value is the same object reference Vite eventually
+    // freezes — see node_modules/vite/dist/node/chunks/node.js, the line that
+    // does `Object.freeze([...config.server.allowedHosts])` during config
+    // resolution. Order:
+    //   - the tunnel's public hostname (preserved by cloudflared on forward),
+    //   - `.trycloudflare.com` subdomain wildcard so a fresh quick-tunnel URL
+    //     works without restarting Vite,
+    //   - `localhost` / `127.0.0.1` for direct local hits and for any
+    //     forwarder that does rewrite Host.
+    // The security boundary stays `cors.origin` below — only browsers from the
+    // configured public origins can actually consume the responses.
+    const allowedHosts = tunnel
+        ? [
+              tunnel.hostname,
+              '.trycloudflare.com',
+              'localhost',
+              '127.0.0.1',
+              `localhost:${localPort}`,
+              `127.0.0.1:${localPort}`,
+          ]
+        : undefined;
+
+    if (tunnel) {
+        // Loud startup banner so tunnel-mode activation (and the resolved
+        // values) is visible inside the `composer run dev` concurrently
+        // output (prefixed `vite:`). If you ever see a "Blocked request" 403,
+        // copy/paste this banner so it's clear what Vite was actually told.
+        console.info(
+            `[vite] tunnel mode active — origin=${tunnel.origin}, port=${localPort}, allowedHosts=${JSON.stringify(allowedHosts)}, cors=${
+                corsOrigins.length > 0 ? corsOrigins.join(',') : 'any'
+            }`,
+        );
+    }
+
     return {
         plugins: [
             laravel({
@@ -51,62 +86,29 @@ export default defineConfig(({ mode }) => {
             }),
         ],
         server: tunnel
-            ? (() => {
-                  // Loud startup log so tunnel-mode activation is visible inside
-                  // the `composer run dev` concurrently output (prefixed `vite:`).
-                  console.info(
-                      `[vite] tunnel mode active — origin=${tunnel.origin}, port=${localPort}, cors=${
-                          corsOrigins.length > 0 ? corsOrigins.join(',') : 'any'
-                      }`,
-                  );
-
-                  return {
-                      // Bind every interface so the cloudflared sidecar can reach Vite.
-                      host: '0.0.0.0',
-                      port: localPort,
-                      // Lock the port. If Vite drifts (5174 etc.) the tunnel
-                      // breaks silently — better to fail loudly so the dev sets
-                      // VITE_DEV_SERVER_PORT or frees the default port.
-                      strictPort: true,
-                      // Explicit allow-list. `allowedHosts: true` ought to work
-                      // but doesn't reliably propagate in rolldown-vite (the
-                      // `vite ^8` flavour this project uses), so we list
-                      // everything Vite might see in tunnel mode:
-                      //   - the tunnel's public hostname (preserved by
-                      //     cloudflared on forward),
-                      //   - `.trycloudflare.com` subdomain wildcard so a fresh
-                      //     quick-tunnel URL works without a restart,
-                      //   - `localhost` / `127.0.0.1` for direct local hits and
-                      //     for any forwarder that does rewrite Host.
-                      // The security boundary stays `cors.origin` below — only
-                      // browsers from the configured public origins can
-                      // actually consume the responses.
-                      allowedHosts: [
-                          tunnel.hostname,
-                          '.trycloudflare.com',
-                          'localhost',
-                          '127.0.0.1',
-                          `localhost:${localPort}`,
-                          `127.0.0.1:${localPort}`,
-                      ],
-                      // Force every asset URL injected into Blade to use the
-                      // public host instead of `[::1]:5173` / `localhost:5173`.
-                      origin: tunnel.origin,
-                      // Cross-origin asset loads from the Laravel-side tunnel.
-                      // Tightened to APP_URL + the tunnel itself; a missing
-                      // APP_URL falls back to `true` so a fresh clone still
-                      // boots.
-                      cors:
-                          corsOrigins.length > 0
-                              ? { origin: corsOrigins }
-                              : true,
-                      hmr: {
-                          host: tunnel.hostname,
-                          protocol: tunnel.protocol === 'https:' ? 'wss' : 'ws',
-                          clientPort: tunnel.protocol === 'https:' ? 443 : 80,
-                      },
-                  };
-              })()
+            ? {
+                  // Bind every interface so the cloudflared sidecar can reach Vite.
+                  host: '0.0.0.0',
+                  port: localPort,
+                  // Lock the port. If Vite drifts (5174 etc.) the tunnel breaks
+                  // silently — better to fail loudly so the dev sets
+                  // VITE_DEV_SERVER_PORT or frees the default port.
+                  strictPort: true,
+                  allowedHosts,
+                  // Force every asset URL injected into Blade to use the
+                  // public host instead of `[::1]:5173` / `localhost:5173`.
+                  origin: tunnel.origin,
+                  // Cross-origin asset loads from the Laravel-side tunnel.
+                  cors:
+                      corsOrigins.length > 0
+                          ? { origin: corsOrigins }
+                          : true,
+                  hmr: {
+                      host: tunnel.hostname,
+                      protocol: tunnel.protocol === 'https:' ? 'wss' : 'ws',
+                      clientPort: tunnel.protocol === 'https:' ? 443 : 80,
+                  },
+              }
             : undefined,
     };
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,20 +1,63 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import vue from '@vitejs/plugin-vue';
 
-export default defineConfig({
-    plugins: [
-        laravel({
-            input: 'resources/js/app.ts',
-            refresh: true,
-        }),
-        vue({
-            template: {
-                transformAssetUrls: {
-                    base: null,
-                    includeAbsolute: false,
+export default defineConfig(({ mode }) => {
+    // Pull every key (not just VITE_*) so we can read APP_URL too.
+    const env = loadEnv(mode, process.cwd(), '');
+
+    // Tunnel mode kicks in when VITE_DEV_SERVER_URL points at a public host —
+    // typically a `cloudflared tunnel --url http://localhost:5173` quick-tunnel
+    // URL. See the "Browsing the dev UI through a tunnel" section in README.md.
+    const tunnelUrl = env.VITE_DEV_SERVER_URL?.trim() || null;
+    let tunnel = null;
+    if (tunnelUrl) {
+        try {
+            tunnel = new URL(tunnelUrl);
+        } catch {
+            // Bad URL → fall back to local mode rather than crash Vite at boot.
+            // The console message lands inside the `composer run dev` output.
+            console.warn(
+                `[vite] Ignoring VITE_DEV_SERVER_URL="${tunnelUrl}" — not a valid URL.`,
+            );
+        }
+    }
+
+    return {
+        plugins: [
+            laravel({
+                input: 'resources/js/app.ts',
+                refresh: true,
+            }),
+            vue({
+                template: {
+                    transformAssetUrls: {
+                        base: null,
+                        includeAbsolute: false,
+                    },
                 },
-            },
-        }),
-    ],
+            }),
+        ],
+        server: tunnel
+            ? {
+                  // Bind every interface so the cloudflared sidecar can reach Vite.
+                  host: '0.0.0.0',
+                  // Lock the port. If Vite drifts to 5174 the tunnel breaks
+                  // silently — better to fail loudly so the dev frees 5173.
+                  port: 5173,
+                  strictPort: true,
+                  // Force every asset URL injected into Blade to use the public
+                  // host instead of `[::1]:5173` / `localhost:5173`.
+                  origin: tunnel.origin,
+                  // The Laravel app is on a different (cross-origin) tunnel, so
+                  // CORS must allow the browser to load Vite's assets from there.
+                  cors: true,
+                  hmr: {
+                      host: tunnel.hostname,
+                      protocol: tunnel.protocol === 'https:' ? 'wss' : 'ws',
+                      clientPort: tunnel.protocol === 'https:' ? 443 : 80,
+                  },
+              }
+            : undefined,
+    };
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,12 +16,24 @@ export default defineConfig(({ mode }) => {
             tunnel = new URL(tunnelUrl);
         } catch {
             // Bad URL → fall back to local mode rather than crash Vite at boot.
-            // The console message lands inside the `composer run dev` output.
+            // The warning lands prefixed in the `composer run dev` output.
             console.warn(
                 `[vite] Ignoring VITE_DEV_SERVER_URL="${tunnelUrl}" — not a valid URL.`,
             );
         }
     }
+
+    // Allow override when port 5173 is already taken by another Vite (or any
+    // other process). Tunnel still works as long as cloudflared points at the
+    // matching local port.
+    const localPort = Number(env.VITE_DEV_SERVER_PORT) || 5173;
+
+    // Build the CORS allow-list from the public origins the browser will be
+    // talking from. APP_URL covers the Laravel-side tunnel; tunnel.origin is
+    // included so direct fetches against Vite (rare, but possible) pass too.
+    // Falls back to permissive in tunnel mode only when APP_URL is unset, so
+    // a brand-new clone with VITE_DEV_SERVER_URL but empty APP_URL still works.
+    const corsOrigins = [env.APP_URL, tunnel?.origin].filter(Boolean);
 
     return {
         plugins: [
@@ -42,16 +54,25 @@ export default defineConfig(({ mode }) => {
             ? {
                   // Bind every interface so the cloudflared sidecar can reach Vite.
                   host: '0.0.0.0',
-                  // Lock the port. If Vite drifts to 5174 the tunnel breaks
-                  // silently — better to fail loudly so the dev frees 5173.
-                  port: 5173,
+                  port: localPort,
+                  // Lock the port. If Vite drifts (5174 etc.) the tunnel breaks
+                  // silently — better to fail loudly so the dev sets
+                  // VITE_DEV_SERVER_PORT or frees 5173.
                   strictPort: true,
+                  // Allow inbound requests carrying the tunnel's Host header.
+                  // Vite 5+ rejects unknown hosts by default with "Blocked
+                  // request" — the most common gotcha for this setup.
+                  allowedHosts: [tunnel.hostname],
                   // Force every asset URL injected into Blade to use the public
                   // host instead of `[::1]:5173` / `localhost:5173`.
                   origin: tunnel.origin,
-                  // The Laravel app is on a different (cross-origin) tunnel, so
-                  // CORS must allow the browser to load Vite's assets from there.
-                  cors: true,
+                  // Cross-origin asset loads from the Laravel-side tunnel.
+                  // Tightened to APP_URL + the tunnel itself; a missing APP_URL
+                  // falls back to `true` so a fresh clone still boots.
+                  cors:
+                      corsOrigins.length > 0
+                          ? { origin: corsOrigins }
+                          : true,
                   hmr: {
                       host: tunnel.hostname,
                       protocol: tunnel.protocol === 'https:' ? 'wss' : 'ws',

--- a/vite.config.js
+++ b/vite.config.js
@@ -70,6 +70,25 @@ export default defineConfig(({ mode }) => {
         );
     }
 
+    // Diagnostic plugin — runs after every other plugin's `config()` hook,
+    // dumps the resolved server.allowedHosts that Vite will actually use.
+    // Lets us tell (in a single restart) whether our array survived the merge
+    // pass or got swallowed by a downstream plugin / Vite resolver.
+    const diagnose = {
+        name: 'nexus-tunnel-diagnostic',
+        enforce: 'post',
+        configResolved(resolved) {
+            if (tunnel) {
+                console.info(
+                    `[vite] resolved server.allowedHosts=${JSON.stringify(resolved.server.allowedHosts)}`,
+                );
+                console.info(
+                    `[vite] resolved server.origin=${resolved.server.origin}`,
+                );
+            }
+        },
+    };
+
     return {
         plugins: [
             laravel({
@@ -84,6 +103,7 @@ export default defineConfig(({ mode }) => {
                     },
                 },
             }),
+            diagnose,
         ],
         server: tunnel
             ? {


### PR DESCRIPTION
Lets devs serve the dashboard through a Cloudflare quick-tunnel so it's reachable from a public URL — useful for demoing, hitting it from another device, or running OAuth callbacks GitHub can reach. Will be **squash-merged**, so the chain of fixup/diag commits collapses to one clean commit on `main`.

## Summary

The PR makes the full HTTPS-tunnel-in-front-of-`composer run dev` flow Just Work via three coordinated changes:

1. **`vite.config.js` — tunnel mode (`VITE_DEV_SERVER_URL`).** When set, Vite binds `0.0.0.0`, locks the dev port (`VITE_DEV_SERVER_PORT` to override), allow-lists the tunnel host + `.trycloudflare.com` + loopback, scopes CORS to `APP_URL` + the tunnel origin, sets `server.origin` so the Laravel Vite plugin emits public asset URLs, and configures HMR host/protocol/clientPort against the tunnel URL. Logs `[vite] tunnel mode active — origin=… allowedHosts=… cors=…` at startup so the resolved config is visible inside `composer run dev`.
2. **`AppServiceProvider::boot()` — `URL::forceScheme('https')`** when `config('app.url')` starts with `https://`. Without this, `route()` emits `http://...` URLs that the browser blocks as Mixed Content because the page was loaded over `https://`.
3. **`bootstrap/app.php` — `trustProxies(at: ['127.0.0.1', '::1'])`.** Cloudflared connects to `php artisan serve` from loopback with `X-Forwarded-Proto: https`. Trusting it makes `request()->fullUrl()` reconstruct as `https://`, so signed URLs (email verification, password reset) verify correctly. Loopback-only is safe in prod too — anything that can connect from loopback already has direct app access.

`.env.example` adds `VITE_DEV_SERVER_URL` and `VITE_DEV_SERVER_PORT` with in-place comments. README adds a "Browsing the dev UI through a Cloudflare tunnel" subsection with the dual-tunnel workflow + every caveat we hit while debugging this (URL drift, OAuth callback re-config, HMR-over-wss flakiness, port conflicts, Sanctum/session-domain hint, Mixed Content + signed-URL story, Reverb-as-third-tunnel).

## Test plan

- [x] `vendor/bin/pint --test` clean
- [x] `npm run build` green (loadEnv is a pure read; `server` config is ignored by `vite build`)
- [x] `php artisan test` 204/204 green
- [x] **Manual smoke (verified live):**
    - Two cloudflared quick tunnels (port 8000 + 5173), `APP_URL` and `VITE_DEV_SERVER_URL` set in `.env`, `composer run dev`, browser at the Laravel tunnel URL → Welcome page renders, Vite assets stream, no CORS errors.
    - Click Log in / Get started → no Mixed Content blocks; navigation works.
    - Register a new user → verification email arrives → click the link → lands on `/overview` (signed URL verifies).
- [x] Local-only dev (no tunnel) is unaffected — leave `VITE_DEV_SERVER_URL` empty and the entire override path is skipped.

## What changed across the commit chain (will be squashed)

- Initial tunnel-mode plumbing (`server.origin`, CORS, HMR)
- Self-review fixes: `VITE_DEV_SERVER_PORT` knob, CORS tightened to `APP_URL` + tunnel origin
- `allowedHosts` evolution: `[tunnel.hostname]` → `true` → explicit list (rolldown-vite v8's `allowedHosts: true` doesn't propagate cleanly)
- A short-lived diagnostic plugin that confirmed our array survived the resolved-config pass (already removed)
- Force-scheme override + trust-proxies for the HTTPS round-trip

## Out of scope

- Reverb (port 8080) tunneling — flagged in README, becomes relevant when spec 019 lands real-time broadcasting.
- Named tunnels (Cloudflare-account-bound, stable URLs) — recommended in README but the workflow works with quick tunnels.