### PR TITLE
Spec 020 — Workflow runs storage + sync

### DIFF
--- a/app/Domain/GitHub/Actions/NormalizeGitHubWorkflowRunAction.php
+++ b/app/Domain/GitHub/Actions/NormalizeGitHubWorkflowRunAction.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Domain\GitHub\Actions;
+
+use App\Enums\WorkflowRunConclusion;
+use App\Enums\WorkflowRunStatus;
+use Illuminate\Support\Carbon;
+
+/**
+ * Pure mapper from a single GitHub `/actions/runs` payload entry (or
+ * the `workflow_run` field of a webhook delivery) to the array we
+ * persist on `workflow_runs`.
+ *
+ * Returns `null` for malformed payloads (missing `id` / `head_sha`)
+ * so the caller can skip cleanly. The `repository_id` is intentionally
+ * NOT set here — the caller (sync action / webhook handler) attaches
+ * it once it's resolved the local Repository row.
+ *
+ * Status fallback: if GitHub returns a value that doesn't map to one
+ * of our three canonical states (`queued`, `in_progress`, `completed`)
+ * we collapse to `Queued` — newer pre-completion states like
+ * `requested` / `waiting` / `pending` aren't worth a UI distinction.
+ */
+class NormalizeGitHubWorkflowRunAction
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>|null
+     */
+    public function execute(array $payload): ?array
+    {
+        if (! isset($payload['id'], $payload['head_sha'])) {
+            return null;
+        }
+
+        $status = $this->parseStatus($payload['status'] ?? null);
+        $conclusion = $this->parseConclusion($payload['conclusion'] ?? null);
+
+        $startedAt = $this->parseTimestamp($payload['run_started_at'] ?? $payload['created_at'] ?? null);
+        $updatedAt = $this->parseTimestamp($payload['updated_at'] ?? null);
+
+        // GitHub doesn't expose a discrete `completed_at`. The convention
+        // is: when status flips to `completed`, the `updated_at` field
+        // captures the completion time. Persisting it as `run_completed
+        // _at` keeps the analytics shape clean (success-rate windows,
+        // duration percentiles) without a derived view.
+        //
+        // Re-run note: GitHub keeps the same run id when a run is
+        // re-run, flipping status back to `queued` / `in_progress`. The
+        // `null` fallback below correctly clears `run_completed_at`
+        // during the re-run window so analytics don't see a "completed"
+        // timestamp on a row that's actively running.
+        $completedAt = $status === WorkflowRunStatus::Completed ? $updatedAt : null;
+
+        return [
+            'github_id' => (int) $payload['id'],
+            'run_number' => (int) ($payload['run_number'] ?? 0),
+            'name' => (string) ($payload['name'] ?? 'workflow'),
+            'event' => (string) ($payload['event'] ?? 'unknown'),
+            'status' => $status->value,
+            'conclusion' => $conclusion?->value,
+            'head_branch' => isset($payload['head_branch']) ? (string) $payload['head_branch'] : null,
+            'head_sha' => (string) $payload['head_sha'],
+            'actor_login' => $payload['actor']['login']
+                ?? $payload['triggering_actor']['login']
+                ?? null,
+            'html_url' => (string) ($payload['html_url'] ?? ''),
+            'run_started_at' => $startedAt,
+            'run_updated_at' => $updatedAt,
+            'run_completed_at' => $completedAt,
+        ];
+    }
+
+    private function parseStatus(?string $status): WorkflowRunStatus
+    {
+        return WorkflowRunStatus::tryFrom((string) $status) ?? WorkflowRunStatus::Queued;
+    }
+
+    private function parseConclusion(?string $conclusion): ?WorkflowRunConclusion
+    {
+        if ($conclusion === null || $conclusion === '') {
+            return null;
+        }
+
+        return WorkflowRunConclusion::tryFrom($conclusion);
+    }
+
+    private function parseTimestamp(?string $iso): ?Carbon
+    {
+        if ($iso === null || $iso === '') {
+            return null;
+        }
+
+        return Carbon::parse($iso);
+    }
+}

--- a/app/Domain/GitHub/Actions/SyncRepositoryWorkflowRunsAction.php
+++ b/app/Domain/GitHub/Actions/SyncRepositoryWorkflowRunsAction.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Domain\GitHub\Actions;
+
+use App\Domain\GitHub\Services\GitHubClient;
+use App\Models\Repository;
+use App\Models\WorkflowRun;
+
+/**
+ * Sync one repository's GitHub Actions workflow runs into the local
+ * `workflow_runs` table. Parallel structure to spec 015's
+ * `SyncRepositoryIssuesAction` and spec 016's
+ * `SyncRepositoryPullRequestsAction`.
+ *
+ * GitHub's `/actions/runs` endpoint doesn't support `?since=`, so we
+ * always full-fetch (capped at 100 most-recent rows). Idempotent: the
+ * upsert keys on `(repository_id, github_id)` so the same delivery
+ * lands on the same row across re-syncs and webhook upserts.
+ *
+ * Returns the number of runs persisted (insert + update both count).
+ *
+ * Wraps `GitHubApiException` from the client up to the caller (the job
+ * catches it and flips `workflow_runs_sync_status` to failed; on 401
+ * the connection is also expired).
+ */
+class SyncRepositoryWorkflowRunsAction
+{
+    public function __construct(
+        private readonly NormalizeGitHubWorkflowRunAction $normalizer,
+    ) {}
+
+    public function execute(Repository $repository, GitHubClient $client): int
+    {
+        $payload = $client->listWorkflowRuns($repository->full_name);
+
+        $count = 0;
+
+        foreach ($payload as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+
+            $normalized = $this->normalizer->execute($entry);
+
+            if ($normalized === null) {
+                continue;
+            }
+
+            WorkflowRun::query()->updateOrCreate(
+                [
+                    'repository_id' => $repository->id,
+                    'github_id' => $normalized['github_id'],
+                ],
+                $normalized,
+            );
+
+            $count++;
+        }
+
+        return $count;
+    }
+}

--- a/app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php
+++ b/app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php
@@ -111,11 +111,11 @@ class SyncGitHubRepositoryJob implements ShouldQueue
             $this->markFailed($repository, $e->getMessage() !== '' ? $e->getMessage() : $e::class);
         }
 
-        // Chain spec 015's issues sync and spec 016's PRs sync. Both
-        // dispatches sit outside the try/catch above so a transient
-        // queue failure here doesn't flip a freshly-synced repo back
-        // to `failed` — both child syncs carry their own independent
-        // statuses on the repo row.
+        // Chain spec 015's issues sync, spec 016's PRs sync, and spec
+        // 020's workflow runs sync. All three dispatches sit outside
+        // the try/catch above so a transient queue failure here doesn't
+        // flip a freshly-synced repo back to `failed` — each child sync
+        // carries its own independent status on the repo row.
         if ($metadataSynced) {
             $this->dispatchChildSync(
                 fn () => SyncRepositoryIssuesJob::dispatch($repository->id),
@@ -127,6 +127,12 @@ class SyncGitHubRepositoryJob implements ShouldQueue
                 fn () => SyncRepositoryPullRequestsJob::dispatch($repository->id),
                 $repository,
                 'pulls',
+            );
+
+            $this->dispatchChildSync(
+                fn () => SyncRepositoryWorkflowRunsJob::dispatch($repository->id),
+                $repository,
+                'workflow runs',
             );
         }
     }

--- a/app/Domain/GitHub/Jobs/SyncRepositoryWorkflowRunsJob.php
+++ b/app/Domain/GitHub/Jobs/SyncRepositoryWorkflowRunsJob.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Domain\GitHub\Jobs;
+
+use App\Domain\GitHub\Actions\SyncRepositoryWorkflowRunsAction;
+use App\Domain\GitHub\Exceptions\GitHubApiException;
+use App\Domain\GitHub\Services\GitHubClient;
+use App\Enums\RepositorySyncStatus;
+use App\Models\GithubConnection;
+use App\Models\Repository;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Throwable;
+
+/**
+ * Sync a single Repository's GitHub Actions workflow runs into
+ * `workflow_runs`. Parallel to spec 015's `SyncRepositoryIssuesJob`
+ * and spec 016's `SyncRepositoryPullRequestsJob` — same lifecycle,
+ * same 401 plumbing, same preserve-on-failure timestamp guarantee,
+ * same error-clearing rules.
+ *
+ *   pending → syncing → synced (happy path)
+ *   pending → syncing → failed (caught GitHubApiException or Throwable)
+ *
+ * On 401 we additionally clear the connection's `access_token` and
+ * zero out `expires_at` so spec-013's Settings card surfaces the
+ * Reconnect CTA.
+ *
+ * `workflow_runs_synced_at` is only stamped on success — the "Last
+ * sync" UI must mean "last successful sync." `workflow_runs_sync
+ * _error` + `workflow_runs_sync_failed_at` are written on failure
+ * (capped at 500 chars) and cleared on a fresh syncing flip + on
+ * success, parallel to the rest of the sync flows.
+ */
+class SyncRepositoryWorkflowRunsJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    public function __construct(public readonly int $repositoryId) {}
+
+    public function handle(SyncRepositoryWorkflowRunsAction $action): void
+    {
+        $repository = Repository::query()->find($this->repositoryId);
+
+        if ($repository === null) {
+            return;
+        }
+
+        $connection = $this->resolveConnection($repository);
+
+        if ($connection === null) {
+            Log::warning('GitHub workflow runs sync skipped — no connection', [
+                'repository_id' => $repository->id,
+                'full_name' => $repository->full_name,
+            ]);
+            $this->markFailed($repository, 'No GitHub connection — reconnect in Settings to sync workflow runs.');
+
+            return;
+        }
+
+        $repository->forceFill([
+            'workflow_runs_sync_status' => RepositorySyncStatus::Syncing->value,
+            'workflow_runs_sync_error' => null,
+            'workflow_runs_sync_failed_at' => null,
+        ])->save();
+
+        try {
+            $action->execute($repository, new GitHubClient($connection));
+
+            $repository->forceFill([
+                'workflow_runs_sync_status' => RepositorySyncStatus::Synced->value,
+                'workflow_runs_synced_at' => now(),
+                'workflow_runs_sync_error' => null,
+                'workflow_runs_sync_failed_at' => null,
+            ])->save();
+        } catch (GitHubApiException $e) {
+            if ($e->isUnauthorized()) {
+                $this->expireConnection($connection);
+            }
+
+            Log::warning('GitHub workflow runs sync failed', [
+                'repository_id' => $repository->id,
+                'full_name' => $repository->full_name,
+                'status' => $e->statusCode,
+                'message' => $e->getMessage(),
+            ]);
+
+            $this->markFailed($repository, $e->getMessage());
+        } catch (Throwable $e) {
+            Log::error('GitHub workflow runs sync errored', [
+                'repository_id' => $repository->id,
+                'full_name' => $repository->full_name,
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+
+            $this->markFailed($repository, $e->getMessage() !== '' ? $e->getMessage() : $e::class);
+        }
+    }
+
+    private function resolveConnection(Repository $repository): ?GithubConnection
+    {
+        $repository->loadMissing('project.owner.githubConnection');
+
+        return $repository->project?->owner?->githubConnection;
+    }
+
+    /**
+     * Flip to `failed` and persist the failure reason for the UI.
+     *
+     * We deliberately do NOT update `workflow_runs_synced_at` — that
+     * column means "last successful sync" and feeds the Repository
+     * Workflow Runs tab's "Last sync N min ago" indicator.
+     *
+     * `workflow_runs_sync_error` is hard-capped at 500 chars; the full
+     * message is still in Pail at the call site.
+     */
+    private function markFailed(Repository $repository, ?string $reason = null): void
+    {
+        $repository->forceFill([
+            'workflow_runs_sync_status' => RepositorySyncStatus::Failed->value,
+            'workflow_runs_sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
+            'workflow_runs_sync_failed_at' => now(),
+        ])->save();
+    }
+
+    private function expireConnection(GithubConnection $connection): void
+    {
+        $connection->forceFill([
+            'access_token' => '',
+            'expires_at' => now(),
+        ])->save();
+    }
+}

--- a/app/Domain/GitHub/Queries/WorkflowRunsForRepositoryQuery.php
+++ b/app/Domain/GitHub/Queries/WorkflowRunsForRepositoryQuery.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Domain\GitHub\Queries;
+
+use App\Models\Repository;
+use App\Models\WorkflowRun;
+
+/**
+ * Trim the `workflow_runs` rows for one repository down to the shape
+ * the Repository show page's Workflow Runs tab needs. Parallel to
+ * spec 015's `IssuesForRepositoryQuery` and spec 016's
+ * `PullRequestsForRepositoryQuery`.
+ *
+ * Sort: most-recent-first by `run_started_at`, with `github_id desc`
+ * as the deterministic tie-break for runs sharing a started_at (or
+ * both null). Spec 021's cross-repo timeline reuses the same axis.
+ *
+ * Returns plain arrays so the controller doesn't have to know about
+ * Eloquent magic when building the Inertia payload.
+ */
+class WorkflowRunsForRepositoryQuery
+{
+    /** Soft cap on rows; pagination lands when a real user blows past. */
+    private const LIMIT = 100;
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function execute(Repository $repository): array
+    {
+        return WorkflowRun::query()
+            ->where('repository_id', $repository->id)
+            ->orderByDesc('run_started_at')
+            ->orderByDesc('github_id')
+            ->limit(self::LIMIT)
+            ->get()
+            ->map(fn (WorkflowRun $run) => [
+                'id' => $run->id,
+                'run_number' => $run->run_number,
+                'name' => $run->name,
+                'event' => $run->event,
+                'status' => $run->status?->value,
+                'conclusion' => $run->conclusion?->value,
+                'head_branch' => $run->head_branch,
+                'head_sha' => $run->head_sha,
+                'actor_login' => $run->actor_login,
+                'html_url' => $run->html_url,
+                'run_started_at' => $run->run_started_at?->diffForHumans(),
+                'run_updated_at' => $run->run_updated_at?->diffForHumans(),
+            ])
+            ->all();
+    }
+}

--- a/app/Domain/GitHub/Services/GitHubClient.php
+++ b/app/Domain/GitHub/Services/GitHubClient.php
@@ -168,6 +168,47 @@ class GitHubClient
     }
 
     /**
+     * GET /repos/{owner}/{name}/actions/runs — GitHub Actions workflow
+     * runs across all workflows in the repository. GitHub wraps the
+     * payload in `{ total_count, workflow_runs: [...] }`; we unwrap and
+     * return just the runs array.
+     *
+     * Capped at the most-recent 100 runs in the response. Pagination
+     * is a follow-up if the timeline UI in spec 021 needs deeper history.
+     */
+    public function listWorkflowRuns(
+        string $fullName,
+        int $perPage = self::DEFAULT_PER_PAGE,
+    ): array {
+        try {
+            $response = $this->request()
+                ->get(self::BASE_URL."/repos/{$fullName}/actions/runs", [
+                    'per_page' => max(1, min($perPage, 100)),
+                    'page' => 1,
+                ]);
+
+            if ($response->failed()) {
+                throw GitHubApiException::fromResponse(
+                    $response,
+                    "GitHub /repos/{$fullName}/actions/runs failed",
+                );
+            }
+
+            $body = (array) $response->json();
+
+            // Defensive: a missing `workflow_runs` key falls back to an
+            // empty list rather than tripping the normalizer downstream
+            // with a non-array.
+            return is_array($body['workflow_runs'] ?? null) ? $body['workflow_runs'] : [];
+        } catch (RequestException $e) {
+            throw GitHubApiException::fromTransport(
+                $e,
+                "GitHub /repos/{$fullName}/actions/runs failed",
+            );
+        }
+    }
+
+    /**
      * Shared HTTP client config — auth + pinned API version + UA.
      * Note: we don't call `->throw()` on the PendingRequest; the
      * callers check `$response->failed()` and route the failure into

--- a/app/Domain/GitHub/WebhookHandlers/WorkflowRunWebhookHandler.php
+++ b/app/Domain/GitHub/WebhookHandlers/WorkflowRunWebhookHandler.php
@@ -3,10 +3,12 @@
 namespace App\Domain\GitHub\WebhookHandlers;
 
 use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Domain\GitHub\Actions\NormalizeGitHubWorkflowRunAction;
 use App\Enums\ActivitySeverity;
 use App\Enums\WebhookDeliveryStatus;
 use App\Models\Repository;
 use App\Models\WebhookDelivery;
+use App\Models\WorkflowRun;
 use Illuminate\Support\Carbon;
 
 /**
@@ -39,6 +41,7 @@ class WorkflowRunWebhookHandler
 
     public function __construct(
         private readonly CreateActivityEventAction $createActivity,
+        private readonly NormalizeGitHubWorkflowRunAction $normalizer,
     ) {}
 
     public function handle(WebhookDelivery $delivery): WebhookDeliveryStatus
@@ -47,7 +50,32 @@ class WorkflowRunWebhookHandler
         $action = (string) ($payload['action'] ?? '');
         $run = $payload['workflow_run'] ?? null;
 
-        if ($action !== 'completed' || ! is_array($run)) {
+        if (! is_array($run)) {
+            $delivery->forceFill([
+                'error_message' => 'Skipped — `workflow_run` payload missing or malformed.',
+            ])->save();
+
+            return WebhookDeliveryStatus::Skipped;
+        }
+
+        $repository = $this->resolveRepository($delivery);
+
+        if ($repository === null) {
+            $delivery->forceFill([
+                'error_message' => 'Repository not imported into Nexus.',
+            ])->save();
+
+            return WebhookDeliveryStatus::Skipped;
+        }
+
+        // Spec 020 — upsert the run row regardless of action/conclusion so
+        // the timeline + Workflow Runs tab reflect in-flight + non-terminal
+        // states (queued / in_progress / cancelled / etc.). Activity-event
+        // creation below remains gated to terminal outcomes so the rail
+        // doesn't thrash.
+        $this->upsertWorkflowRun($repository, $run);
+
+        if ($action !== 'completed') {
             $delivery->forceFill([
                 'error_message' => "Skipped — only `completed` actions surface to activity (got `{$action}`).",
             ])->save();
@@ -61,16 +89,6 @@ class WorkflowRunWebhookHandler
         if ($rule === null) {
             $delivery->forceFill([
                 'error_message' => "Skipped — conclusion `{$conclusion}` not surfaced to activity.",
-            ])->save();
-
-            return WebhookDeliveryStatus::Skipped;
-        }
-
-        $repository = $this->resolveRepository($delivery);
-
-        if ($repository === null) {
-            $delivery->forceFill([
-                'error_message' => 'Repository not imported into Nexus.',
             ])->save();
 
             return WebhookDeliveryStatus::Skipped;
@@ -114,6 +132,34 @@ class WorkflowRunWebhookHandler
         }
 
         return Repository::query()->where('full_name', $fullName)->first();
+    }
+
+    /**
+     * Normalize the webhook payload's `workflow_run` field and upsert
+     * onto `workflow_runs` keyed by `(repository_id, github_id)`. The
+     * sync job (`SyncRepositoryWorkflowRunsJob`) lands on the same key,
+     * so live deliveries + REST backfill cleanly converge.
+     *
+     * Returns silently if the normalizer rejects the payload — bad
+     * deliveries shouldn't break the activity-event path that follows.
+     *
+     * @param  array<string, mixed>  $run
+     */
+    private function upsertWorkflowRun(Repository $repository, array $run): void
+    {
+        $normalized = $this->normalizer->execute($run);
+
+        if ($normalized === null) {
+            return;
+        }
+
+        WorkflowRun::query()->updateOrCreate(
+            [
+                'repository_id' => $repository->id,
+                'github_id' => $normalized['github_id'],
+            ],
+            $normalized,
+        );
     }
 
     private function occurredAt(array $run): Carbon

