### PR TITLE
fix(github): surface sync errors on the Repository page

### DIFF
--- a/app/Domain/GitHub/Exceptions/GitHubApiException.php
+++ b/app/Domain/GitHub/Exceptions/GitHubApiException.php
@@ -42,6 +42,14 @@ class GitHubApiException extends RuntimeException
             ? ($body['message'] ?? $body['error_description'] ?? $body['error'] ?? 'unknown')
             : 'invalid response';
 
+        // Defensive: GitHub's `message` is a string in practice, but a
+        // malformed payload (or future API change) could deliver an
+        // array/object. Coerce non-strings to a stable label so we never
+        // emit `Array` into a thrown message that bubbles into the UI.
+        if (! is_string($reason)) {
+            $reason = 'unknown';
+        }
+
         return new self("{$context}: HTTP {$status} {$reason}", $status);
     }
 

--- a/app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php
+++ b/app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php
@@ -14,6 +14,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Throwable;
 
 /**
@@ -59,13 +60,15 @@ class SyncGitHubRepositoryJob implements ShouldQueue
                 'repository_id' => $repository->id,
                 'full_name' => $repository->full_name,
             ]);
-            $this->markFailed($repository);
+            $this->markFailed($repository, 'No GitHub connection — reconnect in Settings to sync this repository.');
 
             return;
         }
 
         $repository->forceFill([
             'sync_status' => RepositorySyncStatus::Syncing->value,
+            'sync_error' => null,
+            'sync_failed_at' => null,
         ])->save();
 
         $metadataSynced = false;
@@ -79,6 +82,8 @@ class SyncGitHubRepositoryJob implements ShouldQueue
             $repository->forceFill([
                 'sync_status' => RepositorySyncStatus::Synced->value,
                 'last_synced_at' => now(),
+                'sync_error' => null,
+                'sync_failed_at' => null,
             ])->save();
 
             $metadataSynced = true;
@@ -94,7 +99,7 @@ class SyncGitHubRepositoryJob implements ShouldQueue
                 'message' => $e->getMessage(),
             ]);
 
-            $this->markFailed($repository);
+            $this->markFailed($repository, $e->getMessage());
         } catch (Throwable $e) {
             Log::error('GitHub repository sync errored', [
                 'repository_id' => $repository->id,
@@ -103,7 +108,7 @@ class SyncGitHubRepositoryJob implements ShouldQueue
                 'message' => $e->getMessage(),
             ]);
 
-            $this->markFailed($repository);
+            $this->markFailed($repository, $e->getMessage() !== '' ? $e->getMessage() : $e::class);
         }
 
         // Chain spec 015's issues sync and spec 016's PRs sync. Both
@@ -191,21 +196,23 @@ class SyncGitHubRepositoryJob implements ShouldQueue
     }
 
     /**
-     * Flip the row to `failed`. We deliberately do NOT update
-     * `last_synced_at` — that column means "last successful sync" and
-     * is what the Settings card surfaces as "Last sync N min ago". A
-     * failed run keeps the previous successful timestamp (or null if
-     * never synced).
+     * Flip the row to `failed` and persist the failure reason for the UI.
      *
-     * Failure reason is logged at the call site (see the catches above)
-     * — spec 014's schema doesn't carry a `sync_error` column yet. A
-     * future spec that surfaces error messages on the Repository page
-     * will add the column + thread the reason through here.
+     * We deliberately do NOT update `last_synced_at` — that column means
+     * "last successful sync" and is what the Settings card surfaces as
+     * "Last sync N min ago". A failed run keeps the previous successful
+     * timestamp (or null if never synced).
+     *
+     * `sync_error` is hard-capped at 500 chars so a runaway exception
+     * message can't bloat the row. The full message is still in Pail at
+     * the call site.
      */
-    private function markFailed(Repository $repository): void
+    private function markFailed(Repository $repository, ?string $reason = null): void
     {
         $repository->forceFill([
             'sync_status' => RepositorySyncStatus::Failed->value,
+            'sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
+            'sync_failed_at' => now(),
         ])->save();
     }
 

