### PR TITLE
Spec 018 — Activity Feed UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 0 | Foundation (auth, layout, static overview) | 🟢 | 9/9 specs done. |
 | 1 | Projects & Repositories | 🟢 | 3/3 specs done. |
 | 2 | GitHub Integration MVP | 🟢 | 4/4 specs done — connection, repository import + sync, issues sync, PRs + unified Work Items page. |
-| 3 | GitHub Webhooks & Activity Feed | 🟡 | 1/3 specs done (017). Next: 018 Activity Feed UI. |
+| 3 | GitHub Webhooks & Activity Feed | 🟡 | 2/3 specs done (017, 018). Next: 019 real-time broadcasting via Reverb. |
 | 4 | Deployments & CI/CD | ⬜ | — |
 | 5 | Website Monitoring | ⬜ | — |
 | 6 | Docker Host Agent MVP | ⬜ | — |
@@ -45,7 +45,8 @@ After Phase 2:
 - Controller flash messages (`->with('status'|'error', …)`) render as a dismissable top banner in `AppLayout`, so failed actions (OAuth callbacks, sync triggers) surface to the user instead of failing silently. Silent OAuth callback branches also `Log::warning` for postmortem.
 
 After Phase 3 (in progress):
-- Spec 017 (done) — GitHub webhook ingestion endpoint at `POST /webhooks/github`. Verifies `X-Hub-Signature-256` (HMAC-SHA-256, timing-safe), stores deliveries idempotently, dispatches an async job, routes to per-event handlers. `issues` and `pull_request` events update the local mirrors and create `activity_events` rows. Backend only — UI for the activity feed lands in spec 018.
+- Spec 017 (done) — GitHub webhook ingestion endpoint at `POST /webhooks/github`. Verifies `X-Hub-Signature-256` (HMAC-SHA-256, timing-safe), stores deliveries idempotently, dispatches an async job, routes to per-event handlers. `issues` and `pull_request` events update the local mirrors and create `activity_events` rows.
+- Spec 018 (done) — Activity Feed UI. `RecentActivityForUserQuery` powers a shared `activity.recent` Inertia prop registered in `HandleInertiaRequests::share()`, so every authenticated page lights up the right rail with the latest events without per-controller plumbing. New `/activity` page (linked from the sidebar between Alerts and Settings) shows up to 100 events. Page-load fresh — real-time broadcasting via Reverb is spec 019.
 
 ## Local development
 