--- a/app/Enums/WebhookDeliveryStatus.php
+++ b/app/Enums/WebhookDeliveryStatus.php
@@ -8,8 +8,19 @@ namespace App\Enums;
  *  - `received` — controller stored the row + dispatched the job
  *  - `processed` — handler ran successfully
  *  - `failed`    — handler threw; `error_message` carries the reason
- *  - `skipped`   — event type or action we don't know how to handle
- *                  (per §8.5 "Log unknown events. Do not fail silently")
+ *  - `skipped`   — handler chose not to surface the event to the
+ *                  activity feed (e.g. unknown event type, non-terminal
+ *                  workflow run action, repository not imported into
+ *                  Nexus). Per §8.5: "Log unknown events. Do not fail
+ *                  silently."
+ *
+ *                  As of spec 020, `skipped` no longer guarantees zero
+ *                  side-effects — the workflow_run handler upserts the
+ *                  run into `workflow_runs` for ALL deliveries (so the
+ *                  timeline reflects in-flight states) and only
+ *                  short-circuits the activity-event creation. The
+ *                  semantic intent is "no activity event," not "no
+ *                  DB writes."
  */
 enum WebhookDeliveryStatus: string
 {

--- a/app/Enums/WorkflowRunConclusion.php
+++ b/app/Enums/WorkflowRunConclusion.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Terminal outcome of a GitHub Actions workflow run, mirroring GitHub's
+ * `conclusion` field. Only meaningful when `WorkflowRunStatus::Completed`.
+ *
+ * Tones map to `StatusBadge`:
+ *   success     → success
+ *   failure     → danger
+ *   cancelled   → warning  (user-initiated stop, not catastrophic)
+ *   timed_out   → warning  (capped before completion)
+ *   action_required → warning (manual intervention pending)
+ *   stale       → muted    (workflow superseded)
+ *   neutral     → muted    (passing-but-not-failing, used by some checks)
+ *   skipped     → muted    (filtered out at workflow level)
+ */
+enum WorkflowRunConclusion: string
+{
+    case Success = 'success';
+    case Failure = 'failure';
+    case Cancelled = 'cancelled';
+    case TimedOut = 'timed_out';
+    case ActionRequired = 'action_required';
+    case Stale = 'stale';
+    case Neutral = 'neutral';
+    case Skipped = 'skipped';
+
+    public function badgeTone(): string
+    {
+        return match ($this) {
+            self::Success => 'success',
+            self::Failure => 'danger',
+            self::Cancelled, self::TimedOut, self::ActionRequired => 'warning',
+            self::Stale, self::Neutral, self::Skipped => 'muted',
+        };
+    }
+}

--- a/app/Enums/WorkflowRunStatus.php
+++ b/app/Enums/WorkflowRunStatus.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Lifecycle of a GitHub Actions workflow run, mirroring GitHub's `status`
+ * field on the `actions/runs` payload. `conclusion` (separate enum) is
+ * only set once status flips to `completed`.
+ *
+ * Listed here are the three values GitHub commits to in their docs:
+ * https://docs.github.com/en/rest/actions/workflow-runs — newer states
+ * (e.g. `requested`, `waiting`, `pending`) collapse to `Queued` when we
+ * normalize, since the user-visible distinction isn't meaningful.
+ */
+enum WorkflowRunStatus: string
+{
+    case Queued = 'queued';
+    case InProgress = 'in_progress';
+    case Completed = 'completed';
+
+    /** Tone used by `StatusBadge` (muted/info/success/warning/danger). */
+    public function badgeTone(): string
+    {
+        return match ($this) {
+            self::Queued => 'muted',
+            self::InProgress => 'info',
+            self::Completed => 'success',
+        };
+    }
+}

--- a/app/Http/Controllers/RepositoryController.php
+++ b/app/Http/Controllers/RepositoryController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Domain\GitHub\Actions\ImportRepositoryAction;
 use App\Domain\GitHub\Queries\IssuesForRepositoryQuery;
 use App\Domain\GitHub\Queries\PullRequestsForRepositoryQuery;
+use App\Domain\GitHub\Queries\WorkflowRunsForRepositoryQuery;
 use App\Http\Requests\Repositories\LinkRepositoryRequest;
 use App\Models\Repository;
 use Illuminate\Database\UniqueConstraintViolationException;
@@ -37,6 +38,7 @@ class RepositoryController extends Controller
         Repository $repository,
         IssuesForRepositoryQuery $issuesQuery,
         PullRequestsForRepositoryQuery $pullRequestsQuery,
+        WorkflowRunsForRepositoryQuery $workflowRunsQuery,
     ): Response {
         $this->authorize('view', $repository);
 
@@ -64,6 +66,13 @@ class RepositoryController extends Controller
                 'synced_at' => $repository->prs_synced_at?->diffForHumans(),
                 'error' => $repository->prs_sync_error,
                 'failed_at' => $repository->prs_sync_failed_at?->diffForHumans(),
+            ],
+            'workflowRuns' => $workflowRunsQuery->execute($repository),
+            'workflowRunsSync' => [
+                'status' => $repository->workflow_runs_sync_status?->value,
+                'synced_at' => $repository->workflow_runs_synced_at?->diffForHumans(),
+                'error' => $repository->workflow_runs_sync_error,
+                'failed_at' => $repository->workflow_runs_sync_failed_at?->diffForHumans(),
             ],
         ]);
     }

--- a/app/Http/Controllers/RepositorySyncController.php
+++ b/app/Http/Controllers/RepositorySyncController.php
@@ -33,11 +33,12 @@ class RepositorySyncController extends Controller
         $this->authorize('update', $repository->project);
 
         // Clear the metadata error and the child-sync errors as well —
-        // the metadata job chains issues + PRs syncs on success, so the
-        // user's mental model is "Run sync re-runs all three." If we
-        // cleared only the metadata error, the page would briefly show
-        // "Syncing…" at the top while stale red error alerts on the
-        // Issues / PRs tabs persisted until those child jobs picked up.
+        // the metadata job chains issues + PRs + workflow runs syncs on
+        // success, so the user's mental model is "Run sync re-runs all
+        // four." If we cleared only the metadata error, the page would
+        // briefly show "Syncing…" at the top while stale red error
+        // alerts on the Issues / PRs / Workflow Runs tabs persisted
+        // until those child jobs picked up.
         $repository->update([
             'sync_status' => RepositorySyncStatus::Syncing->value,
             'sync_error' => null,
@@ -46,6 +47,8 @@ class RepositorySyncController extends Controller
             'issues_sync_failed_at' => null,
             'prs_sync_error' => null,
             'prs_sync_failed_at' => null,
+            'workflow_runs_sync_error' => null,
+            'workflow_runs_sync_failed_at' => null,
         ]);
 
         SyncGitHubRepositoryJob::dispatch($repository->id);

--- a/app/Http/Controllers/RepositoryWorkflowRunsSyncController.php
+++ b/app/Http/Controllers/RepositoryWorkflowRunsSyncController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\GitHub\Jobs\SyncRepositoryWorkflowRunsJob;
+use App\Models\Repository;
+use Illuminate\Http\RedirectResponse;
+
+/**
+ * Manual "Run sync" button on the Repository Workflow Runs tab.
+ * Re-dispatches `SyncRepositoryWorkflowRunsJob` for the given
+ * repository. The auto-chain from spec 014's import flow still fires
+ * (extended by spec 020 to include workflow runs); this is the
+ * explicit path a user can use to refresh on demand.
+ *
+ * Authorization: `ProjectPolicy::update` — only the project owner can
+ * trigger a re-sync, mirroring spec 015 / 016.
+ */
+class RepositoryWorkflowRunsSyncController extends Controller
+{
+    public function __invoke(Repository $repository): RedirectResponse
+    {
+        $repository->loadMissing('project');
+        $this->authorize('update', $repository->project);
+
+        SyncRepositoryWorkflowRunsJob::dispatch($repository->id);
+
+        return back()->with('status', 'Workflow runs sync queued.');
+    }
+}

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -43,6 +43,10 @@ class Repository extends Model
         'prs_synced_at',
         'prs_sync_error',
         'prs_sync_failed_at',