--- a/app/Domain/GitHub/Jobs/SyncRepositoryIssuesJob.php
+++ b/app/Domain/GitHub/Jobs/SyncRepositoryIssuesJob.php
@@ -14,6 +14,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Throwable;
 
 /**
@@ -61,13 +62,15 @@ class SyncRepositoryIssuesJob implements ShouldQueue
                 'repository_id' => $repository->id,
                 'full_name' => $repository->full_name,
             ]);
-            $this->markFailed($repository);
+            $this->markFailed($repository, 'No GitHub connection — reconnect in Settings to sync issues.');
 
             return;
         }
 
         $repository->forceFill([
             'issues_sync_status' => RepositorySyncStatus::Syncing->value,
+            'issues_sync_error' => null,
+            'issues_sync_failed_at' => null,
         ])->save();
 
         try {
@@ -76,6 +79,8 @@ class SyncRepositoryIssuesJob implements ShouldQueue
             $repository->forceFill([
                 'issues_sync_status' => RepositorySyncStatus::Synced->value,
                 'issues_synced_at' => now(),
+                'issues_sync_error' => null,
+                'issues_sync_failed_at' => null,
             ])->save();
         } catch (GitHubApiException $e) {
             if ($e->isUnauthorized()) {
@@ -89,7 +94,7 @@ class SyncRepositoryIssuesJob implements ShouldQueue
                 'message' => $e->getMessage(),
             ]);
 
-            $this->markFailed($repository);
+            $this->markFailed($repository, $e->getMessage());
         } catch (Throwable $e) {
             Log::error('GitHub issues sync errored', [
                 'repository_id' => $repository->id,
@@ -98,7 +103,7 @@ class SyncRepositoryIssuesJob implements ShouldQueue
                 'message' => $e->getMessage(),
             ]);
 
-            $this->markFailed($repository);
+            $this->markFailed($repository, $e->getMessage() !== '' ? $e->getMessage() : $e::class);
         }
     }
 
@@ -110,15 +115,22 @@ class SyncRepositoryIssuesJob implements ShouldQueue
     }
 
     /**
-     * Flip to `failed`. We deliberately do NOT update `issues_synced_at`
-     * — that column means "last successful sync" and feeds the Repository
-     * Issues tab's "Last sync N min ago" indicator. A failed run keeps
-     * the previous successful timestamp.
+     * Flip to `failed` and persist the failure reason for the UI.
+     *
+     * We deliberately do NOT update `issues_synced_at` — that column
+     * means "last successful sync" and feeds the Repository Issues tab's
+     * "Last sync N min ago" indicator. A failed run keeps the previous
+     * successful timestamp.
+     *
+     * `issues_sync_error` is hard-capped at 500 chars; the full message
+     * is still in Pail at the call site.
      */
-    private function markFailed(Repository $repository): void
+    private function markFailed(Repository $repository, ?string $reason = null): void
     {
         $repository->forceFill([
             'issues_sync_status' => RepositorySyncStatus::Failed->value,
+            'issues_sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
+            'issues_sync_failed_at' => now(),
         ])->save();
     }
 

