### PR TITLE
fix(activity): stop seeding rail with mock data + fix OFFLINE-after-remount + hide rail on /activity

### DIFF
--- a/app/Domain/Activity/ActivityEventPresenter.php
+++ b/app/Domain/Activity/ActivityEventPresenter.php
@@ -11,11 +11,11 @@ use BackedEnum;
  * `ActivityEvent` interface).
  *
  * Used by:
- *   - `RecentActivityForUserQuery` (page-load reads)
- *   - `App\Events\ActivityEventCreated::broadcastWith()` (real-time)
- *   - `GetOverviewDashboardQuery` (when the MOCK_ACTIVITY swap lands)
+ *   - `RecentActivityForUserQuery` (page-load reads, including the shared
+ *     `activity.recent` Inertia prop the AppLayout rail consumes).
+ *   - `App\Events\ActivityEventCreated::broadcastWith()` (real-time).
  *
- * Keeping the mapping here avoids the three-call-site drift the spec-018
+ * Keeping the mapping here avoids the call-site drift the spec-018
  * code-reviewer flagged.
  */
 class ActivityEventPresenter

--- a/app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php
+++ b/app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php
@@ -26,8 +26,12 @@ use Illuminate\Support\Collection;
  *
  * Still mock (extracted to MOCK_* constants — clearly marked):
  *   - dashboard.{deployments,services,alerts,uptime}  → MOCK_KPIS
- *   - recentActivity                                  → MOCK_ACTIVITY
  *   - activityHeatmap                                 → MOCK_HEATMAP
+ *
+ * The right-rail activity feed is no longer surfaced from this query —
+ * the AppLayout consumes the shared `activity.recent` Inertia prop
+ * populated by `HandleInertiaRequests` (specs 018/019), so Overview no
+ * longer ships its own copy.
  *
  * Each MOCK constant comments the phase that ships its real source.
  *
@@ -51,7 +55,6 @@ class GetOverviewDashboardQuery
                 'hosts' => $this->hosts(),
                 'topRepositories' => $this->topRepositories(),
             ]),
-            'recentActivity' => self::MOCK_ACTIVITY,
             'activityHeatmap' => self::MOCK_HEATMAP,
         ];
     }
@@ -187,84 +190,6 @@ class GetOverviewDashboardQuery
             'change' => 0.01,
             'sparkline' => [99.92, 99.93, 99.95, 99.94, 99.96, 99.97, 99.96, 99.97, 99.98, 99.98, 99.97, 99.98],
             'status' => 'success',
-        ],
-    ];
-
-    /** Phase 3 ships the real activity feed. */
-    private const MOCK_ACTIVITY = [
-        [
-            'id' => 'evt-001',
-            'type' => 'deployment.succeeded',
-            'severity' => 'success',
-            'title' => 'Deployed nexus-api v2.14.3 to production',
-            'source' => 'nexus-api',
-            'occurred_at' => '2 min ago',
-            'metadata' => 'us-east',
-        ],
-        [
-            'id' => 'evt-002',
-            'type' => 'pull_request.merged',
-            'severity' => 'info',
-            'title' => 'PR #142 — Switch session driver to Redis cluster',
-            'source' => 'nexus-web',
-            'occurred_at' => '14 min ago',
-        ],
-        [
-            'id' => 'evt-003',
-            'type' => 'alert.triggered',
-            'severity' => 'danger',
-            'title' => 'CPU sustained > 90% on prod-api-02 for 5 min',
-            'source' => 'monitoring',
-            'occurred_at' => '38 min ago',
-            'metadata' => 'critical',
-        ],
-        [
-            'id' => 'evt-004',
-            'type' => 'workflow.failed',
-            'severity' => 'danger',
-            'title' => 'CI failed — flaky test on nexus-mail#main',
-            'source' => 'nexus-mail',
-            'occurred_at' => '52 min ago',
-        ],
-        [
-            'id' => 'evt-005',
-            'type' => 'pull_request.review_requested',
-            'severity' => 'info',
-            'title' => 'Review requested on PR #218 — Billing webhook hardening',
-            'source' => 'nexus-api',
-            'occurred_at' => '1 h ago',
-        ],
-        [
-            'id' => 'evt-006',
-            'type' => 'website.recovered',
-            'severity' => 'success',
-            'title' => 'status.nexus.io recovered after 3 m 12 s outage',
-            'source' => 'monitoring',
-            'occurred_at' => '2 h ago',
-        ],
-        [
-            'id' => 'evt-007',
-            'type' => 'container.unhealthy',
-            'severity' => 'warning',
-            'title' => 'billing-worker container restarted after OOM',
-            'source' => 'prod-api-02',
-            'occurred_at' => '3 h ago',
-        ],
-        [
-            'id' => 'evt-008',
-            'type' => 'issue.created',
-            'severity' => 'muted',
-            'title' => 'Login flow rejects valid 2FA codes intermittently',
-            'source' => 'nexus-web',
-            'occurred_at' => '4 h ago',
-        ],
-        [
-            'id' => 'evt-009',
-            'type' => 'host.recovered',
-            'severity' => 'success',
-            'title' => 'edge-eu-01 back online after scheduled maintenance',
-            'source' => 'edge-eu-01',
-            'occurred_at' => '6 h ago',
         ],
     ];
 