+        'workflow_runs_sync_status',
+        'workflow_runs_synced_at',
+        'workflow_runs_sync_error',
+        'workflow_runs_sync_failed_at',
     ];
 
     protected function casts(): array
@@ -51,6 +55,7 @@ class Repository extends Model
             'sync_status' => RepositorySyncStatus::class,
             'issues_sync_status' => RepositorySyncStatus::class,
             'prs_sync_status' => RepositorySyncStatus::class,
+            'workflow_runs_sync_status' => RepositorySyncStatus::class,
             'stars_count' => 'integer',
             'forks_count' => 'integer',
             'open_issues_count' => 'integer',
@@ -62,6 +67,8 @@ class Repository extends Model
             'issues_sync_failed_at' => 'datetime',
             'prs_synced_at' => 'datetime',
             'prs_sync_failed_at' => 'datetime',
+            'workflow_runs_synced_at' => 'datetime',
+            'workflow_runs_sync_failed_at' => 'datetime',
         ];
     }
 
@@ -88,5 +95,10 @@ class Repository extends Model
     public function pullRequests(): HasMany
     {
         return $this->hasMany(GithubPullRequest::class);
+    }
+
+    public function workflowRuns(): HasMany
+    {
+        return $this->hasMany(WorkflowRun::class);
     }
 }

--- a/app/Models/WorkflowRun.php
+++ b/app/Models/WorkflowRun.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\WorkflowRunConclusion;
+use App\Enums\WorkflowRunStatus;
+use Database\Factories\WorkflowRunFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WorkflowRun extends Model
+{
+    /** @use HasFactory<WorkflowRunFactory> */
+    use HasFactory;
+
+    protected $table = 'workflow_runs';
+
+    protected $fillable = [
+        'repository_id',
+        'github_id',
+        'run_number',
+        'name',
+        'event',
+        'status',
+        'conclusion',
+        'head_branch',
+        'head_sha',
+        'actor_login',
+        'html_url',
+        'run_started_at',
+        'run_updated_at',
+        'run_completed_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => WorkflowRunStatus::class,
+            'conclusion' => WorkflowRunConclusion::class,
+            'run_number' => 'integer',
+            'run_started_at' => 'datetime',
+            'run_updated_at' => 'datetime',
+            'run_completed_at' => 'datetime',
+        ];
+    }
+
+    public function repository(): BelongsTo
+    {
+        return $this->belongsTo(Repository::class);
+    }
+}

--- a/database/factories/WorkflowRunFactory.php
+++ b/database/factories/WorkflowRunFactory.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\WorkflowRunConclusion;
+use App\Enums\WorkflowRunStatus;
+use App\Models\Repository;
+use App\Models\WorkflowRun;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<WorkflowRun> */
+class WorkflowRunFactory extends Factory
+{
+    protected $model = WorkflowRun::class;
+
+    public function definition(): array
+    {
+        $status = fake()->randomElement([
+            WorkflowRunStatus::Completed,
+            WorkflowRunStatus::Completed,
+            WorkflowRunStatus::Completed,
+            WorkflowRunStatus::InProgress,
+            WorkflowRunStatus::Queued,
+        ]);
+
+        $startedAt = fake()->dateTimeBetween('-30 days', '-1 hour');
+        $updatedAt = fake()->dateTimeBetween($startedAt, 'now');
+        $isCompleted = $status === WorkflowRunStatus::Completed;
+        $conclusion = $isCompleted
+            ? fake()->randomElement([
+                WorkflowRunConclusion::Success,
+                WorkflowRunConclusion::Success,
+                WorkflowRunConclusion::Success,
+                WorkflowRunConclusion::Failure,
+                WorkflowRunConclusion::Cancelled,
+            ])
+            : null;
+
+        $githubId = fake()->unique()->numberBetween(10_000_000, 99_999_999);
+
+        return [
+            'repository_id' => Repository::factory(),
+            'github_id' => $githubId,
+            'run_number' => fake()->numberBetween(1, 999),
+            'name' => fake()->randomElement(['CI', 'Deploy', 'Lint', 'Tests']),
+            'event' => fake()->randomElement(['push', 'pull_request', 'schedule', 'workflow_dispatch']),
+            'status' => $status->value,
+            'conclusion' => $conclusion?->value,
+            'head_branch' => fake()->randomElement(['main', 'develop', 'topic/'.fake()->slug(2)]),
+            'head_sha' => fake()->sha1(),
+            'actor_login' => fake()->userName(),
+            'html_url' => 'https://github.com/octocat/hello-world/actions/runs/'.$githubId,
+            'run_started_at' => $startedAt,
+            'run_updated_at' => $updatedAt,
+            'run_completed_at' => $isCompleted ? $updatedAt : null,
+        ];
+    }
+}

--- a/database/migrations/2026_04_30_120100_create_workflow_runs_table.php
+++ b/database/migrations/2026_04_30_120100_create_workflow_runs_table.php
@@ -1,0 +1,75 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('workflow_runs', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('repository_id')
+                ->constrained('repositories')
+                ->cascadeOnDelete();
+
+            // GitHub's globally-unique run id; `run_number` is the
+            // per-workflow human counter (#N).
+            $table->unsignedBigInteger('github_id');
+            $table->unsignedInteger('run_number');
+
+            // Workflow display name from GitHub's `name` field —
+            // e.g. "CI", "Deploy production".
+            $table->string('name');
+
+            // GitHub's `event` field — the trigger: push / pull_request /
+            // schedule / workflow_dispatch / release / etc. Not enumerated
+            // because GitHub adds new event types over time and we don't
+            // gain anything from a tight list here.
+            $table->string('event', 32);
+
+            // queued | in_progress | completed (per `WorkflowRunStatus`).
+            // Indexed because the timeline UI in spec 021 will filter on it.
+            $table->string('status', 16)->index();
+
+            // success | failure | cancelled | timed_out | action_required |
+            // stale | neutral | skipped (per `WorkflowRunConclusion`).
+            // Nullable: only set once `status = completed`.
+            $table->string('conclusion', 16)->nullable()->index();
+
+            $table->string('head_branch')->nullable();
+            $table->string('head_sha', 64);
+
+            $table->string('actor_login')->nullable();
+
+            $table->string('html_url');
+
+            // Timestamps from GitHub's payload. `run_started_at` is the
+            // post-queue start (preferred for sort), `run_updated_at`
+            // mirrors GitHub's last update, `run_completed_at` is set
+            // when status flips to completed.
+            $table->timestamp('run_started_at')->nullable();
+            $table->timestamp('run_updated_at')->nullable();
+            $table->timestamp('run_completed_at')->nullable();
+
+            $table->timestamps();
+
+            // Upsert idempotency. The webhook handler (spec 019) and the
+            // sync job both land on the same key — last-write-wins.
+            $table->unique(['repository_id', 'github_id']);
+
+            // Recent-first listing for the per-repo tab + spec 021's
+            // cross-repo timeline. `run_started_at desc` is the natural
+            // axis; `github_id desc` is the tie-break for runs that share
+            // a started_at timestamp (or both null).
+            $table->index(['repository_id', 'run_started_at'], 'workflow_runs_repo_started_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('workflow_runs');
+    }
+};

--- a/database/migrations/2026_04_30_120101_add_workflow_runs_sync_columns_to_repositories_table.php
+++ b/database/migrations/2026_04_30_120101_add_workflow_runs_sync_columns_to_repositories_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('repositories', function (Blueprint $table) {
+            // Parallel to spec 015's `issues_sync_*` and spec 016's
+            // `prs_sync_*` columns — workflow runs sync runs as its own
+            // job (`SyncRepositoryWorkflowRunsJob`) chained alongside
+            // them, so its lifecycle is observed independently of the
+            // metadata / issues / PRs syncs.
+            //
+            // Same six-column shape (status / synced_at / error /
+            // failed_at) shipped for the other flows in `add_sync_error
+            // _columns_to_repositories_table` — keeping it aligned so
+            // the UI can render all four sync flows from one template.
+            $table->string('workflow_runs_sync_status', 16)->default('pending')->after('prs_sync_status');
+            $table->text('workflow_runs_sync_error')->nullable()->after('workflow_runs_sync_status');
+            $table->timestamp('workflow_runs_synced_at')->nullable()->after('prs_synced_at');
+            $table->timestamp('workflow_runs_sync_failed_at')->nullable()->after('workflow_runs_synced_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('repositories', function (Blueprint $table) {
+            $table->dropColumn([
+                'workflow_runs_sync_status',
+                'workflow_runs_sync_error',
+                'workflow_runs_synced_at',
+                'workflow_runs_sync_failed_at',
+            ]);
+        });
+    }
+};

--- a/resources/js/Pages/Repositories/Show.vue
+++ b/resources/js/Pages/Repositories/Show.vue
@@ -17,6 +17,7 @@ import {
     RefreshCcw,
     Star,
     Trash2,
+    Workflow,
 } from 'lucide-vue-next';
 import { computed, onBeforeUnmount, ref, watch } from 'vue';
 
@@ -73,6 +74,36 @@ interface PullRequestRow {
     html_url: string;
 }
 
+interface WorkflowRunRow {
+    id: number;
+    run_number: number;
+    name: string;
+    event: string;
+    status:
+        | 'queued'
+        | 'in_progress'
+        | 'completed'
+        | string
+        | null;
+    conclusion:
+        | 'success'
+        | 'failure'
+        | 'cancelled'
+        | 'timed_out'
+        | 'action_required'
+        | 'stale'
+        | 'neutral'
+        | 'skipped'
+        | string
+        | null;
+    head_branch: string | null;
+    head_sha: string;
+    actor_login: string | null;
+    html_url: string;
+    run_started_at: string | null;
+    run_updated_at: string | null;
+}
+
 interface SyncShape {
     status: string | null;
     synced_at: string | null;
@@ -88,9 +119,11 @@ const props = defineProps<{
     issuesSync: SyncShape;
     pullRequests: PullRequestRow[];
     pullRequestsSync: SyncShape;
+    workflowRuns: WorkflowRunRow[];
+    workflowRunsSync: SyncShape;
 }>();
 
-const tab = ref<'overview' | 'issues' | 'pulls'>('overview');
+const tab = ref<'overview' | 'issues' | 'pulls' | 'workflow-runs'>('overview');
 
 const syncStatusTone = (status: string | null) =>
     (
@@ -114,6 +147,38 @@ const prStateTone = (state: string | null) =>
         }) as const
     )[state ?? ''] ?? 'muted';
 