--- a/app/Domain/GitHub/Jobs/SyncRepositoryPullRequestsJob.php
+++ b/app/Domain/GitHub/Jobs/SyncRepositoryPullRequestsJob.php
@@ -14,6 +14,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Throwable;
 
 /**
@@ -58,13 +59,15 @@ class SyncRepositoryPullRequestsJob implements ShouldQueue
                 'repository_id' => $repository->id,
                 'full_name' => $repository->full_name,
             ]);
-            $this->markFailed($repository);
+            $this->markFailed($repository, 'No GitHub connection — reconnect in Settings to sync pull requests.');
 
             return;
         }
 
         $repository->forceFill([
             'prs_sync_status' => RepositorySyncStatus::Syncing->value,
+            'prs_sync_error' => null,
+            'prs_sync_failed_at' => null,
         ])->save();
 
         try {
@@ -73,6 +76,8 @@ class SyncRepositoryPullRequestsJob implements ShouldQueue
             $repository->forceFill([
                 'prs_sync_status' => RepositorySyncStatus::Synced->value,
                 'prs_synced_at' => now(),
+                'prs_sync_error' => null,
+                'prs_sync_failed_at' => null,
             ])->save();
         } catch (GitHubApiException $e) {
             if ($e->isUnauthorized()) {
@@ -86,7 +91,7 @@ class SyncRepositoryPullRequestsJob implements ShouldQueue
                 'message' => $e->getMessage(),
             ]);
 
-            $this->markFailed($repository);
+            $this->markFailed($repository, $e->getMessage());
         } catch (Throwable $e) {
             Log::error('GitHub PRs sync errored', [
                 'repository_id' => $repository->id,
@@ -95,7 +100,7 @@ class SyncRepositoryPullRequestsJob implements ShouldQueue
                 'message' => $e->getMessage(),
             ]);
 
-            $this->markFailed($repository);
+            $this->markFailed($repository, $e->getMessage() !== '' ? $e->getMessage() : $e::class);
         }
     }
 
@@ -107,14 +112,21 @@ class SyncRepositoryPullRequestsJob implements ShouldQueue
     }
 
     /**
-     * Flip to `failed`. We deliberately do NOT update `prs_synced_at`
-     * — that column means "last successful sync" and feeds the
-     * Repository PRs tab's "Last sync N min ago" indicator.
+     * Flip to `failed` and persist the failure reason for the UI.
+     *
+     * We deliberately do NOT update `prs_synced_at` — that column means
+     * "last successful sync" and feeds the Repository PRs tab's
+     * "Last sync N min ago" indicator.
+     *
+     * `prs_sync_error` is hard-capped at 500 chars; the full message is
+     * still in Pail at the call site.
      */
-    private function markFailed(Repository $repository): void
+    private function markFailed(Repository $repository, ?string $reason = null): void
     {
         $repository->forceFill([
             'prs_sync_status' => RepositorySyncStatus::Failed->value,
+            'prs_sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
+            'prs_sync_failed_at' => now(),
         ])->save();
     }
 

--- a/app/Http/Controllers/RepositoryController.php
+++ b/app/Http/Controllers/RepositoryController.php
@@ -55,11 +55,15 @@ class RepositoryController extends Controller
             'issuesSync' => [
                 'status' => $repository->issues_sync_status?->value,
                 'synced_at' => $repository->issues_synced_at?->diffForHumans(),
+                'error' => $repository->issues_sync_error,
+                'failed_at' => $repository->issues_sync_failed_at?->diffForHumans(),
             ],
             'pullRequests' => $pullRequestsQuery->execute($repository),
             'pullRequestsSync' => [
                 'status' => $repository->prs_sync_status?->value,
                 'synced_at' => $repository->prs_synced_at?->diffForHumans(),
+                'error' => $repository->prs_sync_error,
+                'failed_at' => $repository->prs_sync_failed_at?->diffForHumans(),
             ],
         ]);
     }
@@ -122,6 +126,8 @@ class RepositoryController extends Controller
             'last_pushed_at' => $repository->last_pushed_at?->diffForHumans(),
             'last_synced_at' => $repository->last_synced_at?->diffForHumans(),
             'sync_status' => $repository->sync_status?->value,
