### PR TITLE
fix(repos): manually-linked repos auto-sync + add Run sync to repo show page

### DIFF
--- a/app/Http/Controllers/RepositoryController.php
+++ b/app/Http/Controllers/RepositoryController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Domain\GitHub\Actions\ImportRepositoryAction;
 use App\Domain\GitHub\Queries\IssuesForRepositoryQuery;
 use App\Domain\GitHub\Queries\PullRequestsForRepositoryQuery;
-use App\Domain\Repositories\Actions\LinkRepositoryToProjectAction;
 use App\Http\Requests\Repositories\LinkRepositoryRequest;
 use App\Models\Repository;
 use Illuminate\Database\UniqueConstraintViolationException;
@@ -64,7 +64,7 @@ class RepositoryController extends Controller
         ]);
     }
 
-    public function store(LinkRepositoryRequest $request, LinkRepositoryToProjectAction $action): RedirectResponse
+    public function store(LinkRepositoryRequest $request, ImportRepositoryAction $action): RedirectResponse
     {
         $project = $request->resolvedProject();
 
@@ -73,7 +73,7 @@ class RepositoryController extends Controller
         $this->authorize('create', [Repository::class, $project]);
 
         try {
-            $action->execute($project, $request->string('repository')->toString());
+            $repository = $action->execute($project, $request->string('repository')->toString());
         } catch (InvalidArgumentException $e) {
             return back()->withErrors(['repository' => $e->getMessage()]);
         } catch (UniqueConstraintViolationException) {
@@ -84,7 +84,7 @@ class RepositoryController extends Controller
 
         return redirect()
             ->route('projects.show', $project)
-            ->with('status', 'Repository linked.');
+            ->with('status', "Linking {$repository->full_name}…");
     }
 
     public function destroy(Repository $repository): RedirectResponse

--- a/app/Http/Controllers/RepositorySyncController.php
+++ b/app/Http/Controllers/RepositorySyncController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Domain\GitHub\Jobs\SyncGitHubRepositoryJob;
+use App\Enums\RepositorySyncStatus;
 use App\Models\Repository;
 use Illuminate\Http\RedirectResponse;
 
@@ -16,6 +17,11 @@ use Illuminate\Http\RedirectResponse;
  * `RepositoryPullRequestsSyncController` shape introduced in specs 015 + 016
  * — the button is the parent-level sibling of those two.
  *
+ * Flips `sync_status` to `syncing` synchronously before queuing the job. The
+ * `back()` re-render therefore re-fetches the row and the show-page button
+ * paints disabled + spinner immediately, debouncing rapid double-clicks
+ * without needing `ShouldBeUnique` on the job.
+ *
  * Authorization: `ProjectPolicy::update` — only the project owner can
  * trigger a re-sync, matching the existing tab-level controllers.
  */
@@ -25,6 +31,10 @@ class RepositorySyncController extends Controller
     {
         $repository->loadMissing('project');
         $this->authorize('update', $repository->project);
+
+        $repository->update([
+            'sync_status' => RepositorySyncStatus::Syncing->value,
+        ]);
 
         SyncGitHubRepositoryJob::dispatch($repository->id);
 

--- a/app/Http/Controllers/RepositorySyncController.php
+++ b/app/Http/Controllers/RepositorySyncController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\GitHub\Jobs\SyncGitHubRepositoryJob;
+use App\Models\Repository;
+use Illuminate\Http\RedirectResponse;
+
+/**
+ * Manual "Run sync" button on the Repository show page header. Re-dispatches
+ * `SyncGitHubRepositoryJob` for the given repository, which refreshes the
+ * metadata (default branch, language, stars, push timestamps) and cascades
+ * into `SyncRepositoryIssuesJob` + `SyncRepositoryPullRequestsJob` on success.
+ *
+ * Mirrors the per-tab `RepositoryIssuesSyncController` /
+ * `RepositoryPullRequestsSyncController` shape introduced in specs 015 + 016
+ * — the button is the parent-level sibling of those two.
+ *
+ * Authorization: `ProjectPolicy::update` — only the project owner can
+ * trigger a re-sync, matching the existing tab-level controllers.
+ */
+class RepositorySyncController extends Controller
+{
+    public function __invoke(Repository $repository): RedirectResponse
+    {
+        $repository->loadMissing('project');
+        $this->authorize('update', $repository->project);
+
+        SyncGitHubRepositoryJob::dispatch($repository->id);
+
+        return back()->with('status', 'Repository sync queued.');
+    }
+}

--- a/resources/js/Pages/Repositories/Show.vue
+++ b/resources/js/Pages/Repositories/Show.vue
@@ -127,6 +127,9 @@ const isIssuesSyncing = computed(() => props.issuesSync.status === 'syncing');
 const isPullRequestsSyncing = computed(
     () => props.pullRequestsSync.status === 'syncing',
 );
+const isRepositorySyncing = computed(
+    () => props.repository.sync_status === 'syncing',
+);
 
 const confirmDelete = () => {
     if (!props.canDelete) return;
@@ -153,6 +156,15 @@ const runPullRequestsSync = () => {
     if (!props.canSync) return;
     router.post(
         route('repositories.pulls.sync', props.repository.full_name),
+        {},
+        { preserveScroll: true },
+    );
+};
+
+const runRepositorySync = () => {
+    if (!props.canSync) return;
+    router.post(
+        route('repositories.sync', props.repository.full_name),
         {},
         { preserveScroll: true },
     );
@@ -217,6 +229,20 @@ const runPullRequestsSync = () => {
                             <ExternalLink class="h-4 w-4" aria-hidden="true" />
                             View on GitHub
                         </a>
+                        <button
+                            v-if="canSync"
+                            type="button"
+                            :disabled="isRepositorySyncing"
+                            class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/10 px-3 py-2 text-sm font-semibold text-accent-cyan transition hover:bg-accent-cyan/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60 disabled:cursor-not-allowed disabled:opacity-50"
+                            @click="runRepositorySync"
+                        >
+                            <RefreshCcw
+                                class="h-4 w-4"
+                                :class="{ 'animate-spin': isRepositorySyncing }"
+                                aria-hidden="true"
+                            />
+                            {{ isRepositorySyncing ? 'Syncing…' : 'Run sync' }}
+                        </button>
                         <button
                             v-if="canDelete"
                             type="button"

--- a/resources/js/Pages/Repositories/Show.vue
+++ b/resources/js/Pages/Repositories/Show.vue
@@ -233,7 +233,7 @@ const runRepositorySync = () => {
                             v-if="canSync"
                             type="button"
                             :disabled="isRepositorySyncing"
-                            class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/10 px-3 py-2 text-sm font-semibold text-accent-cyan transition hover:bg-accent-cyan/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60 disabled:cursor-not-allowed disabled:opacity-50"
+                            class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/15 px-3 py-2 text-sm font-semibold text-accent-cyan transition hover:border-accent-cyan/60 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
                             @click="runRepositorySync"
                         >
                             <RefreshCcw

--- a/resources/js/Pages/Repositories/Show.vue
+++ b/resources/js/Pages/Repositories/Show.vue
@@ -17,7 +17,7 @@ import {
     Star,
     Trash2,
 } from 'lucide-vue-next';
-import { computed, ref } from 'vue';
+import { computed, onBeforeUnmount, ref, watch } from 'vue';
 
 interface RepositoryShape {
     id: number;
@@ -169,6 +169,52 @@ const runRepositorySync = () => {
         { preserveScroll: true },
     );
 };
+
+// While ANY of the three sync flows (repository / issues / PRs) is in
+// `syncing` state, poll the controller every 2.5s for the latest status —
+// a partial Inertia reload that re-fetches just the three sync-related
+// props so the page updates without flashing or losing scroll. Stops on
+// its own as soon as all three flip out of `syncing`. Spec 019 will
+// replace this with Reverb broadcasts.
+const POLL_INTERVAL_MS = 2500;
+let pollHandle: ReturnType<typeof setInterval> | null = null;
+
+const anySyncing = computed(
+    () =>
+        isRepositorySyncing.value ||
+        isIssuesSyncing.value ||
+        isPullRequestsSyncing.value,
+);
+
+const stopPolling = () => {
+    if (pollHandle !== null) {
+        clearInterval(pollHandle);
+        pollHandle = null;
+    }
+};
+
+const startPolling = () => {
+    if (pollHandle !== null) return;
+    pollHandle = setInterval(() => {
+        // `router.reload` is a same-route partial fetch — no navigation, so
+        // scroll + component state are preserved by default. `only` keeps
+        // the payload tiny (just the three sync-related props).
+        router.reload({
+            only: ['repository', 'issuesSync', 'pullRequestsSync'],
+        });
+    }, POLL_INTERVAL_MS);
+};
+
+watch(
+    anySyncing,
+    (now) => {
+        if (now) startPolling();
+        else stopPolling();
+    },
+    { immediate: true },
+);
+
+onBeforeUnmount(stopPolling);
 </script>
 
 <template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\ProjectController;
 use App\Http\Controllers\RepositoryController;
 use App\Http\Controllers\RepositoryIssuesSyncController;
 use App\Http\Controllers\RepositoryPullRequestsSyncController;
+use App\Http\Controllers\RepositorySyncController;
 use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\Webhooks\GitHubWebhookController;
 use App\Http\Controllers\WorkItemController;
@@ -48,6 +49,14 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('projects.repositories.import.index');
     Route::post('/projects/{project}/repositories/import', [GithubRepositoryImportController::class, 'store'])
         ->name('projects.repositories.import.store');
+
+    // Manual "Run sync" button on the Repository show-page header.
+    // Re-dispatches the parent SyncGitHubRepositoryJob, which refreshes
+    // metadata (default branch, language, stars, push timestamps) and
+    // cascades into the issues + PR sync jobs below.
+    Route::post('/repositories/{repository}/sync', RepositorySyncController::class)
+        ->where('repository', '[\w.-]+/[\w.-]+')
+        ->name('repositories.sync');
 
     // Spec 015 — manual "Run sync" button on the Repository Issues tab.
     Route::post('/repositories/{repository}/issues/sync', RepositoryIssuesSyncController::class)

--- a/tests/Feature/GitHub/RepositorySyncControllerTest.php
+++ b/tests/Feature/GitHub/RepositorySyncControllerTest.php
@@ -30,10 +30,37 @@ class RepositorySyncControllerTest extends TestCase
             ->assertRedirect(route('repositories.show', $repository->full_name))
             ->assertSessionHas('status');
 
+        // Status flipped synchronously before the job ran — the next render
+        // will paint the button disabled and stop double-click spam.
+        $this->assertSame(
+            'syncing',
+            $repository->fresh()->sync_status->value,
+        );
+
         Queue::assertPushed(
             SyncGitHubRepositoryJob::class,
             fn (SyncGitHubRepositoryJob $job) => $job->repositoryId === $repository->id,
         );
+    }
+
+    public function test_already_synced_repository_can_be_re_synced(): void
+    {
+        Queue::fake();
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+            'sync_status' => 'synced',
+        ]);
+
+        $this->actingAs($owner)
+            ->from(route('repositories.show', $repository->full_name))
+            ->post(route('repositories.sync', $repository->full_name))
+            ->assertRedirect(route('repositories.show', $repository->full_name));
+
+        $this->assertSame('syncing', $repository->fresh()->sync_status->value);
+        Queue::assertPushed(SyncGitHubRepositoryJob::class);
     }
 
     public function test_non_owner_is_forbidden(): void

--- a/tests/Feature/GitHub/RepositorySyncControllerTest.php
+++ b/tests/Feature/GitHub/RepositorySyncControllerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Domain\GitHub\Jobs\SyncGitHubRepositoryJob;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class RepositorySyncControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_can_dispatch_a_re_sync(): void
+    {
+        Queue::fake();
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+        ]);
+
+        $this->actingAs($owner)
+            ->from(route('repositories.show', $repository->full_name))
+            ->post(route('repositories.sync', $repository->full_name))
+            ->assertRedirect(route('repositories.show', $repository->full_name))
+            ->assertSessionHas('status');
+
+        Queue::assertPushed(
+            SyncGitHubRepositoryJob::class,
+            fn (SyncGitHubRepositoryJob $job) => $job->repositoryId === $repository->id,
+        );
+    }
+
+    public function test_non_owner_is_forbidden(): void
+    {
+        Queue::fake();
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+        $other = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+        ]);
+
+        $this->actingAs($other)
+            ->post(route('repositories.sync', $repository->full_name))
+            ->assertForbidden();
+
+        Queue::assertNotPushed(SyncGitHubRepositoryJob::class);
+    }
+
+    public function test_unknown_repository_returns_404(): void
+    {
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($owner)
+            ->post(route('repositories.sync', 'nope/missing'))
+            ->assertNotFound();
+    }
+}