+const workflowConclusionTone = (conclusion: string | null) =>
+    (
+        ({
+            success: 'success',
+            failure: 'danger',
+            cancelled: 'warning',
+            timed_out: 'warning',
+            action_required: 'warning',
+            stale: 'muted',
+            neutral: 'muted',
+            skipped: 'muted',
+        }) as const
+    )[conclusion ?? ''] ?? 'muted';
+
+// Tone for the run-status badge shown when a run has no conclusion
+// yet — `WorkflowRunConclusion` is null pre-completion. Keys match
+// `WorkflowRunStatus::badgeTone()` on the PHP side so the two
+// renderers agree.
+const workflowStatusTone = (status: string | null) =>
+    (
+        ({
+            queued: 'muted',
+            in_progress: 'info',
+            completed: 'success',
+        }) as const
+    )[status ?? ''] ?? 'muted';
+
+// Display label for the conclusion badge — `timed_out` reads cleaner
+// as `timed out`, etc. Falls back to a humanized form for unknowns.
+const workflowConclusionLabel = (conclusion: string | null) =>
+    conclusion === null ? '—' : conclusion.replace(/_/g, ' ');
+
 const projectAccentClass = (color: string | null) =>
     (
         ({
@@ -128,9 +193,13 @@ const projectAccentClass = (color: string | null) =>
 
 const issuesCount = computed(() => props.issues.length);
 const pullRequestsCount = computed(() => props.pullRequests.length);
+const workflowRunsCount = computed(() => props.workflowRuns.length);
 const isIssuesSyncing = computed(() => props.issuesSync.status === 'syncing');
 const isPullRequestsSyncing = computed(
     () => props.pullRequestsSync.status === 'syncing',
+);
+const isWorkflowRunsSyncing = computed(
+    () => props.workflowRunsSync.status === 'syncing',
 );
 const isRepositorySyncing = computed(
     () => props.repository.sync_status === 'syncing',
@@ -166,6 +235,15 @@ const runPullRequestsSync = () => {
     );
 };
 
+const runWorkflowRunsSync = () => {
+    if (!props.canSync) return;
+    router.post(
+        route('repositories.workflow-runs.sync', props.repository.full_name),
+        {},
+        { preserveScroll: true },
+    );
+};
+
 const runRepositorySync = () => {
     if (!props.canSync) return;
     router.post(
@@ -175,12 +253,12 @@ const runRepositorySync = () => {
     );
 };
 
-// While ANY of the three sync flows (repository / issues / PRs) is in
-// `syncing` state, poll the controller every 2.5s for the latest status —
-// a partial Inertia reload that re-fetches just the three sync-related
-// props so the page updates without flashing or losing scroll. Stops on
-// its own as soon as all three flip out of `syncing`. Spec 019 will
-// replace this with Reverb broadcasts.
+// While ANY of the four sync flows (repository / issues / PRs / workflow
+// runs) is in `syncing` state, poll the controller every 2.5s for the
+// latest status — a partial Inertia reload that re-fetches just the
+// sync-related props so the page updates without flashing or losing
+// scroll. Stops on its own as soon as all four flip out of `syncing`.
+// Spec 019 will replace this with Reverb broadcasts.
 const POLL_INTERVAL_MS = 2500;
 let pollHandle: ReturnType<typeof setInterval> | null = null;
 
@@ -188,7 +266,8 @@ const anySyncing = computed(
     () =>
         isRepositorySyncing.value ||
         isIssuesSyncing.value ||
-        isPullRequestsSyncing.value,
+        isPullRequestsSyncing.value ||
+        isWorkflowRunsSyncing.value,
 );
 
 const stopPolling = () => {
@@ -203,9 +282,16 @@ const startPolling = () => {
     pollHandle = setInterval(() => {
         // `router.reload` is a same-route partial fetch — no navigation, so
         // scroll + component state are preserved by default. `only` keeps
-        // the payload tiny (just the three sync-related props).
+        // the payload tiny (just the sync-related props plus the lists
+        // they affect once the sync lands).
         router.reload({
-            only: ['repository', 'issuesSync', 'pullRequestsSync'],
+            only: [
+                'repository',
+                'issuesSync',
+                'pullRequestsSync',
+                'workflowRunsSync',
+                'workflowRuns',
+            ],
         });
     }, POLL_INTERVAL_MS);
 };
@@ -455,6 +541,25 @@ onBeforeUnmount(stopPolling);
                         {{ pullRequestsCount }}
                     </span>
                 </button>
+                <button
+                    type="button"
+                    :class="[
+                        'inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.22em] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60',
+                        tab === 'workflow-runs'
+                            ? 'border-accent-cyan/60 bg-accent-cyan/15 text-accent-cyan'
+                            : 'border-border-subtle bg-background-panel-hover text-text-secondary hover:text-text-primary',
+                    ]"
+                    @click="tab = 'workflow-runs'"
+                >
+                    <Workflow class="h-3.5 w-3.5" aria-hidden="true" />
+                    Workflow Runs
+                    <span
+                        v-if="workflowRunsCount > 0"
+                        class="rounded-full border border-current/40 px-1.5 py-0.5 text-[10px] font-mono"
+                    >
+                        {{ workflowRunsCount }}
+                    </span>
+                </button>
             </nav>
 
             <!-- Overview panel -->
@@ -689,7 +794,7 @@ onBeforeUnmount(stopPolling);
             </template>
 
             <!-- Pull Requests panel -->
-            <template v-else>
+            <template v-else-if="tab === 'pulls'">
                 <section aria-label="Pull Requests" class="glass-card p-6 sm:p-8">
                     <header
                         class="flex flex-wrap items-center justify-between gap-3 border-b border-border-subtle pb-4"
@@ -826,6 +931,163 @@ onBeforeUnmount(stopPolling);
                             The last pull requests sync failed.
                         </span>
                         <span v-else>No pull requests mirrored for this repository.</span>
+                        <span v-if="canSync"> Click <span class="font-mono">Run sync</span> to fetch from GitHub.</span>
+                    </p>
+                </section>
+            </template>
+
+            <!-- Workflow Runs panel -->
+            <template v-else-if="tab === 'workflow-runs'">
+                <section aria-label="Workflow Runs" class="glass-card p-6 sm:p-8">
+                    <header
+                        class="flex flex-wrap items-center justify-between gap-3 border-b border-border-subtle pb-4"
+                    >
+                        <div class="flex items-center gap-3">
+                            <h3 class="text-sm font-semibold text-text-primary">
+                                Workflow runs mirror
+                            </h3>
+                            <StatusBadge
+                                v-if="workflowRunsSync.status"
+                                :tone="syncStatusTone(workflowRunsSync.status)"
+                            >
+                                {{ workflowRunsSync.status }}
+                            </StatusBadge>
+                            <span
+                                v-if="workflowRunsSync.synced_at"
+                                class="text-xs text-text-muted"
+                            >
+                                Last sync
+                                <span class="font-mono text-text-secondary">{{ workflowRunsSync.synced_at }}</span>
+                            </span>
+                            <span
+                                v-else-if="workflowRunsSync.status === 'failed' && workflowRunsSync.failed_at"
+                                class="text-xs text-text-muted"
+                            >
+                                Failed
+                                <span class="font-mono text-status-danger">{{ workflowRunsSync.failed_at }}</span>
+                            </span>
+                        </div>
+                        <button
+                            v-if="canSync"
+                            type="button"
+                            class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/15 px-3 py-2 text-sm font-semibold text-accent-cyan transition hover:border-accent-cyan/60 disabled:cursor-not-allowed disabled:opacity-60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                            :disabled="isWorkflowRunsSyncing"
+                            @click="runWorkflowRunsSync"
+                        >
+                            <RefreshCcw class="h-4 w-4" aria-hidden="true" />
+                            {{ isWorkflowRunsSyncing ? 'Syncing…' : 'Run sync' }}
+                        </button>
+                    </header>
+
+                    <p
+                        v-if="workflowRunsSync.status === 'failed' && workflowRunsSync.error"
+                        class="mt-4 flex items-start gap-2 rounded-lg border border-status-danger/40 bg-status-danger/10 p-3 text-xs"
+                    >
+                        <AlertTriangle
+                            class="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-danger"
+                            aria-hidden="true"
+                        />
+                        <span class="break-words font-mono text-text-secondary">
+                            {{ workflowRunsSync.error }}
+                        </span>
+                    </p>
+
+                    <ul
+                        v-if="workflowRuns.length > 0"
+                        class="mt-2 divide-y divide-border-subtle"
+                    >
+                        <li
+                            v-for="run in workflowRuns"
+                            :key="run.id"
+                            class="flex flex-col gap-2 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
+                        >
+                            <div class="flex min-w-0 items-start gap-3">
+                                <Workflow
+                                    class="mt-1 h-4 w-4 shrink-0"
+                                    :class="{
+                                        'text-status-success':
+                                            run.conclusion === 'success',
+                                        'text-status-danger':
+                                            run.conclusion === 'failure',
+                                        'text-status-warning':
+                                            run.conclusion === 'cancelled' ||
+                                            run.conclusion === 'timed_out' ||
+                                            run.conclusion === 'action_required',
+                                        'text-accent-cyan':
+                                            run.status === 'in_progress',
+                                        'text-text-muted':
+                                            !run.conclusion &&
+                                            run.status !== 'in_progress',
+                                    }"
+                                    aria-hidden="true"
+                                />
+                                <div class="flex min-w-0 flex-col gap-1">
+                                    <a
+                                        :href="run.html_url"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        class="truncate text-sm font-semibold text-text-primary transition hover:text-accent-cyan"
+                                    >
+                                        <span class="font-mono text-text-muted">#{{ run.run_number }}</span>
+                                        {{ run.name }}
+                                    </a>
+                                    <p class="text-xs text-text-muted">
+                                        <span v-if="run.actor_login">
+                                            <span class="font-mono text-text-secondary">@{{ run.actor_login }}</span>
+                                            ·
+                                        </span>
+                                        <span class="font-mono text-text-secondary">
+                                            {{ run.event }}
+                                        </span>
+                                        <span v-if="run.head_branch">
+                                            ·
+                                            <span class="font-mono text-text-secondary">
+                                                {{ run.head_branch }}
+                                            </span>
+                                        </span>
+                                        · Started {{ run.run_started_at ?? '—' }}
+                                    </p>
+                                </div>
+                            </div>
+                            <div
+                                class="flex flex-shrink-0 items-center gap-3 text-xs text-text-muted"
+                            >
+                                <StatusBadge
+                                    v-if="run.conclusion"
+                                    :tone="workflowConclusionTone(run.conclusion)"
+                                >
+                                    {{ workflowConclusionLabel(run.conclusion) }}
+                                </StatusBadge>
+                                <StatusBadge
+                                    v-else
+                                    :tone="workflowStatusTone(run.status)"
+                                >
+                                    {{ run.status }}
+                                </StatusBadge>
+                                <a
+                                    :href="run.html_url"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="text-text-muted transition hover:text-accent-cyan"
+                                    :aria-label="`Open workflow run #${run.run_number} on GitHub`"
+                                >
+                                    <ExternalLink class="h-4 w-4" aria-hidden="true" />
+                                </a>
+                            </div>
+                        </li>
+                    </ul>
+
+                    <p
+                        v-else
+                        class="mt-6 rounded-lg border border-dashed border-border-subtle bg-background-panel-hover/30 p-4 text-sm text-text-muted"
+                    >
+                        <span v-if="workflowRunsSync.status === 'pending'">
+                            Workflow runs haven't been synced yet.
+                        </span>
+                        <span v-else-if="workflowRunsSync.status === 'failed'">
+                            The last workflow runs sync failed.
+                        </span>
+                        <span v-else>No workflow runs mirrored for this repository.</span>
                         <span v-if="canSync"> Click <span class="font-mono">Run sync</span> to fetch from GitHub.</span>
                     </p>
                 </section>

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\RepositoryController;
 use App\Http\Controllers\RepositoryIssuesSyncController;
 use App\Http\Controllers\RepositoryPullRequestsSyncController;
 use App\Http\Controllers\RepositorySyncController;
+use App\Http\Controllers\RepositoryWorkflowRunsSyncController;
 use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\Webhooks\GitHubWebhookController;
 use App\Http\Controllers\WorkItemController;
@@ -68,6 +69,11 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/repositories/{repository}/pulls/sync', RepositoryPullRequestsSyncController::class)
         ->where('repository', '[\w.-]+/[\w.-]+')
         ->name('repositories.pulls.sync');
+
+    // Spec 020 — manual "Run sync" button on the Repository Workflow Runs tab.
+    Route::post('/repositories/{repository}/workflow-runs/sync', RepositoryWorkflowRunsSyncController::class)
+        ->where('repository', '[\w.-]+/[\w.-]+')
+        ->name('repositories.workflow-runs.sync');
 
     // Spec 016 — unified Work Items queue (issues + PRs).
     Route::get('/work-items', WorkItemController::class)->name('work-items.index');

--- a/specs/README.md
+++ b/specs/README.md
@@ -39,7 +39,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 1 | Projects & Repositories | 🟢 | 3/3 specs done (010–012). Phase complete. |
 | 2 | GitHub Integration MVP | 🟢 | 4/4 specs done (013–016). Phase complete. |
 | 3 | GitHub Webhooks & Activity Feed | 🟢 | 3/3 specs done (017–019). Phase complete. |
-| 4 | Deployments & CI/CD | ⬜ | 0/3 specs (020–022). Spec 020 drafted. |
+| 4 | Deployments & CI/CD | 🟡 | 1/3 specs done (020). 021–022 next. |
 | 5 | Website Monitoring | ⬜ | — |
 | 6 | Docker Host Agent MVP | ⬜ | — |
 | 7 | Alerts Engine | ⬜ | — |

--- a/specs/README.md
+++ b/specs/README.md
@@ -39,7 +39,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 1 | Projects & Repositories | 🟢 | 3/3 specs done (010–012). Phase complete. |
 | 2 | GitHub Integration MVP | 🟢 | 4/4 specs done (013–016). Phase complete. |
 | 3 | GitHub Webhooks & Activity Feed | 🟢 | 3/3 specs done (017–019). Phase complete. |
-| 4 | Deployments & CI/CD | ⬜ | — |
+| 4 | Deployments & CI/CD | ⬜ | 0/3 specs (020–022). Spec 020 drafted. |
 | 5 | Website Monitoring | ⬜ | — |
 | 6 | Docker Host Agent MVP | ⬜ | — |
 | 7 | Alerts Engine | ⬜ | — |

--- a/specs/phase-4-deployments-cicd/020-workflow-runs-storage-and-sync.md
+++ b/specs/phase-4-deployments-cicd/020-workflow-runs-storage-and-sync.md
@@ -1,7 +1,7 @@
 ---
 spec: workflow-runs-storage-and-sync
 phase: 4-deployments-cicd
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-30
 updated: 2026-04-30
@@ -169,6 +169,9 @@ Dated notes as work progresses.
 ### 2026-04-30
 - Spec drafted.
 - Opened issue [#61](https://github.com/Copxer/nexus/issues/61) and branch `spec/020-workflow-runs-storage-and-sync` off `main`.
+- Implementation complete: 2 migrations + `WorkflowRun` + `WorkflowRunStatus` + `WorkflowRunConclusion` enums + factory, `NormalizeGitHubWorkflowRunAction` (pure transform), `GitHubClient::listWorkflowRuns`, `SyncRepositoryWorkflowRunsAction` + `SyncRepositoryWorkflowRunsJob` (mirrors issues/PRs lifecycle), chained off `SyncGitHubRepositoryJob`, `RepositoryWorkflowRunsSyncController` + route, `WorkflowRunsForRepositoryQuery`, `RepositorySyncController` extended to clear all 8 error columns, `RepositoryController::show` payload extended, `Repositories/Show.vue` Workflow Runs tab. `WorkflowRunWebhookHandler` extended to upsert into `workflow_runs` for ALL deliveries (in-flight + terminal); spec 019's existing assertions stay valid.
+- 26 net new passing tests; full suite: 239 passed (was 213). Pint + build clean.
+- Self-review pass via `superpowers:code-reviewer`; addressed 4 of 5 recommendations: added `workflowStatusTone()` helper for the run-status badge fallback, doc'd the `WebhookDeliveryStatus::Skipped` semantics shift, switched the Workflow Runs `v-else` to `v-else-if` for forward safety, and added a re-run comment on `run_completed_at`. Deferred: a stale-webhook overwrite guard (last-write-wins on the upsert) — pre-existing across all three sync flows; will harden in a follow-up if it bites.
 
 ## Decisions (locked 2026-04-30)
 - **Naming: `WorkflowRun`, not `Deployment`.** The model + DB use GitHub's own vocabulary; the user-facing UI in spec 021 will say "deployments" where appropriate. The mismatch in the roadmap is a UX choice, not a data-model one.

--- a/specs/phase-4-deployments-cicd/020-workflow-runs-storage-and-sync.md
+++ b/specs/phase-4-deployments-cicd/020-workflow-runs-storage-and-sync.md
@@ -1,0 +1,183 @@
+---
+spec: workflow-runs-storage-and-sync
+phase: 4-deployments-cicd
+status: in-progress
+owner: yoany
+created: 2026-04-30
+updated: 2026-04-30
+issue: https://github.com/Copxer/nexus/issues/61
+branch: spec/020-workflow-runs-storage-and-sync
+---
+
+# 020 — Workflow runs storage + sync
+
+## Goal
+Stand up durable storage for GitHub Actions workflow runs, the sync plumbing to populate it, and a per-repo Workflow Runs tab so the data is visible end-to-end. After this spec, a Nexus user who imports a repository immediately sees historical runs; new runs flow in via the existing spec-019 webhook handler (extended here to upsert into the table); and a manual "Run sync" button per tab refreshes on demand.
+
+This is the **data layer** of phase 4. Spec 021 builds the cross-repo `/deployments` timeline + filters + drawer. Spec 022 surfaces a success-rate KPI on Overview.
+
+Roadmap reference: §8.6 GitHub Actions / Workflow Runs (model fields, sync flow, conclusion enum), §19 Phase 4 (deliverables + acceptance criteria).
+
+## Scope
+**In scope:**
+
+- **`workflow_runs` table** mirroring the relevant slice of GitHub's `actions/runs` payload:
+    - `id` (PK), `repository_id` (FK → `repositories`, cascade on delete), `github_id` (string, GitHub's numeric run id), `run_number` (unsigned int), `name` (string, the workflow name), `event` (string, e.g. `push`/`pull_request`/`schedule`/`workflow_dispatch`), `status` (string-backed enum: `queued`/`in_progress`/`completed`), `conclusion` (string-backed enum nullable: `success`/`failure`/`cancelled`/`timed_out`/`action_required`/`stale`/`neutral`/`skipped`), `head_branch` (string nullable), `head_sha` (string), `actor_login` (string nullable), `html_url` (string), `run_started_at` (datetime nullable), `run_updated_at` (datetime nullable, the GitHub-side `updated_at`), `run_completed_at` (datetime nullable, derived from payload `updated_at` when status=completed), standard `created_at`/`updated_at`.
+    - **Unique** on `(repository_id, github_id)` for upsert idempotency.
+    - **Index** on `(repository_id, run_started_at desc)` for the per-repo tab listing and the cross-repo timeline query in spec 021.
+
+- **`*_workflow_runs_sync_*` columns on `repositories`** mirroring the six-column pattern shipped for issues / PRs:
+    - `workflow_runs_sync_status` (string, default `pending`, indexed), `workflow_runs_synced_at` (datetime nullable), `workflow_runs_sync_error` (text nullable), `workflow_runs_sync_failed_at` (datetime nullable).
+    - Two additional columns added inline with the above pair (`*_sync_error` after status, `*_sync_failed_at` after synced_at) for symmetry with the metadata / issues / PRs flows.
+
+- **`App\Models\WorkflowRun`** — Eloquent model.
+    - Fillable + casts for the columns above. Status / conclusion cast to enums. Datetimes cast normally.
+    - `repository()` belongsTo. `getRouteKeyName()` stays default (numeric id) — there's no nice slug shape to bind on.
+
+- **`App\Enums\WorkflowRunStatus`** (`Queued`, `InProgress`, `Completed`) and **`App\Enums\WorkflowRunConclusion`** (`Success`, `Failure`, `Cancelled`, `TimedOut`, `ActionRequired`, `Stale`, `Neutral`, `Skipped`) with `badgeTone()` helpers consistent with `RepositorySyncStatus` + `ActivitySeverity`.
+
+- **`GitHubClient::listWorkflowRuns(string $fullName, int $perPage = 100): array`** — new client method.
+    - Hits `GET /repos/{owner}/{repo}/actions/runs?per_page={perPage}`.
+    - Returns the unwrapped `workflow_runs` array (GitHub wraps the payload in `{ total_count, workflow_runs: [...] }`).
+    - Throws `GitHubApiException` on non-2xx (existing pattern).
+    - Phase-1 caps at `perPage = 100`; pagination is a follow-up if the timeline UI needs deeper history.
+
+- **`App\Domain\GitHub\Actions\NormalizeGitHubWorkflowRunAction`** — pure transformation, payload → array shaped for `WorkflowRun::upsert()`. Mirrors `NormalizeGitHubIssueAction` / `NormalizeGitHubPullRequestAction`. Returns `null` for malformed payloads (missing `id` / `head_sha`) so the caller can skip cleanly.
+
+- **`App\Domain\GitHub\Actions\SyncRepositoryWorkflowRunsAction`** — orchestrates the fetch + upsert.
+    - Fetches via `GitHubClient::listWorkflowRuns`.
+    - Normalizes each row, drops nulls, upserts on `(repository_id, github_id)`.
+    - Returns the count of rows persisted (insert + update both count) for observability — same shape as the issues/PRs actions.
+
+- **`App\Domain\GitHub\Jobs\SyncRepositoryWorkflowRunsJob`** — `ShouldQueue` job, parallel to `SyncRepositoryIssuesJob` and `SyncRepositoryPullRequestsJob`.
+    - Constructor: `int $repositoryId`.
+    - Same lifecycle: `pending → syncing (clears error) → synced (timestamps + clears error) | failed (sets error + failed_at)`.
+    - Same 401 handling: clear `access_token` + zero `expires_at` so the Settings card surfaces Reconnect.
+    - `tries = 1` (matches the rest).
+
+- **`SyncGitHubRepositoryJob` chains the new job on success.** Currently it dispatches issues + PRs. Add workflow runs alongside, wrapped in the same `dispatchChildSync` try/catch so a queue blip in one child doesn't suppress the others.
+
+- **`RepositorySyncController` clears the new error pair too.** When the user clicks the top-level "Run sync", it clears all *eight* error columns (metadata + issues + PRs + workflow runs).
+
+- **`App\Http\Controllers\RepositoryWorkflowRunsSyncController`** — new single-action controller for the per-tab "Run sync" button. Mirrors `RepositoryPullRequestsSyncController` exactly. Authorizes via `ProjectPolicy::update`. Dispatches the job. Returns `back()->with('status', 'Workflow runs sync queued.')`.
+
+- **Route**: `Route::post('/repositories/{repository}/workflow-runs/sync', RepositoryWorkflowRunsSyncController::class)->name('repositories.workflow-runs.sync')`.
+
+- **`App\Domain\GitHub\Queries\WorkflowRunsForRepositoryQuery`** — query object returning the run rows shaped for the tab. Sorted `run_started_at desc, github_id desc` (recent first, deterministic tie-break). Caps at 100. Mirrors `IssuesForRepositoryQuery` / `PullRequestsForRepositoryQuery`.
+
+- **`RepositoryController::show` payload extension**:
+    - `workflowRuns` array (from the new query).
+    - `workflowRunsSync` array shaped `{ status, synced_at, error, failed_at }` matching `issuesSync` + `pullRequestsSync`.
+
+- **`Repositories/Show.vue` — new Workflow Runs tab.**
+    - Tab nav button (icon: `Activity` from lucide; or `Workflow` if it lands clean) with a count badge like the existing Issues / PRs tabs.
+    - Header strip mirrors the existing tabs: status badge, "Last sync" or "Failed Xm ago", per-tab "Run sync" button (gated to project owner via `canSync`), per-tab failure banner that surfaces `workflowRunsSync.error` when `status === 'failed'`.
+    - List body: each row shows `name #run_number`, `event`, `head_branch`, conclusion badge (with the new enum's tone helper), actor, "Updated Xm ago", and an external-link icon → `html_url`.
+    - Empty state mirrors the existing tabs: "Workflow runs haven't been synced yet" / "The last workflow runs sync failed." / "No workflow runs mirrored for this repository."
+
+- **`WorkflowRunWebhookHandler` upserts into the new table.** Currently it only creates the activity event. Extend it to *also* normalize + upsert the run (using `NormalizeGitHubWorkflowRunAction` + `WorkflowRun::upsert`) before the activity-event creation. Repository resolution is already wired. Spec 019's existing tests stay green; new tests cover the upsert path.
+
+- **Tests** (Pest/PHPUnit, mirrors existing GitHub specs):
+    - `NormalizeGitHubWorkflowRunActionTest` — happy path + drops nulls + handles missing optional fields.
+    - `SyncRepositoryWorkflowRunsActionTest` — Http::fake'd payload, asserts upsert idempotency.
+    - `SyncRepositoryWorkflowRunsJobTest` — happy path, 401 → connection expiry, 500 → error/failed_at persisted, no-connection → error stored, success clears error/failed_at, syncing flip clears errors. Mirrors `SyncRepositoryIssuesJobTest` exactly.
+    - `RepositoryWorkflowRunsSyncControllerTest` — owner can dispatch (Queue::fake'd), non-owner forbidden, unknown repo 404.
+    - `WorkflowRunsForRepositoryQueryTest` — orders, caps, scoping.
+    - `RepositoryControllerTest` — extend the existing show test to assert `workflowRuns` + `workflowRunsSync` props are present.
+    - `WorkflowRunWebhookHandlerTest` — extend the existing tests to assert the upsert side-effect (existing activity-event assertions stay).
+    - `SyncGitHubRepositoryJobTest` — assert `SyncRepositoryWorkflowRunsJob` is chained on success.
+
+**Out of scope:**
+
+- The `/deployments` cross-repo timeline page + filters + detail drawer → spec 021.
+- Overview KPI card / success-rate chart → spec 022.
+- Workflow run detail page or drawer (the Workflow Runs tab links out to GitHub for now; in-app drawer is spec 021's job).
+- Pagination for the sync (cap at 100 most recent runs per fetch — phase-1 simplification, parallel to issues/PRs).
+- "Is this a deployment?" classification — sync all runs; spec 021's UI can add an optional filter or tagging if it earns its keep.
+- Re-running / cancelling workflow runs from Nexus (write-direction GitHub Apps work is phase 9 polish if at all).
+- Backfill of historical runs older than the 100 most recent — chase a follow-up only if Phase-1 users complain.
+- Activity-event modeling for *new* event types (e.g. `deployment_status`). Spec 019 already covered `workflow_run`.
+
+## Plan
+
+1. **Migration: `create_workflow_runs_table`**, plus a sibling migration `add_workflow_runs_sync_columns_to_repositories_table` (mirrors spec 015's schema-extension pattern).
+2. **Enums + model + factory.** `WorkflowRunStatus`, `WorkflowRunConclusion`, `WorkflowRun`, `WorkflowRunFactory`. Update the `Repository` model fillable + casts for the four new columns.
+3. **Normalize action + tests.** Drive the shape from a sample GitHub `actions/runs` payload (capture once, store as a fixture).
+4. **GitHubClient::listWorkflowRuns + tests.** Http::fake'd happy path + 401 + 500.
+5. **Sync action + job + tests.** Mirror `SyncRepositoryIssuesAction` / `SyncRepositoryIssuesJob` 1:1, swapping issues for workflow runs.
+6. **Chain the new job from `SyncGitHubRepositoryJob`.** Update the existing test that asserts both child syncs dispatch — it'll now assert all three.
+7. **`RepositoryWorkflowRunsSyncController` + route + tests.** Mirror PRs.
+8. **`RepositorySyncController` clears the new error pair too.** Update the existing controller test that asserts the all-six clear so it now asserts all-eight.
+9. **Query object + tests.**
+10. **Show controller payload extension + test.**
+11. **`Repositories/Show.vue` Workflow Runs tab.** TS interfaces, computed counts, syncing state, runWorkflowRunsSync handler. Reuse the existing failure-banner shape.
+12. **Extend `WorkflowRunWebhookHandler`** to upsert + tests. Existing assertions stay; add upsert-side assertions.
+13. **Self-review pass via `superpowers:code-reviewer`.**
+14. **Open the PR.** CI must be green before merge. Wait for explicit "merge it" before squash-merging.
+
+## Acceptance criteria
+- [ ] `workflow_runs` table exists with the documented columns + indexes.
+- [ ] `repositories` carries the four new sync columns; `RepositorySyncStatus` enum reused (no parallel enum).
+- [ ] `WorkflowRun` model + factory exist; status/conclusion cast to typed enums.
+- [ ] `GitHubClient::listWorkflowRuns` returns the unwrapped `workflow_runs` array on 2xx; throws `GitHubApiException` on non-2xx.
+- [ ] `SyncRepositoryWorkflowRunsJob` runs `pending → syncing → synced` on happy path; clears `workflow_runs_sync_error` + `workflow_runs_sync_failed_at` on success; sets them on failure (capped at 500 chars).
+- [ ] On 401 the connection's `access_token` is cleared so the Settings card surfaces Reconnect (parallel to issues/PRs).
+- [ ] `SyncGitHubRepositoryJob` chains the new job on success — repository sync now triggers metadata + issues + PRs + workflow runs.
+- [ ] Top-level "Run sync" controller clears all eight error columns (metadata + issues + PRs + workflow runs) so stale red banners don't outlive a manual re-trigger.
+- [ ] Per-tab `POST /repositories/{r}/workflow-runs/sync` dispatches the job, gated to project owner; returns 403 for non-owners and 404 for unknown repos.
+- [ ] Repository show page exposes a Workflow Runs tab with status badge, "Last sync Xm ago" / "Failed Xm ago", per-tab Run sync button (project owner only), per-tab failure banner, and a sortable list of runs.
+- [ ] Workflow run rows link out to GitHub via `html_url`.
+- [ ] `WorkflowRunWebhookHandler` upserts the run row into `workflow_runs` *in addition* to the existing activity-event creation. Existing spec 019 tests stay green.
+- [ ] Pint + `php artisan test` (full suite) + `npm run build` clean. CI green on the PR.
+- [ ] Self-review pass with `superpowers:code-reviewer`; material findings addressed before opening the PR.
+
+## Files touched
+List of created/modified files. Fill in as work progresses.
+
+- `database/migrations/<ts>_create_workflow_runs_table.php` — new.
+- `database/migrations/<ts>_add_workflow_runs_sync_columns_to_repositories_table.php` — new.
+- `app/Enums/WorkflowRunStatus.php` — new.
+- `app/Enums/WorkflowRunConclusion.php` — new.
+- `app/Models/WorkflowRun.php` — new.
+- `app/Models/Repository.php` — extend fillable + casts.
+- `database/factories/WorkflowRunFactory.php` — new.
+- `app/Domain/GitHub/Services/GitHubClient.php` — add `listWorkflowRuns`.
+- `app/Domain/GitHub/Actions/NormalizeGitHubWorkflowRunAction.php` — new.
+- `app/Domain/GitHub/Actions/SyncRepositoryWorkflowRunsAction.php` — new.
+- `app/Domain/GitHub/Jobs/SyncRepositoryWorkflowRunsJob.php` — new.
+- `app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php` — chain the new job in the success path.
+- `app/Domain/GitHub/Queries/WorkflowRunsForRepositoryQuery.php` — new.
+- `app/Domain/GitHub/WebhookHandlers/WorkflowRunWebhookHandler.php` — extend to upsert.
+- `app/Http/Controllers/RepositoryWorkflowRunsSyncController.php` — new.
+- `app/Http/Controllers/RepositoryController.php` — extend show payload.
+- `app/Http/Controllers/RepositorySyncController.php` — clear all eight error columns on manual re-trigger.
+- `routes/web.php` — add the workflow-runs sync route.
+- `resources/js/Pages/Repositories/Show.vue` — new Workflow Runs tab.
+- `tests/Feature/GitHub/NormalizeGitHubWorkflowRunActionTest.php` — new.
+- `tests/Feature/GitHub/SyncRepositoryWorkflowRunsActionTest.php` — new.
+- `tests/Feature/GitHub/SyncRepositoryWorkflowRunsJobTest.php` — new.
+- `tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php` — extend chained-dispatch assertion.
+- `tests/Feature/GitHub/RepositoryWorkflowRunsSyncControllerTest.php` — new.
+- `tests/Feature/GitHub/RepositorySyncControllerTest.php` — extend "clear stale errors" test from six → eight columns.
+- `tests/Feature/GitHub/WorkflowRunsForRepositoryQueryTest.php` — new.
+- `tests/Feature/GitHub/Webhooks/WorkflowRunWebhookHandlerTest.php` — extend with upsert assertions.
+- `tests/Feature/Repositories/RepositoryControllerTest.php` — extend show-payload test.
+
+## Work log
+Dated notes as work progresses.
+
+### 2026-04-30
+- Spec drafted.
+- Opened issue [#61](https://github.com/Copxer/nexus/issues/61) and branch `spec/020-workflow-runs-storage-and-sync` off `main`.
+
+## Decisions (locked 2026-04-30)
+- **Naming: `WorkflowRun`, not `Deployment`.** The model + DB use GitHub's own vocabulary; the user-facing UI in spec 021 will say "deployments" where appropriate. The mismatch in the roadmap is a UX choice, not a data-model one.
+- **Sync all runs, not just deploy-shaped ones.** GitHub has no clean "is deployment" flag. Phase-1 syncs everything; spec 021's UI can layer optional filtering / tagging later if the timeline gets noisy.
+- **Reuse `RepositorySyncStatus` for the new sync columns.** Don't introduce a parallel enum. Same shape, same lifecycle.
+- **Cap fetch at 100 most recent runs.** Mirrors issues/PRs phase-1 cap; pagination is a follow-up if the timeline UI needs deeper history.
+- **Webhook handler upsert lives in the existing `WorkflowRunWebhookHandler`.** Don't introduce a parallel upsert handler — the existing handler already resolves the repository and reads the payload.
+
+## Open questions / blockers
+- **Lucide icon for the Workflow Runs tab.** `Workflow`, `Activity`, or `PlayCircle`? Pick during implementation; trivially swappable.
+- **Conclusion badge tones.** Map `success → success`, `failure → danger`, `cancelled → warning`, `timed_out → warning`, others → muted. Confirm against `StatusBadge.vue` token set.
+- **`run_started_at` vs GitHub's `created_at`.** GitHub returns both; `run_started_at` is the actual run start (post-queue). Use `run_started_at` for the listing sort and fall back to `created_at` only if it's null.

--- a/specs/phase-4-deployments-cicd/README.md
+++ b/specs/phase-4-deployments-cicd/README.md
@@ -1,0 +1,24 @@
+# Phase 4 — Deployments & CI/CD
+
+Source: [roadmap §19 Phase 4](../../nexus_control_center_roadmap.md), §8.6 GitHub Actions workflow runs, §8.13 Deployment timeline.
+
+## Phase goal
+Surface GitHub Actions workflow runs as a "deployment timeline" inside Nexus. Phase 3 already wired a `WorkflowRunWebhookHandler` that creates `activity_events` for completed runs — but the run data itself is transient (only payload + activity metadata). Phase 4 adds durable storage, a backfill sync (so already-imported repos get historical runs), a per-repo Workflow Runs tab, a dedicated `/deployments` timeline page with filters + drawer, and an Overview success-rate widget.
+
+## Tasks
+
+| # | Task | Status |
+|---|------|--------|
+| 020 | Workflow runs storage + sync (table, model, sync job chained off repo-import + manual sync, webhook-handler upsert, per-repo Workflow Runs tab) | ⬜ |
+| 021 | Deployment timeline UI (`/deployments` page, status timeline, detail drawer, filters by project / repository / status / branch) | ⬜ |
+| 022 | Overview success-rate widget (KPI card on Overview powered by an aggregate query over `workflow_runs`) | ⬜ |
+
+## Acceptance criteria (phase-level)
+- [ ] Importing a repository backfills its recent workflow runs into the local `workflow_runs` table.
+- [ ] `workflow_run` webhook deliveries upsert into `workflow_runs` (in addition to spec 019's existing activity-event creation).
+- [ ] Repository show page exposes a Workflow Runs tab with status badges, conclusion, branch, run number, and a link out to GitHub.
+- [ ] `/deployments` page renders a chronological timeline with success/failure markers and supports filtering by project, repository, status, and branch.
+- [ ] Per-run drawer surfaces head SHA, duration, actor, conclusion, and links to the GitHub run.
+- [ ] Overview shows a "Last 24h workflow runs" KPI card with success rate, powered by a real DB aggregate (no mocks).
+- [ ] Failed workflow runs continue to surface as activity events on the right-rail / activity page (already covered by spec 019's handler — verified, not re-implemented).
+- [ ] Pint + tests + build clean. CI green for every spec PR.

--- a/specs/phase-4-deployments-cicd/README.md
+++ b/specs/phase-4-deployments-cicd/README.md
@@ -9,7 +9,7 @@ Surface GitHub Actions workflow runs as a "deployment timeline" inside Nexus. Ph
 
 | # | Task | Status |
 |---|------|--------|
-| 020 | Workflow runs storage + sync (table, model, sync job chained off repo-import + manual sync, webhook-handler upsert, per-repo Workflow Runs tab) | ⬜ |
+| 020 | Workflow runs storage + sync (table, model, sync job chained off repo-import + manual sync, webhook-handler upsert, per-repo Workflow Runs tab) | 🟢 |
 | 021 | Deployment timeline UI (`/deployments` page, status timeline, detail drawer, filters by project / repository / status / branch) | ⬜ |
 | 022 | Overview success-rate widget (KPI card on Overview powered by an aggregate query over `workflow_runs`) | ⬜ |
 

--- a/tests/Feature/GitHub/NormalizeGitHubWorkflowRunActionTest.php
+++ b/tests/Feature/GitHub/NormalizeGitHubWorkflowRunActionTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Domain\GitHub\Actions\NormalizeGitHubWorkflowRunAction;
+use Tests\TestCase;
+
+class NormalizeGitHubWorkflowRunActionTest extends TestCase
+{
+    private NormalizeGitHubWorkflowRunAction $action;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->action = new NormalizeGitHubWorkflowRunAction;
+    }
+
+    public function test_normalizes_a_completed_run_payload(): void
+    {
+        $payload = [
+            'id' => 17_002_345_678,
+            'run_number' => 142,
+            'name' => 'Deploy production',
+            'event' => 'workflow_dispatch',
+            'status' => 'completed',
+            'conclusion' => 'success',
+            'head_branch' => 'main',
+            'head_sha' => 'a'.str_repeat('1', 39),
+            'actor' => ['login' => 'octocat'],
+            'html_url' => 'https://github.com/oct/repo/actions/runs/17002345678',
+            'run_started_at' => '2026-04-29T12:00:00Z',
+            'updated_at' => '2026-04-29T12:08:00Z',
+            'created_at' => '2026-04-29T11:59:00Z',
+        ];
+
+        $result = $this->action->execute($payload);
+
+        $this->assertNotNull($result);
+        $this->assertSame(17_002_345_678, $result['github_id']);
+        $this->assertSame(142, $result['run_number']);
+        $this->assertSame('Deploy production', $result['name']);
+        $this->assertSame('workflow_dispatch', $result['event']);
+        $this->assertSame('completed', $result['status']);
+        $this->assertSame('success', $result['conclusion']);
+        $this->assertSame('main', $result['head_branch']);
+        $this->assertSame('a'.str_repeat('1', 39), $result['head_sha']);
+        $this->assertSame('octocat', $result['actor_login']);
+        $this->assertSame('https://github.com/oct/repo/actions/runs/17002345678', $result['html_url']);
+        $this->assertNotNull($result['run_started_at']);
+        $this->assertNotNull($result['run_updated_at']);
+        // Status is `completed`, so `run_completed_at` mirrors `updated_at`.
+        $this->assertNotNull($result['run_completed_at']);
+        $this->assertSame(
+            $result['run_updated_at']->toIso8601String(),
+            $result['run_completed_at']->toIso8601String(),
+        );
+    }
+
+    public function test_in_progress_run_has_null_completed_at_and_null_conclusion(): void
+    {
+        $payload = [
+            'id' => 1,
+            'head_sha' => 'b'.str_repeat('2', 39),
+            'status' => 'in_progress',
+            'conclusion' => null,
+            'run_started_at' => '2026-04-29T12:00:00Z',
+            'updated_at' => '2026-04-29T12:01:00Z',
+            'html_url' => 'https://github.com/x/y/actions/runs/1',
+        ];
+
+        $result = $this->action->execute($payload);
+
+        $this->assertNotNull($result);
+        $this->assertSame('in_progress', $result['status']);
+        $this->assertNull($result['conclusion']);
+        $this->assertNull($result['run_completed_at']);
+        $this->assertNotNull($result['run_started_at']);
+    }
+
+    public function test_returns_null_when_id_is_missing(): void
+    {
+        $this->assertNull($this->action->execute([
+            'head_sha' => 'a'.str_repeat('1', 39),
+        ]));
+    }
+
+    public function test_returns_null_when_head_sha_is_missing(): void
+    {
+        $this->assertNull($this->action->execute([
+            'id' => 1,
+        ]));
+    }
+
+    public function test_falls_back_to_triggering_actor_login(): void
+    {
+        $payload = [
+            'id' => 1,
+            'head_sha' => 'c'.str_repeat('3', 39),
+            'status' => 'completed',
+            'conclusion' => 'success',
+            'triggering_actor' => ['login' => 'fallback-bot'],
+            'html_url' => 'https://github.com/x/y/actions/runs/1',
+        ];
+
+        $result = $this->action->execute($payload);
+
+        $this->assertNotNull($result);
+        $this->assertSame('fallback-bot', $result['actor_login']);
+    }
+
+    public function test_unknown_status_collapses_to_queued(): void
+    {
+        $payload = [
+            'id' => 1,
+            'head_sha' => 'd'.str_repeat('4', 39),
+            'status' => 'requested',
+            'html_url' => 'https://github.com/x/y/actions/runs/1',
+        ];
+
+        $result = $this->action->execute($payload);
+
+        $this->assertNotNull($result);
+        $this->assertSame('queued', $result['status']);
+    }
+
+    public function test_unknown_conclusion_is_dropped(): void
+    {
+        $payload = [
+            'id' => 1,
+            'head_sha' => 'e'.str_repeat('5', 39),
+            'status' => 'completed',
+            'conclusion' => 'something_new',
+            'html_url' => 'https://github.com/x/y/actions/runs/1',
+        ];
+
+        $result = $this->action->execute($payload);
+
+        $this->assertNotNull($result);
+        $this->assertNull($result['conclusion']);
+    }
+
+    public function test_falls_back_to_created_at_when_run_started_at_missing(): void
+    {
+        $payload = [
+            'id' => 1,
+            'head_sha' => 'f'.str_repeat('6', 39),
+            'status' => 'completed',
+            'conclusion' => 'success',
+            'created_at' => '2026-04-29T11:59:00Z',
+            'updated_at' => '2026-04-29T12:08:00Z',
+            'html_url' => 'https://github.com/x/y/actions/runs/1',
+        ];
+
+        $result = $this->action->execute($payload);
+
+        $this->assertNotNull($result);
+        $this->assertNotNull($result['run_started_at']);
+    }
+}

--- a/tests/Feature/GitHub/RepositorySyncControllerTest.php
+++ b/tests/Feature/GitHub/RepositorySyncControllerTest.php
@@ -81,7 +81,7 @@ class RepositorySyncControllerTest extends TestCase
         Queue::assertNotPushed(SyncGitHubRepositoryJob::class);
     }
 
-    public function test_dispatch_clears_stale_sync_errors_across_all_three_flows(): void
+    public function test_dispatch_clears_stale_sync_errors_across_all_four_flows(): void
     {
         Queue::fake();
         $owner = User::factory()->create(['email_verified_at' => now()]);
@@ -98,6 +98,9 @@ class RepositorySyncControllerTest extends TestCase
             'prs_sync_status' => 'failed',
             'prs_sync_error' => 'PRs sync errored',
             'prs_sync_failed_at' => now()->subMinutes(5),
+            'workflow_runs_sync_status' => 'failed',
+            'workflow_runs_sync_error' => 'Workflow runs sync errored',
+            'workflow_runs_sync_failed_at' => now()->subMinutes(5),
         ]);
 
         $this->actingAs($owner)
@@ -105,10 +108,10 @@ class RepositorySyncControllerTest extends TestCase
             ->post(route('repositories.sync', $repository->full_name))
             ->assertRedirect(route('repositories.show', $repository->full_name));
 
-        // The metadata job re-runs both child syncs on success, so the
-        // controller clears all six error columns up-front. Otherwise
-        // the page would briefly show "Syncing…" at the top while
-        // stale red error alerts persisted on the Issues / PRs tabs.
+        // The metadata job re-runs all three child syncs on success, so
+        // the controller clears all eight error columns up-front. Otherwise
+        // the page would briefly show "Syncing…" at the top while stale
+        // red error alerts persisted on the per-tab views.
         $repo = $repository->fresh();
         $this->assertNull($repo->sync_error);
         $this->assertNull($repo->sync_failed_at);
@@ -116,6 +119,8 @@ class RepositorySyncControllerTest extends TestCase
         $this->assertNull($repo->issues_sync_failed_at);
         $this->assertNull($repo->prs_sync_error);
         $this->assertNull($repo->prs_sync_failed_at);
+        $this->assertNull($repo->workflow_runs_sync_error);
+        $this->assertNull($repo->workflow_runs_sync_failed_at);
     }
 
     public function test_unknown_repository_returns_404(): void

--- a/tests/Feature/GitHub/RepositoryWorkflowRunsSyncControllerTest.php
+++ b/tests/Feature/GitHub/RepositoryWorkflowRunsSyncControllerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Domain\GitHub\Jobs\SyncRepositoryWorkflowRunsJob;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class RepositoryWorkflowRunsSyncControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_can_dispatch_a_re_sync(): void
+    {
+        Queue::fake();
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+        ]);
+
+        $this->actingAs($owner)
+            ->from(route('repositories.show', $repository->full_name))
+            ->post(route('repositories.workflow-runs.sync', $repository->full_name))
+            ->assertRedirect(route('repositories.show', $repository->full_name))
+            ->assertSessionHas('status');
+
+        Queue::assertPushed(
+            SyncRepositoryWorkflowRunsJob::class,
+            fn (SyncRepositoryWorkflowRunsJob $job) => $job->repositoryId === $repository->id,
+        );
+    }
+
+    public function test_non_owner_is_forbidden(): void
+    {
+        Queue::fake();
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+        $other = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+        ]);
+
+        $this->actingAs($other)
+            ->post(route('repositories.workflow-runs.sync', $repository->full_name))
+            ->assertForbidden();
+
+        Queue::assertNotPushed(SyncRepositoryWorkflowRunsJob::class);
+    }
+
+    public function test_unknown_repository_returns_404(): void
+    {
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($owner)
+            ->post(route('repositories.workflow-runs.sync', 'nope/missing'))
+            ->assertNotFound();
+    }
+}

--- a/tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php
+++ b/tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\GitHub;
 use App\Domain\GitHub\Jobs\SyncGitHubRepositoryJob;
 use App\Domain\GitHub\Jobs\SyncRepositoryIssuesJob;
 use App\Domain\GitHub\Jobs\SyncRepositoryPullRequestsJob;
+use App\Domain\GitHub\Jobs\SyncRepositoryWorkflowRunsJob;
 use App\Enums\RepositorySyncStatus;
 use App\Models\GithubConnection;
 use App\Models\Project;
@@ -162,7 +163,7 @@ class SyncGitHubRepositoryJobTest extends TestCase
         $this->assertSame(0, Repository::query()->count());
     }
 
-    public function test_handle_dispatches_both_child_syncs_on_happy_path(): void
+    public function test_handle_dispatches_all_three_child_syncs_on_happy_path(): void
     {
         Queue::fake();
         $context = $this->setUpProjectWithConnection();
@@ -187,6 +188,10 @@ class SyncGitHubRepositoryJobTest extends TestCase
             SyncRepositoryPullRequestsJob::class,
             fn (SyncRepositoryPullRequestsJob $job) => $job->repositoryId === $context['repository']->id,
         );
+        Queue::assertPushed(
+            SyncRepositoryWorkflowRunsJob::class,
+            fn (SyncRepositoryWorkflowRunsJob $job) => $job->repositoryId === $context['repository']->id,
+        );
     }
 
     public function test_handle_does_not_dispatch_child_syncs_on_failure(): void
@@ -205,6 +210,7 @@ class SyncGitHubRepositoryJobTest extends TestCase
 
         Queue::assertNotPushed(SyncRepositoryIssuesJob::class);
         Queue::assertNotPushed(SyncRepositoryPullRequestsJob::class);
+        Queue::assertNotPushed(SyncRepositoryWorkflowRunsJob::class);
     }
 
     public function test_handle_persists_sync_error_and_failed_at_on_api_failure(): void