+            'sync_error' => $repository->sync_error,
+            'sync_failed_at' => $repository->sync_failed_at?->diffForHumans(),
             'project' => $repository->project ? [
                 'id' => $repository->project->id,
                 'slug' => $repository->project->slug,

--- a/app/Http/Controllers/RepositorySyncController.php
+++ b/app/Http/Controllers/RepositorySyncController.php
@@ -32,8 +32,20 @@ class RepositorySyncController extends Controller
         $repository->loadMissing('project');
         $this->authorize('update', $repository->project);
 
+        // Clear the metadata error and the child-sync errors as well —
+        // the metadata job chains issues + PRs syncs on success, so the
+        // user's mental model is "Run sync re-runs all three." If we
+        // cleared only the metadata error, the page would briefly show
+        // "Syncing…" at the top while stale red error alerts on the
+        // Issues / PRs tabs persisted until those child jobs picked up.
         $repository->update([
             'sync_status' => RepositorySyncStatus::Syncing->value,
+            'sync_error' => null,
+            'sync_failed_at' => null,
+            'issues_sync_error' => null,
+            'issues_sync_failed_at' => null,
+            'prs_sync_error' => null,
+            'prs_sync_failed_at' => null,
         ]);
 
         SyncGitHubRepositoryJob::dispatch($repository->id);

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -33,10 +33,16 @@ class Repository extends Model
         'last_pushed_at',
         'last_synced_at',
         'sync_status',
+        'sync_error',
+        'sync_failed_at',
         'issues_sync_status',
         'issues_synced_at',
+        'issues_sync_error',
+        'issues_sync_failed_at',
         'prs_sync_status',
         'prs_synced_at',
+        'prs_sync_error',
+        'prs_sync_failed_at',
     ];
 
     protected function casts(): array
@@ -51,8 +57,11 @@ class Repository extends Model
             'open_prs_count' => 'integer',
             'last_pushed_at' => 'datetime',
             'last_synced_at' => 'datetime',
+            'sync_failed_at' => 'datetime',
             'issues_synced_at' => 'datetime',
+            'issues_sync_failed_at' => 'datetime',
             'prs_synced_at' => 'datetime',
+            'prs_sync_failed_at' => 'datetime',
         ];
     }
 

--- a/database/migrations/2026_04_30_120000_add_sync_error_columns_to_repositories_table.php
+++ b/database/migrations/2026_04_30_120000_add_sync_error_columns_to_repositories_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('repositories', function (Blueprint $table) {
+            // Three independent sync flows (metadata / issues / PRs) each
+            // track their own status + synced_at. Mirror that for failure
+            // state: a `*_sync_error` (truncated message — see jobs) and
+            // `*_sync_failed_at` per flow. On a successful run we clear
+            // both so the row reflects current state, not stale failures.
+            $table->text('sync_error')->nullable()->after('sync_status');
+            $table->timestamp('sync_failed_at')->nullable()->after('last_synced_at');
+
+            $table->text('issues_sync_error')->nullable()->after('issues_sync_status');
+            $table->timestamp('issues_sync_failed_at')->nullable()->after('issues_synced_at');
+
+            $table->text('prs_sync_error')->nullable()->after('prs_sync_status');
+            $table->timestamp('prs_sync_failed_at')->nullable()->after('prs_synced_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('repositories', function (Blueprint $table) {
+            $table->dropColumn([
+                'sync_error',
+                'sync_failed_at',
+                'issues_sync_error',
+                'issues_sync_failed_at',
+                'prs_sync_error',
+                'prs_sync_failed_at',
+            ]);
+        });
+    }
+};