--- a/tests/Feature/Repositories/RepositoryControllerTest.php
+++ b/tests/Feature/Repositories/RepositoryControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Repositories;
 
+use App\Domain\GitHub\Jobs\SyncGitHubRepositoryJob;
 use App\Enums\GithubIssueState;
 use App\Enums\GithubPullRequestState;
 use App\Models\GithubIssue;
@@ -10,6 +11,7 @@ use App\Models\Project;
 use App\Models\Repository;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
 
@@ -143,6 +145,7 @@ class RepositoryControllerTest extends TestCase
 
     public function test_store_links_via_a_full_github_url(): void
     {
+        Queue::fake();
         $user = $this->verifiedUser();
         $project = Project::factory()->create(['owner_user_id' => $user->id]);
 
@@ -157,10 +160,20 @@ class RepositoryControllerTest extends TestCase
             'full_name' => 'nexus-org/nexus-api',
             'sync_status' => 'pending',
         ]);
+
+        $linked = Repository::query()
+            ->where('full_name', 'nexus-org/nexus-api')
+            ->firstOrFail();
+
+        Queue::assertPushed(
+            SyncGitHubRepositoryJob::class,
+            fn (SyncGitHubRepositoryJob $job) => $job->repositoryId === $linked->id,
+        );
     }
 
     public function test_store_links_via_owner_slash_name(): void
     {
+        Queue::fake();
         $user = $this->verifiedUser();
         $project = Project::factory()->create(['owner_user_id' => $user->id]);
 
@@ -173,6 +186,8 @@ class RepositoryControllerTest extends TestCase
             'project_id' => $project->id,
             'full_name' => 'nexus-labs/edge-cache',
         ]);