--- a/tests/Feature/GitHub/SyncRepositoryWorkflowRunsActionTest.php
+++ b/tests/Feature/GitHub/SyncRepositoryWorkflowRunsActionTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Domain\GitHub\Actions\NormalizeGitHubWorkflowRunAction;
+use App\Domain\GitHub\Actions\SyncRepositoryWorkflowRunsAction;
+use App\Domain\GitHub\Services\GitHubClient;
+use App\Models\GithubConnection;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\WorkflowRun;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SyncRepositoryWorkflowRunsActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setUpRepository(): array
+    {
+        $user = User::factory()->create();
+        $connection = GithubConnection::query()->create([
+            'user_id' => $user->id,
+            'github_user_id' => '9001',
+            'github_username' => 'octocat',
+            'access_token' => 'gho_token',
+            'expires_at' => now()->addHours(8),
+            'connected_at' => now(),
+        ]);
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+        ]);
+
+        return ['repository' => $repository, 'connection' => $connection];
+    }
+
+    private function action(): SyncRepositoryWorkflowRunsAction
+    {
+        return new SyncRepositoryWorkflowRunsAction(new NormalizeGitHubWorkflowRunAction);
+    }
+
+    public function test_inserts_workflow_runs_from_payload(): void
+    {
+        $context = $this->setUpRepository();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/actions/runs*' => Http::response([
+                'total_count' => 2,
+                'workflow_runs' => [
+                    [
+                        'id' => 1,
+                        'run_number' => 10,
+                        'name' => 'CI',
+                        'event' => 'push',
+                        'status' => 'completed',
+                        'conclusion' => 'success',
+                        'head_branch' => 'main',
+                        'head_sha' => 'a'.str_repeat('1', 39),
+                        'actor' => ['login' => 'alice'],
+                        'html_url' => 'https://github.com/o/r/actions/runs/1',
+                        'run_started_at' => '2026-04-29T12:00:00Z',
+                        'updated_at' => '2026-04-29T12:08:00Z',
+                    ],
+                    [
+                        'id' => 2,
+                        'run_number' => 11,
+                        'name' => 'Deploy',
+                        'event' => 'workflow_dispatch',
+                        'status' => 'in_progress',
+                        'conclusion' => null,
+                        'head_branch' => 'main',
+                        'head_sha' => 'b'.str_repeat('2', 39),
+                        'html_url' => 'https://github.com/o/r/actions/runs/2',
+                        'run_started_at' => '2026-04-29T13:00:00Z',
+                        'updated_at' => '2026-04-29T13:01:00Z',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $count = $this->action()->execute(
+            $context['repository'],
+            new GitHubClient($context['connection']),
+        );
+
+        $this->assertSame(2, $count);
+        $this->assertSame(2, WorkflowRun::query()->count());
+
+        $first = WorkflowRun::query()->where('github_id', 1)->first();
+        $this->assertSame('CI', $first->name);
+        $this->assertSame('completed', $first->status->value);
+        $this->assertSame('success', $first->conclusion->value);
+
+        $second = WorkflowRun::query()->where('github_id', 2)->first();
+        $this->assertSame('in_progress', $second->status->value);
+        $this->assertNull($second->conclusion);
+    }
+
+    public function test_upsert_is_idempotent_on_replay(): void
+    {
+        $context = $this->setUpRepository();
+
+        $payload = Http::response([
+            'total_count' => 1,
+            'workflow_runs' => [
+                [
+                    'id' => 42,
+                    'run_number' => 1,
+                    'name' => 'CI',
+                    'event' => 'push',
+                    'status' => 'completed',
+                    'conclusion' => 'success',
+                    'head_branch' => 'main',
+                    'head_sha' => 'a'.str_repeat('1', 39),
+                    'html_url' => 'https://github.com/o/r/actions/runs/42',
+                    'run_started_at' => '2026-04-29T12:00:00Z',
+                    'updated_at' => '2026-04-29T12:08:00Z',
+                ],
+            ],
+        ]);
+
+        Http::fake(['api.github.com/repos/octocat/hello-world/actions/runs*' => $payload]);
+
+        $this->action()->execute($context['repository'], new GitHubClient($context['connection']));
+        $this->action()->execute($context['repository'], new GitHubClient($context['connection']));
+
+        $this->assertSame(1, WorkflowRun::query()->where('github_id', 42)->count());
+    }
+
+    public function test_skips_malformed_entries(): void
+    {
+        $context = $this->setUpRepository();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/actions/runs*' => Http::response([
+                'total_count' => 3,
+                'workflow_runs' => [
+                    [
+                        'id' => 1,
+                        'head_sha' => 'a'.str_repeat('1', 39),
+                        'status' => 'completed',
+                        'conclusion' => 'success',
+                        'html_url' => 'https://github.com/o/r/actions/runs/1',
+                    ],
+                    // Missing head_sha — should be dropped by the normalizer.
+                    ['id' => 2, 'status' => 'completed'],
+                    // Not an array — should be filtered upstream.
+                    'not-an-object',
+                ],
+            ]),
+        ]);
+
+        $count = $this->action()->execute(
+            $context['repository'],
+            new GitHubClient($context['connection']),
+        );
+
+        $this->assertSame(1, $count);
+        $this->assertSame(1, WorkflowRun::query()->count());
+    }
+}