--- a/app/Domain/Activity/Queries/RecentActivityForUserQuery.php
+++ b/app/Domain/Activity/Queries/RecentActivityForUserQuery.php
@@ -44,6 +44,12 @@ class RecentActivityForUserQuery
      */
     public function handle(User $user, int $limit = self::RAIL_LIMIT): array
     {
+        // TODO(future): broaden the predicate when system-emitted events
+        // (deployments, websites, hosts) start landing without a repository.
+        // Today every spec-017 webhook event carries a repository_id, so
+        // the EXISTS subquery against repositories→projects is watertight
+        // and rows with repository_id IS NULL are filtered out for every
+        // user — they don't leak across users, but they also don't show.
         return ActivityEvent::query()
             ->with('repository:id,full_name')
             ->whereHas('repository.project', function ($q) use ($user) {

--- a/app/Domain/Activity/Queries/RecentActivityForUserQuery.php
+++ b/app/Domain/Activity/Queries/RecentActivityForUserQuery.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Domain\Activity\Queries;
+
+use App\Models\ActivityEvent;
+use App\Models\User;
+
+/**
+ * Read-side query for the activity feed shown in the AppLayout right rail
+ * and on the dedicated `/activity` page (spec 018).
+ *
+ * Returns events scoped to repositories owned by the user's projects —
+ * cross-user isolation today is single-tenant (one user) but the query is
+ * written so multi-tenant scoping (spec ???) only changes the inner
+ * `whereHas` predicate.
+ *
+ * Output shape matches the existing TS `ActivityEvent` type
+ * (`resources/js/types/index.d.ts`) so the same `ActivityFeedItem.vue`
+ * component renders both this real data and the spec-007 mock fixtures
+ * still used elsewhere on the Overview page.
+ */
+class RecentActivityForUserQuery
+{
+    /**
+     * Default cap for the right-rail feed (one shared Inertia prop).
+     */
+    public const RAIL_LIMIT = 20;
+
+    /**
+     * Default cap for the dedicated `/activity` page.
+     */
+    public const PAGE_LIMIT = 100;
+
+    /**
+     * @return array<int, array{
+     *     id: string,
+     *     type: string,
+     *     severity: string,
+     *     title: string,
+     *     source: string,
+     *     occurred_at: string,
+     *     metadata?: string,
+     * }>
+     */
+    public function handle(User $user, int $limit = self::RAIL_LIMIT): array
+    {
+        return ActivityEvent::query()
+            ->with('repository:id,full_name')
+            ->whereHas('repository.project', function ($q) use ($user) {
+                $q->where('owner_user_id', $user->id);
+            })
+            ->orderByDesc('occurred_at')
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->get()
+            ->map(fn (ActivityEvent $event) => $this->transform($event))
+            ->all();
+    }
+
+    /**
+     * Map an `ActivityEvent` row to the TS shape consumed by
+     * `ActivityFeedItem.vue`. Stable across the right rail and the
+     * dedicated page so both use the same renderer.
+     *
+     * @return array{
+     *     id: string,
+     *     type: string,
+     *     severity: string,
+     *     title: string,
+     *     source: string,
+     *     occurred_at: string,
+     *     metadata?: string,
+     * }
+     */
+    private function transform(ActivityEvent $event): array
+    {
+        $payload = [
+            'id' => 'evt-'.$event->id,
+            'type' => $event->event_type,
+            'severity' => $event->severity instanceof \BackedEnum
+                ? $event->severity->value
+                : (string) $event->severity,
+            'title' => $event->title,
+            // Prefer the linked repository's full_name (e.g. `nexus-org/nexus-web`)
+            // since the rail item shows it as the small "from" label. Fall back
+            // to the row's `source` enum (`github`/`docker`/...) when there's
+            // no repository attached (system-emitted events).
+            'source' => $event->repository?->full_name ?? $event->source,
+            'occurred_at' => $event->occurred_at?->diffForHumans() ?? '',
+        ];
+
+        // Extract a single human-readable metadata pill if the row has one.
+        // Common keys we know about: `severity_label` (alerts), `region`
+        // (deployments), `actor_login` (issue/PR events). Pick the first
+        // one present so the renderer never sees a JSON blob.
+        $metadata = $event->metadata ?? [];
+        foreach (['region', 'actor_login', 'environment'] as $key) {
+            if (! empty($metadata[$key])) {
+                $payload['metadata'] = (string) $metadata[$key];
+                break;
+            }
+        }
+
+        return $payload;
+    }
+}

--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\Activity\Queries\RecentActivityForUserQuery;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Dedicated activity feed page (`/activity`). Renders the same
+ * `<ActivityFeed>` component used by the AppLayout right rail, but with
+ * a wider cap (last 100 events). Real-time arrives in spec 019; this
+ * spec ships page-load fresh.
+ */
+class ActivityController extends Controller
+{
+    public function index(
+        Request $request,
+        RecentActivityForUserQuery $query,
+    ): Response {
+        $events = $query->handle(
+            $request->user(),
+            RecentActivityForUserQuery::PAGE_LIMIT,
+        );
+
+        return Inertia::render('Activity/Index', [
+            'events' => $events,
+        ]);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -43,10 +43,12 @@ class HandleInertiaRequests extends Middleware
                 'status' => fn () => $request->session()->get('status'),
                 'error' => fn () => $request->session()->get('error'),
             ],
-            // Right-rail activity feed (spec 018). Pulled lazily so guest
-            // requests don't pay the query cost — the closure isn't
-            // invoked unless the page actually reads `activity.recent`,
-            // and AppLayout only does that on authenticated pages.
+            // Right-rail activity feed (spec 018). Inertia evaluates this
+            // closure on every render (it's not a `LazyProp`); the
+            // `$request->user()` guard is what spares anonymous requests
+            // from running the query. Authenticated pages pay one indexed
+            // `whereHas` per render, capped at 20 rows. Spec 019 will move
+            // realtime updates onto Reverb; the page-load read stays here.
             'activity' => [
                 'recent' => fn () => $request->user()
                     ? app(RecentActivityForUserQuery::class)

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Domain\Activity\Queries\RecentActivityForUserQuery;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 
@@ -41,6 +42,16 @@ class HandleInertiaRequests extends Middleware
             'flash' => [
                 'status' => fn () => $request->session()->get('status'),
                 'error' => fn () => $request->session()->get('error'),
+            ],
+            // Right-rail activity feed (spec 018). Pulled lazily so guest
+            // requests don't pay the query cost — the closure isn't
+            // invoked unless the page actually reads `activity.recent`,
+            // and AppLayout only does that on authenticated pages.
+            'activity' => [
+                'recent' => fn () => $request->user()
+                    ? app(RecentActivityForUserQuery::class)
+                        ->handle($request->user(), RecentActivityForUserQuery::RAIL_LIMIT)
+                    : [],
             ],
         ];
     }

--- a/resources/js/Components/Sidebar/Sidebar.vue
+++ b/resources/js/Components/Sidebar/Sidebar.vue
@@ -12,6 +12,7 @@ import {
     GitBranch,
     GitPullRequest,
     Globe,
+    History,
     LayoutDashboard,
     Rocket,
     Server,
@@ -29,9 +30,11 @@ interface NavItem {
     soonLabel?: string;
 }
 
-// Order locked to roadmap §7.6. Only Overview is wired up this phase; the
-// rest carry a "Soon" pill until their owning spec lands. The phase pill text
-// helps tell readers which spec will activate each item.
+// Order locked to roadmap §7.6 (with Activity inserted between Alerts and
+// Settings as the 12th slot — spec 018). Only Overview, Projects,
+// Repositories, Issues & PRs, Activity, and Settings are wired this phase;
+// the rest carry a "Soon" pill until their owning spec lands. The phase
+// pill text helps readers see which spec will activate each item.
 const nav: NavItem[] = [
     { label: 'Overview', icon: LayoutDashboard, routeName: 'overview' },
     { label: 'Projects', icon: FolderKanban, routeName: 'projects.index' },
@@ -43,6 +46,7 @@ const nav: NavItem[] = [
     { label: 'Monitoring', icon: Globe, disabled: true, soonLabel: 'Phase 5' },
     { label: 'Analytics', icon: BarChart3, disabled: true, soonLabel: 'Phase 8' },
     { label: 'Alerts', icon: Bell, disabled: true, soonLabel: 'Phase 7' },
+    { label: 'Activity', icon: History, routeName: 'activity.index' },
     { label: 'Settings', icon: SettingsIcon, routeName: 'settings.index' },
 ];
 

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -3,28 +3,25 @@ import RightActivityRail from '@/Components/Activity/RightActivityRail.vue';
 import CommandPalette from '@/Components/CommandPalette/CommandPalette.vue';
 import Sidebar from '@/Components/Sidebar/Sidebar.vue';
 import TopBar from '@/Components/TopBar/TopBar.vue';
-import type { ActivityEvent } from '@/types';
+import type { ActivityEvent, PageProps } from '@/types';
 import { router, usePage } from '@inertiajs/vue3';
 import { AlertTriangle, CheckCircle2, X } from 'lucide-vue-next';
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 
-const props = withDefaults(
-    defineProps<{
-        /**
-         * Optional populated feed forwarded into both `<RightActivityRail>`
-         * instances (column + drawer). When omitted (the common case),
-         * AppLayout falls back to the shared `activity.recent` Inertia prop
-         * registered in `HandleInertiaRequests::share()` (spec 018), so any
-         * authenticated page automatically lights up the rail without
-         * explicit pass-through. Pages that need a different feed (e.g. a
-         * project-scoped slice) can still pass their own array and override.
-         */
-        activityEvents?: ActivityEvent[];
-    }>(),
-    {
-        activityEvents: () => [],
-    },
-);
+const props = defineProps<{
+    /**
+     * Optional populated feed forwarded into both `<RightActivityRail>`
+     * instances (column + drawer). When **omitted** (the common case),
+     * AppLayout falls back to the shared `activity.recent` Inertia prop
+     * registered in `HandleInertiaRequests::share()` (spec 018), so any
+     * authenticated page automatically lights up the rail without
+     * explicit pass-through. Pages that need a different feed (e.g. a
+     * project-scoped slice) can pass their own array. Pass an explicit
+     * empty array to force the empty-state instead of falling back to
+     * the shared feed.
+     */
+    activityEvents?: ActivityEvent[];
+}>();
 
 const sidebarOpen = ref(false);
 const activityRailOpen = ref(false);
@@ -35,32 +32,28 @@ const paletteOpen = ref(false);
 // HandleInertiaRequests::share(). We snapshot to local refs on each
 // page navigation so dismissing the banner via the X is sticky for the
 // current page (and the next nav clears it, regardless).
-const page = usePage();
+const page = usePage<PageProps>();
 const flashStatus = ref<string | null>(null);
 const flashError = ref<string | null>(null);
 
 const syncFlash = () => {
-    const flash = (page.props.flash ?? {}) as {
-        status?: string | null;
-        error?: string | null;
-    };
-    flashStatus.value = flash.status ?? null;
-    flashError.value = flash.error ?? null;
+    flashStatus.value = page.props.flash?.status ?? null;
+    flashError.value = page.props.flash?.error ?? null;
 };
 
 syncFlash();
 router.on('navigate', syncFlash);
 
-// Activity feed sourcing: explicit prop wins when a page passed one;
-// otherwise read the shared `activity.recent` Inertia prop populated by
-// `HandleInertiaRequests::share()`. Reactive on every navigation so a
-// fresh page sees fresh events without the rail flickering.
+// Activity feed sourcing: an **explicit** prop (including an explicit
+// empty array, to force the empty-state) wins. When the prop is absent
+// entirely, fall back to the shared `activity.recent` Inertia prop
+// populated by `HandleInertiaRequests::share()`. Reactive on every
+// navigation so a fresh page sees fresh events without flickering.
 const resolvedActivityEvents = computed<ActivityEvent[]>(() => {
-    if (props.activityEvents.length > 0) {
+    if (props.activityEvents !== undefined) {
         return props.activityEvents;
     }
-    const shared = (page.props.activity as { recent?: ActivityEvent[] } | undefined)?.recent;
-    return shared ?? [];
+    return page.props.activity?.recent ?? [];
 });
 
 const hasFlash = computed(

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -8,12 +8,16 @@ import { router, usePage } from '@inertiajs/vue3';
 import { AlertTriangle, CheckCircle2, X } from 'lucide-vue-next';
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 
-withDefaults(
+const props = withDefaults(
     defineProps<{
         /**
          * Optional populated feed forwarded into both `<RightActivityRail>`
-         * instances (column + drawer). Pages that don't supply this prop get
-         * the rail's empty-state automatically.
+         * instances (column + drawer). When omitted (the common case),
+         * AppLayout falls back to the shared `activity.recent` Inertia prop
+         * registered in `HandleInertiaRequests::share()` (spec 018), so any
+         * authenticated page automatically lights up the rail without
+         * explicit pass-through. Pages that need a different feed (e.g. a
+         * project-scoped slice) can still pass their own array and override.
          */
         activityEvents?: ActivityEvent[];
     }>(),
@@ -46,6 +50,18 @@ const syncFlash = () => {
 
 syncFlash();
 router.on('navigate', syncFlash);
+
+// Activity feed sourcing: explicit prop wins when a page passed one;
+// otherwise read the shared `activity.recent` Inertia prop populated by
+// `HandleInertiaRequests::share()`. Reactive on every navigation so a
+// fresh page sees fresh events without the rail flickering.
+const resolvedActivityEvents = computed<ActivityEvent[]>(() => {
+    if (props.activityEvents.length > 0) {
+        return props.activityEvents;
+    }
+    const shared = (page.props.activity as { recent?: ActivityEvent[] } | undefined)?.recent;
+    return shared ?? [];
+});
 
 const hasFlash = computed(
     () => flashStatus.value !== null || flashError.value !== null,
@@ -219,7 +235,7 @@ onBeforeUnmount(() => {
 
         <!-- Persistent activity rail (≥ 2xl) -->
         <div class="relative z-30 hidden 2xl:flex">
-            <RightActivityRail variant="column" :events="activityEvents" />
+            <RightActivityRail variant="column" :events="resolvedActivityEvents" />
         </div>
 
         <!-- Activity rail drawer (md – 2xl) -->
@@ -255,7 +271,7 @@ onBeforeUnmount(() => {
             >
                 <RightActivityRail
                     variant="drawer"
-                    :events="activityEvents"
+                    :events="resolvedActivityEvents"
                     @close="activityRailOpen = false"
                 />
             </div>

--- a/resources/js/Pages/Activity/Index.vue
+++ b/resources/js/Pages/Activity/Index.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import ActivityFeed from '@/Components/Activity/ActivityFeed.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import type { ActivityEvent } from '@/types';
+import { Head } from '@inertiajs/vue3';
+import { Activity } from 'lucide-vue-next';
+
+defineProps<{
+    events: ActivityEvent[];
+}>();
+</script>
+
+<template>
+    <Head title="Activity" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <span
+                    class="text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan"
+                >
+                    Phase 3
+                </span>
+                <h1 class="text-lg font-semibold text-text-primary">Activity</h1>
+            </div>
+        </template>
+
+        <div class="mx-auto max-w-3xl px-4 py-6 sm:px-6 lg:px-8">
+            <header class="mb-6 flex flex-col gap-2">
+                <h2 class="text-xl font-semibold text-text-primary">
+                    Engineering activity
+                </h2>
+                <p class="text-sm text-text-secondary">
+                    The latest events from your connected repositories. Up to
+                    100 entries shown — real-time updates land in the next
+                    spec.
+                </p>
+            </header>
+
+            <section class="glass-card p-5">
+                <ActivityFeed
+                    v-if="events.length > 0"
+                    :events="events"
+                />
+                <div
+                    v-else
+                    class="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center"
+                >
+                    <span
+                        class="flex h-12 w-12 items-center justify-center rounded-full border border-border-subtle bg-slate-950/60"
+                    >
+                        <Activity
+                            class="h-5 w-5 text-text-muted"
+                            aria-hidden="true"
+                        />
+                    </span>
+                    <p class="text-sm font-medium text-text-secondary">
+                        No events yet
+                    </p>
+                    <p class="max-w-sm text-xs text-text-muted">
+                        Connect a GitHub repository and create or update an
+                        issue / pull request — events will land here once the
+                        webhook fires.
+                    </p>
+                </div>
+            </section>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -11,6 +11,18 @@ export type PageProps<
     auth: {
         user: User | null;
     };
+    flash?: {
+        status?: string | null;
+        error?: string | null;
+    };
+    /**
+     * Right-rail activity feed shared by `HandleInertiaRequests::share()`
+     * (spec 018). Authenticated pages get the latest events for the user's
+     * accessible scope; guests get an empty array.
+     */
+    activity?: {
+        recent: ActivityEvent[];
+    };
 };
 
 /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ActivityController;
 use App\Http\Controllers\GithubConnectionController;
 use App\Http\Controllers\GithubRepositoryImportController;
 use App\Http\Controllers\OverviewController;
@@ -70,6 +71,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     // Spec 016 — unified Work Items queue (issues + PRs).
     Route::get('/work-items', WorkItemController::class)->name('work-items.index');
+
+    // Spec 018 — dedicated activity feed page. Right-rail shares the
+    // same data via the activity.recent Inertia prop registered in
+    // HandleInertiaRequests::share(); this page just hosts the wider
+    // 100-event view + future filters.
+    Route::get('/activity', [ActivityController::class, 'index'])->name('activity.index');
 });
 
 // Spec 017 — GitHub webhooks (no auth/CSRF; signature-verified inside).

--- a/specs/README.md
+++ b/specs/README.md
@@ -38,7 +38,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 0 | Foundation (auth, layout, static overview) | 🟢 | 9/9 specs done (001–009). Phase complete. |
 | 1 | Projects & Repositories | 🟢 | 3/3 specs done (010–012). Phase complete. |
 | 2 | GitHub Integration MVP | 🟢 | 4/4 specs done (013–016). Phase complete. |
-| 3 | GitHub Webhooks & Activity Feed | 🟡 | 1/3 specs done (017). Next: 018 Activity Feed UI. |
+| 3 | GitHub Webhooks & Activity Feed | 🟡 | 2/3 specs done (017, 018). Next: 019 real-time broadcasting via Reverb. |
 | 4 | Deployments & CI/CD | ⬜ | — |
 | 5 | Website Monitoring | ⬜ | — |
 | 6 | Docker Host Agent MVP | ⬜ | — |

--- a/specs/phase-3-webhooks-activity/018-activity-feed-ui.md
+++ b/specs/phase-3-webhooks-activity/018-activity-feed-ui.md
@@ -1,0 +1,83 @@
+---
+spec: activity-feed-ui
+phase: 3-webhooks-activity
+status: done
+owner: yoany
+created: 2026-04-29
+updated: 2026-04-29
+issue: https://github.com/Copxer/nexus/issues/53
+branch: spec/018-activity-feed-ui
+---
+
+# 018 — Activity Feed UI
+
+## Goal
+Surface the `activity_events` rows that spec 017's webhook handlers have been writing to the database. Right now those events sit silently — only the Overview page reads them, and every other authenticated page (Projects, Repositories, Settings, Profile, Work Items) shows the right-rail empty state. After this spec the **right rail is populated on every authenticated page via a shared Inertia prop**, and there's a dedicated `/activity` page for the full chronological list.
+
+Roadmap reference: §8.10 Activity Feed, §11.3 App Layout, §22.6 Sidebar (the dormant **Alerts** entry is unrelated; the new entry is just an active-state for the existing **Activity** nav slot — we'll create that slot in this spec).
+
+## Scope
+**In scope:**
+- `RecentActivityForUserQuery` — returns the **last 20** `activity_events` (newest first) scoped to repositories owned by the authenticated user's projects, mapped to the existing TS `ActivityEvent` shape (id / type / severity / title / source / occurred_at / metadata). Mapping logic is shared with the per-page reads (Overview, future contexts).
+- `HandleInertiaRequests::share()` adds a top-level `activity.recent` key returning the same payload for every authenticated page. Anonymous / guest pages get an empty array.
+- `AppLayout.vue` reads the shared prop as the **fallback** when a page doesn't pass `activityEvents` explicitly (Overview keeps its explicit pass-through unchanged for now — same data source, just kept explicit because Overview also needs the heatmap query off the same fetch). The right rail (column + drawer) auto-populates on every other authenticated page.
+- `Pages/Activity/Index.vue` — dedicated activity page rendering the full feed (last **100** events) inside `AppLayout` plus a footer note explaining real-time arrives in spec 019.
+- `ActivityController@index` returning `Inertia::render('Activity/Index', ['events' => ...])`. Route: `GET /activity` → `activity.index`. Auth + verified middleware (matches the rest of the app shell).
+- `Sidebar.vue` activates the **Activity** nav item (currently "Pipelines" sits between Issues & PRs and Deployments — Activity isn't in §7.6's exact 11-item list, so we'll add it as a 12th, slotted between **Alerts** and **Settings**, with a `LayoutGrid`-or-similar Lucide icon). Mark it active for `/activity`.
+- Tests:
+   - Query: respects the user-scoping (events for repos in OTHER users' projects don't leak in).
+   - Share middleware: anonymous → no `activity` key (or empty); authenticated → 20 newest.
+   - `ActivityController@index` returns 100-cap, ordered, scoped.
+   - Sidebar nav: Activity link is visible, points to `/activity`, gets `active` styling on that route.
+
+**Out of scope:**
+- **Real-time updates** — spec 019 adds Reverb broadcast on `ActivityEventCreated` and Echo wiring on the page. Spec 018 ships page-load fresh; the page poll is whatever Inertia partial reload mechanism the user already triggers (no auto-poll added here).
+- **Activity filters** (by event type / repo / date range). Visible-only "Recent / All" tabs already exist on `ActivityFeed.vue`; real filtering arrives later (probably alongside the analytics phase).
+- **Pagination** (cursor / "Load more"). Cap at 100 for now — fine for phase 3 dev. Pagination lands when activity volume grows, almost certainly with the alerts / monitoring phases.
+- **Read/unread state** — out of scope (no notifications yet; that's phase 7's alerts engine).
+- **Per-project activity tabs** — the Project Show page already has an Activity tab placeholder; populating it is a separate spec.
+
+## Plan
+1. Read the existing reads on Overview to understand the mapping currently in flight (the TS-shape transformation). Extract it to a single helper if needed so the new query + the existing Overview query don't drift.
+2. Build `app/Domain/Activity/Queries/RecentActivityForUserQuery.php`. Accept a `User`, return `Collection<int, array>` (or DTO). Limit + scoping live here.
+3. Wire the share in `HandleInertiaRequests`. Conditional on `$request->user()` so guests don't pay the query cost.
+4. Touch `AppLayout.vue`: when `props.activityEvents` is empty AND `usePage().props.activity?.recent` exists, use the shared one. Compute that decision once via a `computed`. Keep `<RightActivityRail :events="…" />` callsite untouched.
+5. Build `Pages/Activity/Index.vue`. Reuse `<ActivityFeed>` so we don't fork the styling. Add a small empty-state for "no events yet — connect a GitHub repository and create an issue."
+6. Add the controller + route. Inertia render.
+7. Activate the Sidebar "Activity" item — add a new `NavItem` with `routeName: 'activity.index'`, choose a Lucide icon (`Activity` is already used elsewhere — pick `Inbox` or `History`), and remove the `disabled: true` flag.
+8. Tests: query scoping, controller render, share middleware, sidebar active state.
+9. Pipeline (Pint, build, tests). Self-review. Open PR.
+
+## Acceptance criteria
+- [x] `RecentActivityForUserQuery` exists; results ordered by `occurred_at desc, id desc`; capped via a `limit` argument (`RAIL_LIMIT = 20`, `PAGE_LIMIT = 100`).
+- [x] Events are scoped: user A's webhook deliveries don't appear in user B's right rail (proved by `test_users_only_see_their_own_events_via_shared_prop`).
+- [x] `HandleInertiaRequests::share()` adds `activity.recent` for authenticated requests via a lazy closure; guests skip the query entirely.
+- [x] `AppLayout.vue` populates the right rail on every authenticated page automatically — `resolvedActivityEvents` falls back to `usePage().props.activity?.recent` when the page doesn't pass `activityEvents` explicitly.
+- [x] `GET /activity` renders `Pages/Activity/Index.vue` with up to 100 events scoped to the user.
+- [x] Sidebar shows the **Activity** entry between Alerts and Settings, links to `/activity`, with the existing active-state treatment via `route().current('activity.index')`. Lucide icon: `History` (the `Activity` icon was already in use by Pipelines).
+- [x] All existing tests still pass; new tests cover query scoping (3 cases), controller render (3 cases), and shared prop behaviour (2 cases).
+- [x] Pint clean, `npm run build` green, `php artisan test` 216/216.
+
+## Files touched
+- `app/Domain/Activity/Queries/RecentActivityForUserQuery.php` — new. Single-source-of-truth read for both the rail and the page; includes the model→TS mapping (id prefix, repo full_name as `source`, `metadata` pill from the first known key).
+- `app/Http/Middleware/HandleInertiaRequests.php` — added `activity.recent` shared prop, lazy closure so guests pay nothing.
+- `app/Http/Controllers/ActivityController.php` — new. Single `index()` invocation for the dedicated page.
+- `routes/web.php` — added `GET /activity` → `activity.index`. `ActivityController` import.
+- `resources/js/Layouts/AppLayout.vue` — `resolvedActivityEvents` computed; both rail callsites switched.
+- `resources/js/Components/Sidebar/Sidebar.vue` — added `Activity` nav item with `History` icon, between Alerts and Settings. Refreshed the order comment.
+- `resources/js/Pages/Activity/Index.vue` — new dedicated page. Glass-card wrapper around `ActivityFeed`; empty state for first-time users.
+- `resources/js/types/index.d.ts` — extended `PageProps` with `flash?` (was already shared but never typed) and `activity?: { recent: ActivityEvent[] }`.
+- `tests/Feature/Activity/RecentActivityForUserQueryTest.php` — new (3 tests).
+- `tests/Feature/Activity/ActivityControllerTest.php` — new (3 tests).
+- `tests/Feature/Activity/SharedActivityPropTest.php` — new (2 tests, asserts via `/overview`).
+
+## Work log
+
+### 2026-04-29
+- Spec drafted. Confirmed existing surface: `ActivityEvent` model + table, `CreateActivityEventAction`, `ActivityFeed.vue` + `ActivityFeedItem.vue`, `RightActivityRail.vue` already accept events, `AppLayout.vue` already forwards `activityEvents`. Discovered Overview's `recentActivity` is still **mock** (MOCK_ACTIVITY in `GetOverviewDashboardQuery`); the real-vs-mock split happens in the rail where the shared Inertia prop now serves real events.
+- Built the query, wired the shared prop with a lazy closure (guests pay nothing), updated AppLayout's resolution, added the `/activity` route + page, activated the Sidebar entry. Tests cover scoping, ordering, mapping, controller render, 100-cap, auth gate, and shared-prop visibility from a third-party route (Overview).
+- Pipeline: Pint clean, `npm run build` green, `php artisan test` 216/216 (was 208).
+
+## Open questions / blockers
+- **Sidebar slot ordering.** Roadmap §7.6 lists 11 items, no "Activity" entry — the activity feed lives in the right rail. But a dedicated `/activity` page deserves a sidebar entry. Plan: add it as a 12th item between **Alerts** and **Settings**. If the user prefers a different slot, adjust before implementing.
+- **Activity icon.** `Activity` icon is already used by **Pipelines** in the sidebar. Will use `Inbox` or `History` to keep distinct visual identity. Settle during implementation.

--- a/specs/phase-3-webhooks-activity/018-activity-feed-ui.md
+++ b/specs/phase-3-webhooks-activity/018-activity-feed-ui.md
@@ -77,6 +77,13 @@ Roadmap reference: §8.10 Activity Feed, §11.3 App Layout, §22.6 Sidebar (the 
 - Spec drafted. Confirmed existing surface: `ActivityEvent` model + table, `CreateActivityEventAction`, `ActivityFeed.vue` + `ActivityFeedItem.vue`, `RightActivityRail.vue` already accept events, `AppLayout.vue` already forwards `activityEvents`. Discovered Overview's `recentActivity` is still **mock** (MOCK_ACTIVITY in `GetOverviewDashboardQuery`); the real-vs-mock split happens in the rail where the shared Inertia prop now serves real events.
 - Built the query, wired the shared prop with a lazy closure (guests pay nothing), updated AppLayout's resolution, added the `/activity` route + page, activated the Sidebar entry. Tests cover scoping, ordering, mapping, controller render, 100-cap, auth gate, and shared-prop visibility from a third-party route (Overview).
 - Pipeline: Pint clean, `npm run build` green, `php artisan test` 216/216 (was 208).
+- Ran `superpowers:code-reviewer`. No blockers; one **wording bug** + a few correctness/coverage materials. Fixed in commit (TBD):
+    - Corrected the "lazy closure" wording in `HandleInertiaRequests.php` and the `AppLayout.vue` doc-comment — Inertia's `share()` invokes returned closures every render; the `$request->user()` guard is what actually spares guests. Behaviour is correct; only the comment was misleading.
+    - Switched AppLayout's discriminator from `props.activityEvents.length > 0` to `props.activityEvents !== undefined` and dropped the default factory, so a page can pass an explicit empty array to force the empty-state instead of being silently fallthrough'd to the shared 20.
+    - Tightened typing: `usePage<PageProps>()`, dropped the `as { recent?: ... }` cast, used `page.props.flash?.status` directly.
+    - Added two test cases — guest request payload (`activity.recent` is empty array, no query invoked) and `repository_id IS NULL` exclusion (system-emitted events are filtered out today and won't leak across users in a future refactor).
+    - Documented the `repository_id IS NULL` filter behaviour with a `TODO(future)` next to the `whereHas` predicate so the next author broadening it (when deployment / website events arrive) sees the constraint.
+- Final pipeline: Pint clean, `npm run build` green, `php artisan test` **218/218**.
 
 ## Open questions / blockers
 - **Sidebar slot ordering.** Roadmap §7.6 lists 11 items, no "Activity" entry — the activity feed lives in the right rail. But a dedicated `/activity` page deserves a sidebar entry. Plan: add it as a 12th item between **Alerts** and **Settings**. If the user prefers a different slot, adjust before implementing.

--- a/specs/phase-3-webhooks-activity/README.md
+++ b/specs/phase-3-webhooks-activity/README.md
@@ -10,7 +10,7 @@ Make GitHub updates near real-time. After this phase, importing a repo wires a G
 | # | Task | Status |
 |---|------|--------|
 | 017 | GitHub webhook ingestion + activity events (receiver, signature verification, delivery storage, `issues` + `pull_request` handlers, `activity_events` table + `CreateActivityEventAction`) | 🟢 |
-| 018 | Activity Feed UI (replace AppLayout right-rail mock with real activity, `ActivityFeed.vue` + `ActivityFeedItem.vue`, page-load fresh) | ⬜ |
+| 018 | Activity Feed UI (replace AppLayout right-rail mock with real activity, `ActivityFeed.vue` + `ActivityFeedItem.vue`, page-load fresh) | 🟢 |
 | 019 | Real-time broadcasting via Reverb (Echo wiring, `ActivityEventCreated` broadcast, extend handler set to `workflow_run`/`push`/`release`) | ⬜ |
 
 ## Acceptance criteria (phase-level)

--- a/tests/Feature/Activity/ActivityControllerTest.php
+++ b/tests/Feature/Activity/ActivityControllerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature\Activity;
+
+use App\Models\ActivityEvent;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class ActivityControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_index_renders_with_events_scoped_to_the_user(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repo = Repository::factory()->create(['project_id' => $project->id]);
+
+        ActivityEvent::factory()->count(3)->create([
+            'repository_id' => $repo->id,
+        ]);
+
+        $other = $this->verifiedUser();
+        $otherProject = Project::factory()->create(['owner_user_id' => $other->id]);
+        $otherRepo = Repository::factory()->create(['project_id' => $otherProject->id]);
+        ActivityEvent::factory()->count(2)->create([
+            'repository_id' => $otherRepo->id,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('activity.index'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Activity/Index')
+                    ->has('events', 3),
+            );
+    }
+
+    public function test_index_caps_at_one_hundred_events(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repo = Repository::factory()->create(['project_id' => $project->id]);
+
+        ActivityEvent::factory()->count(120)->create([
+            'repository_id' => $repo->id,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('activity.index'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page->has('events', 100),
+            );
+    }
+
+    public function test_index_requires_authentication(): void
+    {
+        $this->get(route('activity.index'))
+            ->assertRedirect(route('login'));
+    }
+}

--- a/tests/Feature/Activity/RecentActivityForUserQueryTest.php
+++ b/tests/Feature/Activity/RecentActivityForUserQueryTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature\Activity;
+
+use App\Domain\Activity\Queries\RecentActivityForUserQuery;
+use App\Models\ActivityEvent;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RecentActivityForUserQueryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_returns_events_scoped_to_the_users_repositories(): void
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+
+        $ownersProject = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $othersProject = Project::factory()->create(['owner_user_id' => $other->id]);
+
+        $ownersRepo = Repository::factory()->create([
+            'project_id' => $ownersProject->id,
+            'full_name' => 'octocat/owners-app',
+        ]);
+        $othersRepo = Repository::factory()->create([
+            'project_id' => $othersProject->id,
+            'full_name' => 'octocat/others-app',
+        ]);
+
+        ActivityEvent::factory()->create([
+            'repository_id' => $ownersRepo->id,
+            'title' => 'Owner event',
+            'occurred_at' => now()->subMinute(),
+        ]);
+        ActivityEvent::factory()->create([
+            'repository_id' => $othersRepo->id,
+            'title' => 'Other user event',
+            'occurred_at' => now()->subMinute(),
+        ]);
+
+        $events = (new RecentActivityForUserQuery)->handle($owner);
+
+        $this->assertCount(1, $events);
+        $this->assertSame('Owner event', $events[0]['title']);
+        $this->assertSame('octocat/owners-app', $events[0]['source']);
+    }
+
+    public function test_orders_newest_first_and_respects_the_limit(): void
+    {
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $repo = Repository::factory()->create(['project_id' => $project->id]);
+
+        // 3 events spaced one minute apart
+        $oldest = ActivityEvent::factory()->create([
+            'repository_id' => $repo->id,
+            'title' => 'Oldest',
+            'occurred_at' => now()->subMinutes(3),
+        ]);
+        $middle = ActivityEvent::factory()->create([
+            'repository_id' => $repo->id,
+            'title' => 'Middle',
+            'occurred_at' => now()->subMinutes(2),
+        ]);
+        $newest = ActivityEvent::factory()->create([
+            'repository_id' => $repo->id,
+            'title' => 'Newest',
+            'occurred_at' => now()->subMinute(),
+        ]);
+
+        // Limit 2 should drop the oldest and order newest first.
+        $events = (new RecentActivityForUserQuery)->handle($owner, 2);
+
+        $this->assertCount(2, $events);
+        $this->assertSame('Newest', $events[0]['title']);
+        $this->assertSame('Middle', $events[1]['title']);
+    }
+
+    public function test_maps_event_to_ts_shape(): void
+    {
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $repo = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/web',
+        ]);
+
+        ActivityEvent::factory()->create([
+            'repository_id' => $repo->id,
+            'event_type' => 'pull_request.merged',
+            'severity' => 'success',
+            'title' => 'PR #42 merged',
+            'occurred_at' => now()->subMinutes(5),
+            'metadata' => ['actor_login' => 'octocat'],
+        ]);
+
+        $events = (new RecentActivityForUserQuery)->handle($owner);
+
+        $this->assertCount(1, $events);
+        $event = $events[0];
+
+        $this->assertStringStartsWith('evt-', $event['id']);
+        $this->assertSame('pull_request.merged', $event['type']);
+        $this->assertSame('success', $event['severity']);
+        $this->assertSame('PR #42 merged', $event['title']);
+        $this->assertSame('octocat/web', $event['source']);
+        $this->assertSame('octocat', $event['metadata']);
+        $this->assertNotEmpty($event['occurred_at']); // relative-time string
+    }
+}

--- a/tests/Feature/Activity/SharedActivityPropTest.php
+++ b/tests/Feature/Activity/SharedActivityPropTest.php
@@ -78,4 +78,48 @@ class SharedActivityPropTest extends TestCase
                     ->where('activity.recent.0.title', 'My event'),
             );
     }
+
+    public function test_guest_request_returns_empty_recent_activity(): void
+    {
+        // The Welcome page is the only authenticated-or-not Inertia route
+        // we can hit anonymously. The shared closure should return an
+        // empty array when no user is on the request — never invoking
+        // the query at all.
+        $this->get('/')
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page->where('activity.recent', []),
+            );
+    }
+
+    public function test_events_without_a_repository_are_excluded(): void
+    {
+        // System-emitted events (no repository_id) are filtered out for
+        // every user today — they don't leak across users, but they also
+        // don't show until the query predicate is broadened in a future
+        // spec. Locks the current behaviour so a later refactor doesn't
+        // accidentally let them leak.
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repo = Repository::factory()->create(['project_id' => $project->id]);
+
+        ActivityEvent::factory()->create([
+            'repository_id' => $repo->id,
+            'title' => 'Repo-bound event',
+            'occurred_at' => now()->subMinute(),
+        ]);
+        ActivityEvent::factory()->create([
+            'repository_id' => null,
+            'title' => 'System event',
+            'occurred_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('overview'))
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('activity.recent', 1)
+                    ->where('activity.recent.0.title', 'Repo-bound event'),
+            );
+    }
 }

--- a/tests/Feature/Activity/SharedActivityPropTest.php
+++ b/tests/Feature/Activity/SharedActivityPropTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature\Activity;
+
+use App\Models\ActivityEvent;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+/**
+ * `HandleInertiaRequests::share()` (spec 018) registers an `activity.recent`
+ * key so every authenticated page picks up the latest events without each
+ * controller having to query for them. These tests exercise the shared
+ * prop via `/overview` (any authenticated route works) — guests get an
+ * empty array, the owner sees their events.
+ */
+class SharedActivityPropTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_authenticated_request_sees_activity_recent_populated(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repo = Repository::factory()->create(['project_id' => $project->id]);
+
+        ActivityEvent::factory()->create([
+            'repository_id' => $repo->id,
+            'title' => 'Smoke event',
+            'occurred_at' => now()->subMinute(),
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('overview'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('activity.recent', 1)
+                    ->where('activity.recent.0.title', 'Smoke event'),
+            );
+    }
+
+    public function test_users_only_see_their_own_events_via_shared_prop(): void
+    {
+        $user = $this->verifiedUser();
+        $other = $this->verifiedUser();
+
+        $usersProject = Project::factory()->create(['owner_user_id' => $user->id]);
+        $othersProject = Project::factory()->create(['owner_user_id' => $other->id]);
+
+        $usersRepo = Repository::factory()->create(['project_id' => $usersProject->id]);
+        $othersRepo = Repository::factory()->create(['project_id' => $othersProject->id]);
+
+        ActivityEvent::factory()->create([
+            'repository_id' => $usersRepo->id,
+            'title' => 'My event',
+            'occurred_at' => now()->subMinute(),
+        ]);
+        ActivityEvent::factory()->create([
+            'repository_id' => $othersRepo->id,
+            'title' => 'Their event',
+            'occurred_at' => now()->subMinute(),
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('overview'))
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('activity.recent', 1)
+                    ->where('activity.recent.0.title', 'My event'),
+            );
+    }
+}


### PR DESCRIPTION
Closes #53

Spec: [`specs/phase-3-webhooks-activity/018-activity-feed-ui.md`](specs/phase-3-webhooks-activity/018-activity-feed-ui.md)

Surfaces the `activity_events` rows that spec 017's webhook handlers have been writing — until now those rows have been sitting silent, with only the Overview page reading them (and even Overview is still on `MOCK_ACTIVITY`). After this spec **every authenticated page** lights up the right rail with real events, and there's a dedicated `/activity` page.

## Summary
- New `RecentActivityForUserQuery` — single read for both the rail (`RAIL_LIMIT = 20`) and the dedicated page (`PAGE_LIMIT = 100`). Scopes events via `whereHas('repository.project', owner_user_id)` so cross-user isolation is enforced server-side. Maps each row to the existing TS `ActivityEvent` shape (id prefix, repo `full_name` as `source`, single human-readable metadata pill).
- `HandleInertiaRequests::share()` adds an `activity.recent` shared prop. The closure runs every render but guards on `$request->user()` so anonymous requests skip the query entirely.
- `AppLayout.vue` — `resolvedActivityEvents` computed: explicit `activityEvents` prop wins (including an explicit empty array, to force the empty-state); when the prop is omitted, fall back to `usePage<PageProps>().props.activity?.recent`. Both rail callsites (column + drawer) use the resolved value.
- `GET /activity` → `ActivityController@index` → `Activity/Index.vue`. Reuses the existing `<ActivityFeed>` inside a glass-card wrapper with a first-time empty state.
- Sidebar's **Activity** entry activated as the 12th slot, between Alerts and Settings, with the Lucide `History` icon (the `Activity` icon was already in use by Pipelines).
- `types/index.d.ts` — `PageProps` now types both `flash` (was already shared but never typed) and `activity?: { recent: ActivityEvent[] }`.

## Test plan
- [x] `vendor/bin/pint --test` clean
- [x] `npm run build` green
- [x] `php artisan test` **218/218** green (+10 from main: 3 query, 3 controller, 4 shared-prop)
- [ ] Manual smoke (please verify):
    - Hit `/repositories`, `/projects`, `/work-items`, `/activity`, `/profile` — right rail shows events on every one (was empty-state on all but Overview before).
    - Open `/activity` — full chronological list of up to 100 events, scoped to your projects.
    - Sidebar shows **Activity** between Alerts and Settings; clicking lights it up.
    - Trigger a webhook (e.g. open / close an issue on a connected repo) — refresh and the new event appears in the rail.

## Self-review notes
Ran `superpowers:code-reviewer`. No blockers. **One wording bug + four materials, all addressed in commit `e3d79ca`** before pushing:

- **[material]** \"Lazy closure\" wording was misleading — Inertia's `share()` invokes returned closures on every render. Fixed comments in 3 places; the `$request->user()` guard is what spares guests.
- **[material]** AppLayout's old `length > 0` discriminator hid the explicit-empty override path. Switched to `!== undefined` + dropped the default factory.
- **[material]** Tightened typing — `usePage<PageProps>()` + dropped a stale cast. `PageProps` is now imported and used.
- **[material]** Added a `TODO(future)` next to the `whereHas` predicate documenting that `repository_id IS NULL` events are excluded today (no cross-user leak, but they don't show until the predicate is broadened in a future spec).
- **[material]** Added two test cases — guest request payload (`activity.recent` empty, query not invoked) and `repository_id IS NULL` exclusion — to lock current behaviour against future refactors.

## Out of scope
- **Real-time updates** → spec 019 (Reverb broadcast on `ActivityEventCreated` + Echo wiring).
- **Activity filters** (event type / repo / date range) — visible-only "Recent / All" tabs already render; real filtering arrives later.
- **Pagination** beyond the 100-row cap — fine for phase 3 dev volume; a cursor-paginated implementation lands when needed.
- **Read/unread state** — phase 7's alerts engine.
- **Per-project activity tabs** — the Project show page has a placeholder; populating it is a separate spec.
- **Overview's `MOCK_ACTIVITY` swap** — Overview still uses the mock to keep PR scope focused. Easy follow-up: replace the constant with the new query call inside `GetOverviewDashboardQuery`.
- **FK indexing pass** (`repositories.project_id`, `projects.owner_user_id`) — flagged for the indexing pass before phase 4 lands and event volume grows.