### PR TITLE
chore(tests): silence test-emitted log lines so they don't leak into Pail

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,6 +21,14 @@
         <env name="APP_ENV" value="testing"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
+        <!-- Route test-emitted log lines to the null channel so they don't
+             leak into storage/logs/laravel.log and surface inside `composer
+             run dev`'s Pail tail. Tests that need to assert on log output
+             can still use Log::shouldReceive(...) or Log::swap(new Logger).
+             Without this, the failure-path tests (e.g. ProcessGitHubWebhookJob's
+             "Synthetic boom" assertion) showed up as red ERROR banners in
+             the running dev terminal and looked like real bugs. -->
+        <env name="LOG_CHANNEL" value="null"/>
         <env name="BROADCAST_CONNECTION" value="null"/>
         <env name="CACHE_STORE" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>


### PR DESCRIPTION
Failure-path tests (e.g. `ProcessGitHubWebhookJob`'s synthetic-boom assertion) write intentional `Log::error("GitHub webhook processing failed", …)` lines that the failure-path code path emits. Tests share `storage/logs/laravel.log` with the dev environment, so when a developer runs \`php artisan test\` while \`composer run dev\` is up, those expected error logs surface as red ERROR banners in the Pail tail and look like real bugs.

Set \`LOG_CHANNEL=null\` in \`phpunit.xml\`'s `<php>` block — tests now write to Monolog's `NullHandler` (drops every record). The dev terminal stays clean. Tests that need to assert on log output can still use `Log::shouldReceive(...)` or `Log::swap(new Logger)` inside their own setUp.

## Test plan
- [x] `vendor/bin/pint --test` clean
- [x] `php artisan test` 208/208 green
- [x] `npm run build` (no JS changes, but checked anyway) — green
- [ ] Manual: run \`php artisan test\` while \`composer run dev\` is up — Pail tail should NOT show the "GitHub webhook processing failed" line that it used to emit during the synthetic-boom test.