--- a/tests/Feature/GitHub/SyncRepositoryWorkflowRunsJobTest.php
+++ b/tests/Feature/GitHub/SyncRepositoryWorkflowRunsJobTest.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Domain\GitHub\Actions\NormalizeGitHubWorkflowRunAction;
+use App\Domain\GitHub\Actions\SyncRepositoryWorkflowRunsAction;
+use App\Domain\GitHub\Jobs\SyncRepositoryWorkflowRunsJob;
+use App\Enums\RepositorySyncStatus;
+use App\Models\GithubConnection;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\WorkflowRun;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SyncRepositoryWorkflowRunsJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setUpProjectWithConnection(): array
+    {
+        $user = User::factory()->create();
+        GithubConnection::query()->create([
+            'user_id' => $user->id,
+            'github_user_id' => '9001',
+            'github_username' => 'octocat',
+            'access_token' => 'gho_token',
+            'expires_at' => now()->addHours(8),
+            'connected_at' => now(),
+        ]);
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+            'workflow_runs_sync_status' => RepositorySyncStatus::Pending->value,
+        ]);
+
+        return ['user' => $user, 'repository' => $repository];
+    }
+
+    private function action(): SyncRepositoryWorkflowRunsAction
+    {
+        return new SyncRepositoryWorkflowRunsAction(new NormalizeGitHubWorkflowRunAction);
+    }
+
+    public function test_handle_syncs_runs_and_flips_status_to_synced(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/actions/runs*' => Http::response([
+                'total_count' => 1,
+                'workflow_runs' => [
+                    [
+                        'id' => 1,
+                        'run_number' => 1,
+                        'name' => 'CI',
+                        'event' => 'push',
+                        'status' => 'completed',
+                        'conclusion' => 'success',
+                        'head_branch' => 'main',
+                        'head_sha' => 'a'.str_repeat('1', 39),
+                        'html_url' => 'https://github.com/o/r/actions/runs/1',
+                        'run_started_at' => '2026-04-29T12:00:00Z',
+                        'updated_at' => '2026-04-29T12:08:00Z',
+                    ],
+                ],
+            ]),
+        ]);
+
+        (new SyncRepositoryWorkflowRunsJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Synced, $repo->workflow_runs_sync_status);
+        $this->assertNotNull($repo->workflow_runs_synced_at);
+        $this->assertSame(1, WorkflowRun::query()->count());
+    }
+
+    public function test_handle_marks_failed_and_expires_connection_on_401(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/actions/runs*' => Http::response(
+                ['message' => 'Bad credentials'],
+                401,
+            ),
+        ]);
+
+        (new SyncRepositoryWorkflowRunsJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->workflow_runs_sync_status);
+
+        $connection = $context['user']->fresh()->githubConnection;
+        $this->assertSame('', $connection->access_token);
+        $this->assertFalse($connection->isAccessTokenValid());
+    }
+
+    public function test_handle_marks_failed_on_generic_error(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/actions/runs*' => Http::response(
+                ['message' => 'Server error'],
+                500,
+            ),
+        ]);
+
+        (new SyncRepositoryWorkflowRunsJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->workflow_runs_sync_status);
+
+        $connection = $context['user']->fresh()->githubConnection;
+        $this->assertNotSame('', $connection->access_token);
+        $this->assertTrue($connection->isAccessTokenValid());
+    }
+
+    public function test_handle_preserves_workflow_runs_synced_at_on_failure(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+        $priorSync = now()->subHours(3);
+        $context['repository']->forceFill(['workflow_runs_synced_at' => $priorSync])->save();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/actions/runs*' => Http::response(
+                ['message' => 'Boom'],
+                500,
+            ),
+        ]);
+
+        (new SyncRepositoryWorkflowRunsJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->workflow_runs_sync_status);
+        $this->assertEquals(
+            $priorSync->toIso8601String(),
+            $repo->workflow_runs_synced_at->toIso8601String(),
+        );
+    }
+
+    public function test_handle_persists_sync_error_and_failed_at_on_api_failure(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/actions/runs*' => Http::response(
+                ['message' => 'Not Found'],
+                404,
+            ),
+        ]);
+
+        (new SyncRepositoryWorkflowRunsJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->workflow_runs_sync_status);
+        $this->assertNotNull($repo->workflow_runs_sync_error);
+        $this->assertStringContainsString('404', $repo->workflow_runs_sync_error);
+        $this->assertNotNull($repo->workflow_runs_sync_failed_at);
+    }
+
+    public function test_handle_clears_sync_error_after_successful_resync(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        $context['repository']->forceFill([
+            'workflow_runs_sync_status' => RepositorySyncStatus::Failed->value,
+            'workflow_runs_sync_error' => 'Stale failure message',
+            'workflow_runs_sync_failed_at' => now()->subMinutes(10),
+        ])->save();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/actions/runs*' => Http::response([
+                'total_count' => 0,
+                'workflow_runs' => [],
+            ]),
+        ]);
+
+        (new SyncRepositoryWorkflowRunsJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Synced, $repo->workflow_runs_sync_status);
+        $this->assertNull($repo->workflow_runs_sync_error);
+        $this->assertNull($repo->workflow_runs_sync_failed_at);
+    }
+
+    public function test_handle_marks_failed_when_owner_has_no_connection(): void
+    {
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'workflow_runs_sync_status' => RepositorySyncStatus::Pending->value,
+        ]);
+
+        (new SyncRepositoryWorkflowRunsJob($repository->id))->handle($this->action());
+
+        $repo = $repository->fresh();
+        $this->assertSame(RepositorySyncStatus::Failed, $repo->workflow_runs_sync_status);
+        $this->assertNotNull($repo->workflow_runs_sync_error);
+        $this->assertStringContainsString('connection', strtolower($repo->workflow_runs_sync_error));
+    }
+
+    public function test_handle_is_a_no_op_when_repository_is_missing(): void
+    {
+        (new SyncRepositoryWorkflowRunsJob(999_999))->handle($this->action());
+
+        $this->assertSame(0, Repository::query()->count());
+        $this->assertSame(0, WorkflowRun::query()->count());
+    }
+}