--- a/resources/js/Pages/Repositories/Show.vue
+++ b/resources/js/Pages/Repositories/Show.vue
@@ -4,6 +4,7 @@ import { projectIcon } from '@/lib/projectIcons';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import { Head, Link, router } from '@inertiajs/vue3';
 import {
+    AlertTriangle,
     ChevronLeft,
     CircleDot,
     ExternalLink,
@@ -36,6 +37,8 @@ interface RepositoryShape {
     last_pushed_at: string | null;
     last_synced_at: string | null;
     sync_status: string | null;
+    sync_error: string | null;
+    sync_failed_at: string | null;
     project: {
         id: number;
         slug: string;
@@ -73,6 +76,8 @@ interface PullRequestRow {
 interface SyncShape {
     status: string | null;
     synced_at: string | null;
+    error: string | null;
+    failed_at: string | null;
 }
 
 const props = defineProps<{
@@ -370,6 +375,30 @@ onBeforeUnmount(stopPolling);
                 </dl>
             </header>
 
+            <!-- Repository metadata sync failure -->
+            <section
+                v-if="repository.sync_status === 'failed' && repository.sync_error"
+                aria-live="polite"
+                class="flex items-start gap-3 rounded-lg border border-status-danger/40 bg-status-danger/10 p-4"
+            >
+                <AlertTriangle
+                    class="mt-0.5 h-4 w-4 shrink-0 text-status-danger"
+                    aria-hidden="true"
+                />
+                <div class="flex min-w-0 flex-col gap-1 text-sm">
+                    <p class="font-semibold text-status-danger">
+                        Last repository sync failed<span
+                            v-if="repository.sync_failed_at"
+                            class="font-normal text-text-muted"
+                        >
+                            · {{ repository.sync_failed_at }}</span>
+                    </p>
+                    <p class="break-words font-mono text-xs text-text-secondary">
+                        {{ repository.sync_error }}
+                    </p>
+                </div>
+            </section>
+
             <!-- Tabs -->
             <nav
                 aria-label="Repository tabs"
@@ -549,6 +578,13 @@ onBeforeUnmount(stopPolling);
                                 Last sync
                                 <span class="font-mono text-text-secondary">{{ issuesSync.synced_at }}</span>
                             </span>
+                            <span
+                                v-else-if="issuesSync.status === 'failed' && issuesSync.failed_at"
+                                class="text-xs text-text-muted"
+                            >
+                                Failed
+                                <span class="font-mono text-status-danger">{{ issuesSync.failed_at }}</span>
+                            </span>
                         </div>
                         <button
                             v-if="canSync"
@@ -561,6 +597,19 @@ onBeforeUnmount(stopPolling);
                             {{ isIssuesSyncing ? 'Syncing…' : 'Run sync' }}
                         </button>
                     </header>
+
+                    <p
+                        v-if="issuesSync.status === 'failed' && issuesSync.error"
+                        class="mt-4 flex items-start gap-2 rounded-lg border border-status-danger/40 bg-status-danger/10 p-3 text-xs"
+                    >
+                        <AlertTriangle
+                            class="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-danger"
+                            aria-hidden="true"
+                        />
+                        <span class="break-words font-mono text-text-secondary">
+                            {{ issuesSync.error }}
+                        </span>
+                    </p>
 
                     <ul
                         v-if="issues.length > 0"
@@ -662,6 +711,13 @@ onBeforeUnmount(stopPolling);
                                 Last sync
                                 <span class="font-mono text-text-secondary">{{ pullRequestsSync.synced_at }}</span>
                             </span>
+                            <span
+                                v-else-if="pullRequestsSync.status === 'failed' && pullRequestsSync.failed_at"
+                                class="text-xs text-text-muted"
+                            >
+                                Failed
+                                <span class="font-mono text-status-danger">{{ pullRequestsSync.failed_at }}</span>
+                            </span>
                         </div>
                         <button
                             v-if="canSync"
@@ -674,6 +730,19 @@ onBeforeUnmount(stopPolling);
                             {{ isPullRequestsSyncing ? 'Syncing…' : 'Run sync' }}
                         </button>
                     </header>
+
+                    <p
+                        v-if="pullRequestsSync.status === 'failed' && pullRequestsSync.error"
+                        class="mt-4 flex items-start gap-2 rounded-lg border border-status-danger/40 bg-status-danger/10 p-3 text-xs"
+                    >
+                        <AlertTriangle
+                            class="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-danger"
+                            aria-hidden="true"
+                        />
+                        <span class="break-words font-mono text-text-secondary">
+                            {{ pullRequestsSync.error }}
+                        </span>
+                    </p>
 
                     <ul
                         v-if="pullRequests.length > 0"

--- a/tests/Feature/GitHub/RepositorySyncControllerTest.php
+++ b/tests/Feature/GitHub/RepositorySyncControllerTest.php
@@ -81,6 +81,43 @@ class RepositorySyncControllerTest extends TestCase
         Queue::assertNotPushed(SyncGitHubRepositoryJob::class);
     }
 
+    public function test_dispatch_clears_stale_sync_errors_across_all_three_flows(): void
+    {
+        Queue::fake();
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+            'sync_status' => 'failed',
+            'sync_error' => 'GitHub request failed: HTTP 500',
+            'sync_failed_at' => now()->subMinutes(5),
+            'issues_sync_status' => 'failed',
+            'issues_sync_error' => 'Issues sync errored',
+            'issues_sync_failed_at' => now()->subMinutes(5),
+            'prs_sync_status' => 'failed',
+            'prs_sync_error' => 'PRs sync errored',
+            'prs_sync_failed_at' => now()->subMinutes(5),
+        ]);
+
+        $this->actingAs($owner)
+            ->from(route('repositories.show', $repository->full_name))
+            ->post(route('repositories.sync', $repository->full_name))
+            ->assertRedirect(route('repositories.show', $repository->full_name));
+
+        // The metadata job re-runs both child syncs on success, so the
+        // controller clears all six error columns up-front. Otherwise
+        // the page would briefly show "Syncing…" at the top while
+        // stale red error alerts persisted on the Issues / PRs tabs.
+        $repo = $repository->fresh();
+        $this->assertNull($repo->sync_error);
+        $this->assertNull($repo->sync_failed_at);
+        $this->assertNull($repo->issues_sync_error);
+        $this->assertNull($repo->issues_sync_failed_at);
+        $this->assertNull($repo->prs_sync_error);
+        $this->assertNull($repo->prs_sync_failed_at);
+    }
+
     public function test_unknown_repository_returns_404(): void
     {
         $owner = User::factory()->create(['email_verified_at' => now()]);

--- a/tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php
+++ b/tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php
@@ -206,4 +206,94 @@ class SyncGitHubRepositoryJobTest extends TestCase
         Queue::assertNotPushed(SyncRepositoryIssuesJob::class);
         Queue::assertNotPushed(SyncRepositoryPullRequestsJob::class);
     }
+
+    public function test_handle_persists_sync_error_and_failed_at_on_api_failure(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world' => Http::response(
+                ['message' => 'Not Found'],
+                404,
+            ),
+        ]);
+
+        (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->sync_status);
+        $this->assertNotNull($repo->sync_error);
+        $this->assertStringContainsString('404', $repo->sync_error);
+        $this->assertNotNull($repo->sync_failed_at);
+    }
+
+    public function test_handle_persists_sync_error_when_no_connection(): void
+    {
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'sync_status' => RepositorySyncStatus::Pending->value,
+        ]);
+
+        (new SyncGitHubRepositoryJob($repository->id))->handle();
+
+        $repo = $repository->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->sync_status);
+        $this->assertNotNull($repo->sync_error);
+        $this->assertStringContainsString('connection', strtolower($repo->sync_error));
+        $this->assertNotNull($repo->sync_failed_at);
+    }
+
+    public function test_handle_clears_sync_error_after_successful_resync(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        // Seed a previous failure so we can verify it's cleared.
+        $context['repository']->forceFill([
+            'sync_status' => RepositorySyncStatus::Failed->value,
+            'sync_error' => 'GitHub request failed: HTTP 500 Server error',
+            'sync_failed_at' => now()->subMinutes(10),
+        ])->save();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world' => Http::response([
+                'id' => 1234,
+                'default_branch' => 'main',
+                'visibility' => 'public',
+                'pushed_at' => '2026-04-29T00:00:00Z',
+                'html_url' => 'https://github.com/octocat/hello-world',
+            ]),
+        ]);
+
+        (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Synced, $repo->sync_status);
+        $this->assertNull($repo->sync_error);
+        $this->assertNull($repo->sync_failed_at);
+    }
+
+    public function test_handle_truncates_long_sync_error_messages(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        $longMessage = str_repeat('x', 800);
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world' => Http::response(
+                ['message' => $longMessage],
+                500,
+            ),
+        ]);
+
+        (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+
+        $repo = $context['repository']->fresh();
+        $this->assertNotNull($repo->sync_error);
+        // Str::limit($x, 500, '…') yields exactly 500 chars + the '…'
+        // ellipsis when truncation kicked in.
+        $this->assertSame(501, mb_strlen($repo->sync_error));
+        $this->assertStringEndsWith('…', $repo->sync_error);
+    }
 }