--- a/resources/js/Components/TopBar/TopBar.vue
+++ b/resources/js/Components/TopBar/TopBar.vue
@@ -14,10 +14,15 @@ import {
 } from 'lucide-vue-next';
 import { computed } from 'vue';
 
-defineProps<{
-    /** Number of unread notifications to render in the bell badge. Visual only this spec. */
-    notificationsCount?: number;
-}>();
+withDefaults(
+    defineProps<{
+        /** Number of unread notifications to render in the bell badge. Visual only this spec. */
+        notificationsCount?: number;
+        /** Hide the activity rail toggle when the page itself is the activity feed. */
+        showActivityRailToggle?: boolean;
+    }>(),
+    { showActivityRailToggle: true },
+);
 
 const emit = defineEmits<{
     /** Mobile/tablet hamburger pressed — AppLayout opens the sidebar drawer. */
@@ -101,8 +106,11 @@ const initials = computed(() => {
 
         <!-- Activity rail toggle — visible whenever the rail isn't a
              persistent column (i.e. below 2xl). Includes mobile so users
-             can reach the populated feed via the drawer. -->
+             can reach the populated feed via the drawer. Hidden on
+             pages that *are* the feed (e.g. /activity) so the toggle
+             doesn't open a redundant drawer. -->
         <button
+            v-if="showActivityRailToggle"
             type="button"
             class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border-subtle bg-slate-950/40 text-text-muted transition hover:border-accent-cyan/40 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60 2xl:hidden"
             aria-label="Toggle activity rail"

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -22,6 +22,12 @@ const props = defineProps<{
      * the shared feed.
      */
     activityEvents?: ActivityEvent[];
+    /**
+     * Suppresses the right-side activity rail (and its TopBar drawer
+     * toggle). Useful on pages that *are* the activity feed (e.g. the
+     * dedicated `/activity` index) where a duplicate rail is just noise.
+     */
+    hideActivityRail?: boolean;
 }>();
 
 const sidebarOpen = ref(false);
@@ -168,6 +174,7 @@ onBeforeUnmount(() => {
         <!-- Main column -->
         <div class="flex min-w-0 flex-1 flex-col">
             <TopBar
+                :show-activity-rail-toggle="!hideActivityRail"
                 @open-sidebar="sidebarOpen = true"
                 @open-activity-rail="activityRailOpen = true"
                 @open-palette="paletteOpen = true"
@@ -233,7 +240,7 @@ onBeforeUnmount(() => {
         </div>
 
         <!-- Persistent activity rail (≥ 2xl) -->
-        <div class="relative z-30 hidden 2xl:flex">
+        <div v-if="!hideActivityRail" class="relative z-30 hidden 2xl:flex">
             <RightActivityRail
                 variant="column"
                 :events="resolvedActivityEvents"

--- a/resources/js/Pages/Activity/Index.vue
+++ b/resources/js/Pages/Activity/Index.vue
@@ -22,7 +22,7 @@ const { events: liveEvents, connected: realtimeConnected } = useActivityFeed({
 <template>
     <Head title="Activity" />
 
-    <AppLayout>
+    <AppLayout :hide-activity-rail="true">
         <template #title>
             <div class="flex flex-col">
                 <span

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -4,11 +4,7 @@ import KpiCard from '@/Components/Dashboard/KpiCard.vue';
 import Sparkline from '@/Components/Dashboard/Sparkline.vue';
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import type {
-    ActivityEvent,
-    ActivityHeatmapPayload,
-    DashboardPayload,
-} from '@/types';
+import type { ActivityHeatmapPayload, DashboardPayload } from '@/types';
 import { Head } from '@inertiajs/vue3';
 import {
     Activity,
@@ -28,7 +24,6 @@ import {
 
 defineProps<{
     dashboard: DashboardPayload;
-    recentActivity: ActivityEvent[];
     activityHeatmap: ActivityHeatmapPayload;
 }>();
 
@@ -113,7 +108,7 @@ const visualizationStubs = [
 <template>
     <Head title="Overview" />
 
-    <AppLayout :activity-events="recentActivity">
+    <AppLayout>
         <template #title>
             <div class="flex flex-col">
                 <span

--- a/resources/js/bootstrap.ts
+++ b/resources/js/bootstrap.ts
@@ -13,24 +13,46 @@ declare global {
 window.axios = axios;
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
-// Spec 019 — Echo singleton wired against Reverb. The composable in
-// `lib/useActivityFeed.ts` consumes it via `window.Echo`. Reverb speaks
-// the Pusher protocol, so we configure the `reverb` broadcaster (which
-// internally uses `pusher-js`) and expose `window.Pusher` so the
-// laravel-echo lookup succeeds at runtime.
-//
-// `enabledTransports: ['ws', 'wss']` skips Pusher's HTTP fallback —
-// Reverb only speaks websockets. `forceTLS` is derived from the
-// configured scheme so http/wss don't get accidentally mismatched
-// behind a tunnel.
 window.Pusher = Pusher;
 
 const reverbHost = import.meta.env.VITE_REVERB_HOST;
 const reverbKey = import.meta.env.VITE_REVERB_APP_KEY;
+const scheme = import.meta.env.VITE_REVERB_SCHEME ?? 'http';
+const port = import.meta.env.VITE_REVERB_PORT ?? '8080';
+
+// Spec 019 debug — gate behind `localStorage.NEXUS_DEBUG_ECHO = '1'`
+// (or the build-time `VITE_REVERB_DEBUG=true` env). Off by default so
+// production / regular dev is silent. Set the localStorage flag once
+// in DevTools, refresh, and you get the full lifecycle.
+const isTruthy = (v: unknown): boolean =>
+    v === true || v === '1' || v === 'true';
+const debugFlag =
+    isTruthy(import.meta.env.VITE_REVERB_DEBUG) ||
+    (typeof window !== 'undefined' &&
+        isTruthy(window.localStorage?.getItem('NEXUS_DEBUG_ECHO')));
+
+const log = (...args: unknown[]) => {
+    if (debugFlag) console.log('[echo]', ...args);
+};
+
+// Always emit one boot-status line, even with the verbose flag off, so
+// the user can immediately see whether the VITE_REVERB_* env reached the
+// browser without having to toggle anything in DevTools.
+console.info('[echo] boot env', {
+    host: reverbHost || '(missing)',
+    port,
+    scheme,
+    keyPresent: !!reverbKey,
+    debugFlag,
+});
 
 if (reverbHost && reverbKey) {
-    const scheme = import.meta.env.VITE_REVERB_SCHEME ?? 'http';
-    const port = import.meta.env.VITE_REVERB_PORT ?? '8080';
+    if (debugFlag) {
+        // pusher-js exposes its own verbose logging — pipe through the
+        // same flag so a single localStorage toggle covers both layers.
+        Pusher.logToConsole = true;
+    }
+
     window.Echo = new Echo({
         broadcaster: 'reverb',
         key: reverbKey,
@@ -40,4 +62,34 @@ if (reverbHost && reverbKey) {
         forceTLS: scheme === 'https',
         enabledTransports: ['ws', 'wss'],
     });
+
+    log('Echo instance created', {
+        wsHost: reverbHost,
+        wsPort: Number(port),
+        forceTLS: scheme === 'https',
+    });
+
+    // Connection-level lifecycle: `connecting` → `connected` (or
+    // `unavailable` / `failed`). Useful for spotting tunnel handshake
+    // issues that never reach the channel layer.
+    type PusherConnection = {
+        bind: (e: string, cb: (data?: unknown) => void) => void;
+        state?: string;
+    };
+    const pusher = (
+        window.Echo.connector as { pusher?: { connection?: PusherConnection } }
+    )?.pusher;
+
+    pusher?.connection?.bind('state_change', (states: unknown) => {
+        log('connection state', states);
+    });
+    pusher?.connection?.bind('error', (err: unknown) => {
+        log('connection error', err);
+    });
+} else {
+    // Loud warning — without these the rail will always show OFFLINE.
+    console.warn(
+        '[echo] NOT initialized — VITE_REVERB_HOST or VITE_REVERB_APP_KEY missing in the bundle. ' +
+            'Restart `composer run dev` after editing .env so Vite picks up the new values.',
+    );
 }

--- a/resources/js/lib/useActivityFeed.ts
+++ b/resources/js/lib/useActivityFeed.ts
@@ -2,6 +2,18 @@ import type { ActivityEvent, PageProps } from '@/types';
 import { router, usePage } from '@inertiajs/vue3';
 import { onBeforeUnmount, onMounted, ref } from 'vue';
 
+// Same gate as bootstrap.ts — set `localStorage.NEXUS_DEBUG_ECHO = '1'`
+// in DevTools and refresh to see the channel + connection lifecycle.
+const isTruthy = (v: unknown): boolean =>
+    v === true || v === '1' || v === 'true';
+const debugFlag =
+    isTruthy(import.meta.env.VITE_REVERB_DEBUG) ||
+    (typeof window !== 'undefined' &&
+        isTruthy(window.localStorage?.getItem('NEXUS_DEBUG_ECHO')));
+const log = (...args: unknown[]) => {
+    if (debugFlag) console.log('[echo:feed]', ...args);
+};
+
 /**
  * Reactive activity-feed composable used by the AppLayout right rail
  * and the dedicated `/activity` page. Spec 019.
@@ -62,6 +74,7 @@ export function useActivityFeed(options: {
         unbindNavigate = router.on('navigate', () => reseed());
 
         if (typeof window === 'undefined' || !window.Echo) {
+            log('skipping subscription — window.Echo is undefined');
             return;
         }
 
@@ -69,21 +82,48 @@ export function useActivityFeed(options: {
         const userId = page.props.auth?.user?.id;
 
         if (userId == null) {
+            log('skipping subscription — no auth.user.id in shared props');
             return;
         }
 
-        const channel = window.Echo.private(`users.${userId}.activity`);
+        const channelName = `users.${userId}.activity`;
+        log('subscribing to private channel', channelName);
+
+        const channel = window.Echo.private(channelName);
         channel.listen('.ActivityEventCreated', (payload: ActivityEvent) => {
+            log('event received', payload.id, payload.type);
             prepend(payload);
+        });
+        channel.error?.((err: unknown) => {
+            log('channel error', err);
+        });
+        channel.subscribed?.(() => {
+            log('channel subscribed');
         });
 
         const connector = window.Echo.connector;
-        const pusher = (connector as { pusher?: { connection?: { bind: (e: string, cb: () => void) => void; unbind: (e: string, cb: () => void) => void } } })?.pusher;
+        const pusher = (connector as { pusher?: { connection?: { state?: string; bind: (e: string, cb: () => void) => void; unbind: (e: string, cb: () => void) => void } } })?.pusher;
+        log('initial pusher state', pusher?.connection?.state);
 
-        const onConnect = () => (connected.value = true);
-        const onDisconnect = () => (connected.value = false);
+        const onConnect = () => {
+            log('connected');
+            connected.value = true;
+        };
+        const onDisconnect = () => {
+            log('disconnected');
+            connected.value = false;
+        };
 
         if (pusher?.connection) {
+            // Seed from the current state. When this composable mounts
+            // *after* the connection is already established (Inertia
+            // navigation, second instance on the same page) the
+            // 'connected' bind never fires for us — it already fired
+            // for the original listener. Without this, the pill
+            // permanently shows OFFLINE despite an active socket.
+            if (pusher.connection.state === 'connected') {
+                connected.value = true;
+            }
             pusher.connection.bind('connected', onConnect);
             pusher.connection.bind('disconnected', onDisconnect);
             pusher.connection.bind('unavailable', onDisconnect);

--- a/tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php
+++ b/tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php
@@ -18,8 +18,8 @@ class GetOverviewDashboardQueryTest extends TestCase
         $payload = (new GetOverviewDashboardQuery)->handle();
 
         $this->assertArrayHasKey('dashboard', $payload);
-        $this->assertArrayHasKey('recentActivity', $payload);
         $this->assertArrayHasKey('activityHeatmap', $payload);
+        $this->assertArrayNotHasKey('recentActivity', $payload);
 
         foreach (['projects', 'deployments', 'services', 'hosts', 'alerts', 'uptime', 'topRepositories'] as $key) {
             $this->assertArrayHasKey($key, $payload['dashboard']);
@@ -154,7 +154,6 @@ class GetOverviewDashboardQueryTest extends TestCase
         $this->assertSame('danger', $payload['dashboard']['alerts']['status']);
         $this->assertSame(99.98, $payload['dashboard']['uptime']['overall']);
 
-        $this->assertCount(9, $payload['recentActivity']);
         $this->assertCount(7, $payload['activityHeatmap']);
         $this->assertCount(6, $payload['activityHeatmap'][0]);
     }

--- a/tests/Feature/SmokeTest.php
+++ b/tests/Feature/SmokeTest.php
@@ -49,27 +49,22 @@ class SmokeTest extends TestCase
             );
     }
 
-    public function test_overview_carries_activity_feed_and_heatmap_payloads(): void
+    public function test_overview_carries_activity_heatmap_payload(): void
     {
         $user = User::factory()->create([
             'email_verified_at' => now(),
         ]);
 
+        // Overview no longer ships its own activity slice — the rail
+        // consumes the shared `activity.recent` prop populated by
+        // `HandleInertiaRequests` (specs 018/019). Heatmap stays here
+        // until phase 3's heatmap aggregate replaces the mock.
         $this->actingAs($user)
             ->get('/overview')
             ->assertInertia(
                 fn (AssertableInertia $page) => $page
                     ->component('Overview')
-                    ->has('recentActivity', 9)
-                    ->has('recentActivity.0', fn (AssertableInertia $event) => $event
-                        ->has('id')
-                        ->has('type')
-                        ->has('severity')
-                        ->has('title')
-                        ->has('source')
-                        ->has('occurred_at')
-                        ->etc()
-                    )
+                    ->missing('recentActivity')
                     ->has('activityHeatmap', 7)
                     ->has('activityHeatmap.0', 6)
             );


### PR DESCRIPTION
## Summary

Three real bugs surfaced in spec-019 testing once the websocket actually connected end-to-end:

1. **Overview rail showed nine hardcoded mock entries.** `Overview.vue` passed `:activity-events="recentActivity"` into AppLayout, which won the explicit-prop-wins decision in `useActivityFeed` and clobbered the real `activity.recent` shared prop populated by spec 018's `RecentActivityForUserQuery`. The mock came from `GetOverviewDashboardQuery::MOCK_ACTIVITY` — a phase-0 placeholder the spec-018 swap forgot to delete. Removed the constant, the payload key, the prop wiring, and the dead `recentActivity` prop; AppLayout now correctly falls back to real data.

2. **Rail's "OFFLINE" pill was permanent on remount.** `useActivityFeed` bound `connected.value = true` to pusher's `'connected'` event, but that event only fires on transitions — when the composable mounted *after* the connection was already established (Inertia navigation, second instance on the same page) the listener never fired and the pill stayed orange even though the channel was happily relaying `subscription_succeeded`. Now seeds `connected.value` from `pusher.connection.state` at mount; subsequent transitions still work as before.

3. **`/activity` page showed a duplicate empty rail.** The page itself IS the activity feed, so the AppLayout rail (column at 2xl, drawer below) was just noise. Added `hideActivityRail` to AppLayout + `showActivityRailToggle` to TopBar; `Activity/Index.vue` passes both.

## Debug logging

Also added gated debug logging across `bootstrap.ts` and `useActivityFeed.ts` so future "is the websocket actually working?" diagnostics don't require manual instrumentation:

- Toggle via `VITE_REVERB_DEBUG=1` (build-time) **or** `localStorage.NEXUS_DEBUG_ECHO = '1'` (runtime).
- A single `[echo] boot env { … }` line prints **unconditionally** so env mishaps are visible without any flag setup.
- pusher-js's own verbose log piggybacks on the same flag.
- Lifecycle: connection `state_change`, `error`, channel `subscribed` / `error`, every received broadcast.

## Test plan

- [x] `php artisan test` — 241/241 passing
- [x] `./vendor/bin/pint --dirty`
- [x] `npm run build`
- [x] Manually verified end-to-end against the cloudflared tunnel: rail flips ONLINE on `/overview` and `/activity`, `/activity` no longer shows the duplicate rail, real-data feed surfaces (was previously buried by `MOCK_ACTIVITY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)