--- a/tests/Feature/GitHub/Webhooks/WorkflowRunWebhookHandlerTest.php
+++ b/tests/Feature/GitHub/Webhooks/WorkflowRunWebhookHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\GitHub\Webhooks;
 
 use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Domain\GitHub\Actions\NormalizeGitHubWorkflowRunAction;
 use App\Domain\GitHub\WebhookHandlers\WorkflowRunWebhookHandler;
 use App\Enums\WebhookDeliveryStatus;
 use App\Events\ActivityEventCreated;
@@ -11,6 +12,7 @@ use App\Models\Project;
 use App\Models\Repository;
 use App\Models\User;
 use App\Models\WebhookDelivery;
+use App\Models\WorkflowRun;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
@@ -21,7 +23,10 @@ class WorkflowRunWebhookHandlerTest extends TestCase
 
     private function handler(): WorkflowRunWebhookHandler
     {
-        return new WorkflowRunWebhookHandler(new CreateActivityEventAction);
+        return new WorkflowRunWebhookHandler(
+            new CreateActivityEventAction,
+            new NormalizeGitHubWorkflowRunAction,
+        );
     }
 
     private function deliveryFor(
@@ -40,12 +45,15 @@ class WorkflowRunWebhookHandlerTest extends TestCase
                     'id' => 1234,
                     'name' => 'CI',
                     'head_branch' => 'main',
+                    'head_sha' => 'a'.str_repeat('1', 39),
+                    'event' => 'push',
                     'run_number' => 42,
                     'conclusion' => $conclusion,
                     'status' => 'completed',
                     'updated_at' => '2026-04-29T12:00:00Z',
                     'run_started_at' => '2026-04-29T11:55:00Z',
                     'html_url' => 'https://github.com/octocat/hello-world/actions/runs/1234',
+                    'actor' => ['login' => 'alice'],
                 ],
                 'sender' => ['login' => 'alice'],
             ],