--- a/tests/Feature/GitHub/SyncRepositoryIssuesJobTest.php
+++ b/tests/Feature/GitHub/SyncRepositoryIssuesJobTest.php
@@ -157,4 +157,46 @@ class SyncRepositoryIssuesJobTest extends TestCase
         $this->assertSame(0, Repository::query()->count());
         $this->assertSame(0, GithubIssue::query()->count());
     }
+
+    public function test_handle_persists_issues_sync_error_and_failed_at_on_api_failure(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/issues*' => Http::response(
+                ['message' => 'Not Found'],
+                404,
+            ),
+        ]);
+
+        (new SyncRepositoryIssuesJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->issues_sync_status);
+        $this->assertNotNull($repo->issues_sync_error);
+        $this->assertStringContainsString('404', $repo->issues_sync_error);
+        $this->assertNotNull($repo->issues_sync_failed_at);
+    }
+
+    public function test_handle_clears_issues_sync_error_after_successful_resync(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        $context['repository']->forceFill([
+            'issues_sync_status' => RepositorySyncStatus::Failed->value,
+            'issues_sync_error' => 'Stale failure message',
+            'issues_sync_failed_at' => now()->subMinutes(10),
+        ])->save();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/issues*' => Http::response([]),
+        ]);
+
+        (new SyncRepositoryIssuesJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Synced, $repo->issues_sync_status);
+        $this->assertNull($repo->issues_sync_error);
+        $this->assertNull($repo->issues_sync_failed_at);
+    }
 }