+
+        Queue::assertPushed(SyncGitHubRepositoryJob::class);
     }
 
     public function test_store_rejects_garbage_input(): void


### PR DESCRIPTION
Two related UX bugs in the repository link/sync flow, surfaced while syncing a private repo into a project:

1. **Manual link doesn't sync.** The "Link a GitHub repository manually" form on a project's Repositories tab calls `LinkRepositoryToProjectAction` directly — which only inserts the row. Manually-linked repos sit at `sync_status=pending` forever with no way to trigger metadata fetching. Meanwhile the picker-import path (`Browse...` → pick a repo) wraps the same linker AND dispatches `SyncGitHubRepositoryJob` via `ImportRepositoryAction`, so it Just Works. The two paths diverged in spec 011 vs spec 014 and never re-converged.
2. **No way to re-sync a repository's metadata from the show page.** Per-tab "Run sync" buttons exist for Issues and PRs (specs 015 + 016), but the parent metadata sync (default branch, language, stars, push timestamps) had no manual trigger — even when the header showed PENDING, the only escape was unlink + re-link.

## Summary

- `RepositoryController::store` now injects `ImportRepositoryAction` instead of `LinkRepositoryToProjectAction`. Both link paths now converge on the same linked-and-synced flow. Flash copy switches from "Repository linked." to "Linking {full_name}…" to reflect the now-async behaviour.
- New `RepositorySyncController` + `POST /repositories/{repository}/sync` route, mirroring `RepositoryIssuesSyncController` / `RepositoryPullRequestsSyncController`. Re-dispatches `SyncGitHubRepositoryJob`, which already cascades into the issues + PR sync jobs on success — one button refreshes everything.
- The new controller flips `sync_status` to `syncing` **synchronously** before queuing the job. Prevents rapid double-clicks from queuing N jobs (and 2N child cascades) — the next render after `back()` paints the button disabled.
- `Show.vue` adds a "Run sync" button to the header next to **View on GitHub** / **Unlink**. Hidden for non-owners (`canSync` prop). Disabled + spins (`animate-spin`) while `sync_status === 'syncing'`. Styled to match the per-tab Issues/PR sync buttons (`bg-accent-cyan/15`, `hover:border-accent-cyan/60`, `disabled:opacity-60`).