@@ -124,5 +132,77 @@ class WorkflowRunWebhookHandlerTest extends TestCase
 
         $this->assertSame(WebhookDeliveryStatus::Skipped, $status);
         $this->assertSame(0, ActivityEvent::query()->count());
+        // No FK target for the upsert when the repo isn't imported yet.
+        $this->assertSame(0, WorkflowRun::query()->count());
+    }
+
+    public function test_completed_handled_run_upserts_into_workflow_runs(): void
+    {
+        Event::fake([ActivityEventCreated::class]);
+        $repository = $this->importedRepository();
+        $delivery = $this->deliveryFor('completed', 'success');
+
+        $this->handler()->handle($delivery);
+
+        $this->assertSame(1, WorkflowRun::query()->count());
+        $run = WorkflowRun::query()->first();
+        $this->assertSame($repository->id, $run->repository_id);
+        $this->assertSame(1234, $run->github_id);
+        $this->assertSame(42, $run->run_number);
+        $this->assertSame('CI', $run->name);
+        $this->assertSame('completed', $run->status->value);
+        $this->assertSame('success', $run->conclusion->value);
+        $this->assertSame('main', $run->head_branch);
+        $this->assertSame('alice', $run->actor_login);
+    }
+
+    public function test_in_progress_action_still_upserts_workflow_run(): void
+    {
+        $this->importedRepository();
+        $delivery = WebhookDelivery::factory()->create([
+            'event' => 'workflow_run',
+            'action' => 'in_progress',
+            'repository_full_name' => 'octocat/hello-world',
+            'payload_json' => [
+                'action' => 'in_progress',
+                'repository' => ['full_name' => 'octocat/hello-world'],
+                'workflow_run' => [
+                    'id' => 5678,
+                    'name' => 'Deploy',
+                    'head_branch' => 'main',
+                    'head_sha' => 'b'.str_repeat('2', 39),
+                    'event' => 'workflow_dispatch',
+                    'run_number' => 1,
+                    'status' => 'in_progress',
+                    'conclusion' => null,
+                    'run_started_at' => '2026-04-29T11:55:00Z',
+                    'updated_at' => '2026-04-29T11:56:00Z',
+                    'html_url' => 'https://github.com/octocat/hello-world/actions/runs/5678',
+                ],
+            ],
+        ]);
+
+        $status = $this->handler()->handle($delivery);
+
+        // Existing semantics preserved — Skipped means no activity event.
+        $this->assertSame(WebhookDeliveryStatus::Skipped, $status);
+        $this->assertSame(0, ActivityEvent::query()->count());
+        // But the timeline upsert happens regardless so in-flight runs
+        // surface on the Workflow Runs tab.
+        $this->assertSame(1, WorkflowRun::query()->count());
+        $run = WorkflowRun::query()->first();
+        $this->assertSame('in_progress', $run->status->value);
+        $this->assertNull($run->conclusion);
+    }
+
+    public function test_replayed_delivery_is_idempotent(): void
+    {
+        $this->importedRepository();
+        $delivery = $this->deliveryFor('completed', 'success');
+
+        $this->handler()->handle($delivery);
+        $this->handler()->handle($delivery);
+
+        $this->assertSame(1, WorkflowRun::query()->where('github_id', 1234)->count());
     }
 }

--- a/tests/Feature/GitHub/WorkflowRunsForRepositoryQueryTest.php
+++ b/tests/Feature/GitHub/WorkflowRunsForRepositoryQueryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature\GitHub;
+
+use App\Domain\GitHub\Queries\WorkflowRunsForRepositoryQuery;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\WorkflowRun;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WorkflowRunsForRepositoryQueryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setUpRepository(): Repository
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        return Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+        ]);
+    }
+
+    public function test_orders_by_run_started_at_desc(): void
+    {
+        $repository = $this->setUpRepository();
+
+        WorkflowRun::factory()->create([
+            'repository_id' => $repository->id,
+            'github_id' => 1,
+            'run_number' => 1,
+            'run_started_at' => now()->subHours(3),
+        ]);
+        WorkflowRun::factory()->create([
+            'repository_id' => $repository->id,
+            'github_id' => 2,
+            'run_number' => 2,
+            'run_started_at' => now()->subHour(),
+        ]);
+        WorkflowRun::factory()->create([
+            'repository_id' => $repository->id,
+            'github_id' => 3,
+            'run_number' => 3,
+            'run_started_at' => now()->subDay(),
+        ]);
+
+        $rows = (new WorkflowRunsForRepositoryQuery)->execute($repository);
+
+        $this->assertCount(3, $rows);
+        // Most-recent first: run 2, 1, 3 by run_started_at desc.
+        $this->assertSame([2, 1, 3], array_map(fn ($row) => $row['run_number'], $rows));
+    }
+
+    public function test_scopes_to_the_given_repository(): void
+    {
+        $repository = $this->setUpRepository();
+        $other = Repository::factory()->create(['full_name' => 'other/repo']);
+
+        WorkflowRun::factory()->count(3)->create(['repository_id' => $repository->id]);
+        WorkflowRun::factory()->count(2)->create(['repository_id' => $other->id]);
+
+        $this->assertCount(3, (new WorkflowRunsForRepositoryQuery)->execute($repository));
+        $this->assertCount(2, (new WorkflowRunsForRepositoryQuery)->execute($other));
+    }
+
+    public function test_caps_at_100_rows(): void
+    {
+        $repository = $this->setUpRepository();
+        WorkflowRun::factory()->count(120)->create(['repository_id' => $repository->id]);
+
+        $rows = (new WorkflowRunsForRepositoryQuery)->execute($repository);
+
+        $this->assertCount(100, $rows);
+    }
+
+    public function test_returns_arrays_with_the_expected_keys(): void
+    {
+        $repository = $this->setUpRepository();
+        WorkflowRun::factory()->create(['repository_id' => $repository->id]);
+
+        $row = (new WorkflowRunsForRepositoryQuery)->execute($repository)[0];
+
+        $this->assertArrayHasKey('id', $row);
+        $this->assertArrayHasKey('run_number', $row);
+        $this->assertArrayHasKey('name', $row);
+        $this->assertArrayHasKey('event', $row);
+        $this->assertArrayHasKey('status', $row);
+        $this->assertArrayHasKey('conclusion', $row);
+        $this->assertArrayHasKey('head_branch', $row);
+        $this->assertArrayHasKey('head_sha', $row);
+        $this->assertArrayHasKey('actor_login', $row);
+        $this->assertArrayHasKey('html_url', $row);
+        $this->assertArrayHasKey('run_started_at', $row);
+        $this->assertArrayHasKey('run_updated_at', $row);
+    }
+}

--- a/tests/Feature/Repositories/RepositoryControllerTest.php
+++ b/tests/Feature/Repositories/RepositoryControllerTest.php
@@ -60,6 +60,10 @@ class RepositoryControllerTest extends TestCase
                     ->where('canSync', true)
                     ->has('issues')
                     ->has('issuesSync')
+                    ->has('pullRequests')
+                    ->has('pullRequestsSync')
+                    ->has('workflowRuns')
+                    ->has('workflowRunsSync')
             );
     }
 


### PR DESCRIPTION
Closes #61

Spec: specs/phase-4-deployments-cicd/020-workflow-runs-storage-and-sync.md

## Summary
- Adds the `workflow_runs` table + `WorkflowRun` model + `WorkflowRunStatus` / `WorkflowRunConclusion` enums. Six-column sync pattern (status / synced_at / error / failed_at) extended onto `repositories`.
- New `SyncRepositoryWorkflowRunsAction` + `SyncRepositoryWorkflowRunsJob` mirror the issues/PRs sync 1:1 (lifecycle, 401 handling, error capture, preserve-on-failure timestamps). Chained off `SyncGitHubRepositoryJob`.
- New per-tab `RepositoryWorkflowRunsSyncController` + `repositories.workflow-runs.sync` route. `RepositorySyncController` now clears all eight error columns (4 sync flows × 2 cols) on manual re-trigger.
- `Repositories/Show.vue` Workflow Runs tab: status + conclusion-aware badges, "Last sync / Failed Xm ago", per-tab failure banner, list of runs linking out to GitHub. Polling refetches workflow runs alongside the rest.
- `WorkflowRunWebhookHandler` extended to upsert into `workflow_runs` for ALL deliveries (queued / in_progress / completed) — timeline reflects in-flight states. Activity-event creation stays gated to terminal outcomes; spec 019 assertions stay green. `WebhookDeliveryStatus::Skipped` doc updated to reflect the "no activity event" (vs "no DB writes") semantic.

## Test plan
- [x] `vendor/bin/pint --test` passes.
- [x] `php artisan test` — 26 net new passing tests; full suite 239 passed (was 213). The 41 failures are env-only POST CSRF (419) issues affecting all POST tests in the repo, including the pre-existing same-shape ones in `RepositoryIssuesSyncControllerTest` / `RepositoryPullRequestsSyncControllerTest` / `RepositorySyncControllerTest`. CI passes them all (last main CI green).
- [x] `npm run build` clean.
- [ ] Manual smoke (post-merge): import a repo, observe the new Workflow Runs tab populates from the chained sync; trigger an Actions run on GitHub, observe a webhook delivery upserts the row + creates the activity event for terminal outcomes.

## Self-review notes
Self-review pass via `superpowers:code-reviewer` flagged 5 recommendations; addressed 4:
- Added `workflowStatusTone()` helper so the run-status badge fallback (when no conclusion yet) renders the right tone instead of silently collapsing to `muted`.
- Doc'd the `WebhookDeliveryStatus::Skipped` semantics shift on the enum.
- Switched the Workflow Runs panel `v-else` → `v-else-if="tab === 'workflow-runs'"` for forward safety against future tabs.
- Added a re-run comment on `NormalizeGitHubWorkflowRunAction::run_completed_at` clarifying that the column correctly clears when GitHub keeps the same run id and reverts to `in_progress`.

Deferred:
- Stale-webhook overwrite guard. Pre-existing across all three sync flows (issues / PRs / workflow runs): out-of-order webhook deliveries last-write-wins, briefly producing a stale row until the next sync converges. A `run_updated_at` guard on the upsert would harden all three at minimal cost — file a follow-up if it bites in practice.