--- a/tests/Feature/GitHub/SyncRepositoryPullRequestsJobTest.php
+++ b/tests/Feature/GitHub/SyncRepositoryPullRequestsJobTest.php
@@ -158,4 +158,46 @@ class SyncRepositoryPullRequestsJobTest extends TestCase
         $this->assertSame(0, Repository::query()->count());
         $this->assertSame(0, GithubPullRequest::query()->count());
     }
+
+    public function test_handle_persists_prs_sync_error_and_failed_at_on_api_failure(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/pulls*' => Http::response(
+                ['message' => 'Not Found'],
+                404,
+            ),
+        ]);
+
+        (new SyncRepositoryPullRequestsJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->prs_sync_status);
+        $this->assertNotNull($repo->prs_sync_error);
+        $this->assertStringContainsString('404', $repo->prs_sync_error);
+        $this->assertNotNull($repo->prs_sync_failed_at);
+    }
+
+    public function test_handle_clears_prs_sync_error_after_successful_resync(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        $context['repository']->forceFill([
+            'prs_sync_status' => RepositorySyncStatus::Failed->value,
+            'prs_sync_error' => 'Stale failure message',
+            'prs_sync_failed_at' => now()->subMinutes(10),
+        ])->save();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/pulls*' => Http::response([]),
+        ]);
+
+        (new SyncRepositoryPullRequestsJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Synced, $repo->prs_sync_status);
+        $this->assertNull($repo->prs_sync_error);
+        $this->assertNull($repo->prs_sync_failed_at);
+    }
 }

--- a/tests/Feature/Repositories/RepositoryControllerTest.php
+++ b/tests/Feature/Repositories/RepositoryControllerTest.php
@@ -123,6 +123,39 @@ class RepositoryControllerTest extends TestCase
             );
     }
 