## Test plan

- [x] `vendor/bin/pint --test` clean
- [x] `npm run build` green
- [x] `php artisan test` **208/208** green (was 204; +4 new assertions/tests)
- [ ] Manual smoke (please verify):
    1. Project → "Link a GitHub repository manually" → enter `owner/name` → submit. Repo card appears with `PENDING` momentarily then transitions to `SYNCED` (or `FAILED` if the App lacks access).
    2. Repository show page → "Run sync" button visible in the header (project owner only). Click it — button disables + spins, badge flips to `SYNCING`, then refreshes to `SYNCED`/`FAILED`.
    3. Spam-click the button five times — only one job runs because `sync_status` flips to `syncing` synchronously.

## Self-review notes

Ran `superpowers:code-reviewer`. **One material + two nits, all addressed in commit `47e8a44`** before pushing:

- **[material]** Idempotency / race — five rapid clicks queued five jobs (and 10 child cascades). Flip `sync_status='syncing'` synchronously in the controller so the button disables on the next render; one effective dispatch per click-burst. Cheaper than `ShouldBeUnique` on the job and gives users immediate UI feedback.
- **[nit]** Header button styling now matches per-tab Issues/PR sync buttons exactly.
- **[nit]** Added an idempotent-re-sync test (already-synced repo can be re-synced) and an assertion that `sync_status` flips to `syncing`.

## Out of scope

- Adding `ShouldBeUnique` (per-job-class debounce) — current synchronous flip is sufficient for the click-spam scenario; a more sophisticated retry/debounce policy can come with the wider sync-engine work in later phases.
- Repainting the per-tab Run sync controllers to use the same synchronous-flip pattern — out of scope for this PR but a reasonable follow-up if desired.