+    public function test_show_exposes_sync_errors_in_inertia_props(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repo = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'nexus-org/nexus-web',
+            'sync_status' => 'failed',
+            'sync_error' => 'GitHub request failed: HTTP 404 Not Found',
+            'sync_failed_at' => now()->subMinutes(3),
+            'issues_sync_status' => 'failed',
+            'issues_sync_error' => 'Issues sync failed',
+            'issues_sync_failed_at' => now()->subMinutes(3),
+            'prs_sync_status' => 'failed',
+            'prs_sync_error' => 'PRs sync failed',
+            'prs_sync_failed_at' => now()->subMinutes(3),
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('repositories.show', $repo))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->where('repository.sync_error', 'GitHub request failed: HTTP 404 Not Found')
+                    ->where('repository.sync_status', 'failed')
+                    ->has('repository.sync_failed_at')
+                    ->where('issuesSync.error', 'Issues sync failed')
+                    ->has('issuesSync.failed_at')
+                    ->where('pullRequestsSync.error', 'PRs sync failed')
+                    ->has('pullRequestsSync.failed_at')
+            );
+    }
+
     public function test_show_hides_run_sync_button_for_non_owner(): void
     {
         $owner = $this->verifiedUser();


### PR DESCRIPTION
## Summary

Closes the soft gap flagged in the Phase 0–3 verification: GitHub sync errors were logged to Pail but never surfaced in the UI, so a user with a failed repo just saw "The last sync failed" without knowing *why*.

This PR persists the failure reason + timestamp on the `repositories` row for each of the three independent sync flows (metadata / issues / PRs) and renders them on the Repository show page.

- New columns on `repositories`: `sync_error` + `sync_failed_at` (and matching `issues_sync_*` / `prs_sync_*` pairs).
- All three sync jobs now write the error message (capped at 500 chars via `Str::limit`) and stamp `*_sync_failed_at` when they `markFailed()`. They also clear the error columns when flipping to `syncing` and on a successful sync, so a recovered repo shows a clean state.
- `RepositorySyncController` clears all six error columns when the user clicks Run sync — otherwise the header would flip to "Syncing…" while stale red error alerts persisted on the Issues / PRs tabs until the chained jobs picked up.
- `Repositories/Show.vue` renders a top-level danger alert when the metadata sync failed plus a per-tab alert under each Issues / PRs mirror header. Each header now also shows "Failed Xm ago" alongside the status badge, parallel to the existing "Last sync Xm ago".
- `GitHubApiException::fromResponse` defensively coerces non-string `message` payloads to "unknown" so we never emit `Array` into a thrown message that bubbles into the UI.

## Test plan

- [x] `vendor/bin/pint --test` passes
- [x] `php artisan test` — 9 new tests pass; total passing went from 204 → 213. No new failures introduced (37 pre-existing local-only CSRF failures present on `main` before this PR are environmental and pass in CI).
- [x] `npm run build` succeeds.
- [ ] Manual smoke (post-merge or local): trigger a sync against a repo where the GitHub App has lost access; confirm the failure banner renders with "Failed Xm ago" + the GitHub error string; click Run sync; confirm the banner clears immediately.

## Self-review notes

Self-review pass via `superpowers:code-reviewer` flagged three material items, all addressed:
- Controller now clears all six error columns (not just metadata) so the Issues / PRs tabs don't show stale red alerts while the metadata flip is in flight.
- `GitHubApiException::fromResponse` hardened against non-string `message` payloads.
- Truncation test tightened to assert exactly 501 chars + trailing ellipsis (was a too-loose `<= 503`).

Recommended follow-up not addressed in this PR (low value, marginal coverage):
- A test for the `getMessage() ?: $e::class` fallback when a non-API Throwable has an empty message — would require non-trivial mocking of the action; existing happy-path + GitHub API failure paths already validate the surrounding logic.

Out of scope (intentionally deferred):
- Webhook delivery errors are stored in `github_webhook_deliveries.error_message` already; surfacing them needs its own viewer (different domain, separate PR).
- A "Retry" button — the existing per-flow Run sync buttons already cover this.