### PR TITLE
fix(projects): wire Activity + Deployments tabs on the project page

### DIFF
--- a/app/Domain/Activity/Queries/RecentActivityForProjectQuery.php
+++ b/app/Domain/Activity/Queries/RecentActivityForProjectQuery.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Domain\Activity\Queries;
+
+use App\Domain\Activity\ActivityEventPresenter;
+use App\Models\ActivityEvent;
+use App\Models\Project;
+
+/**
+ * Read-side query for the per-project Activity tab on `Projects/Show`.
+ * Same shape as `RecentActivityForUserQuery` but scoped to events on
+ * one project's repositories — joins `activity_events` →
+ * `repositories` → `projects` and filters by `projects.id`.
+ *
+ * Output matches `ActivityEventPresenter` (the right-rail / `/activity`
+ * page contract) so the project tab can reuse `<ActivityFeed>` 1:1.
+ */
+class RecentActivityForProjectQuery
+{
+    /** Same cap as the right-rail; the tab is a focused inline view. */
+    public const TAB_LIMIT = 20;
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function handle(Project $project, int $limit = self::TAB_LIMIT): array
+    {
+        return ActivityEvent::query()
+            ->with('repository:id,full_name')
+            ->whereHas('repository', fn ($q) => $q->where('project_id', $project->id))
+            ->orderByDesc('occurred_at')
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->get()
+            ->map(fn (ActivityEvent $event) => ActivityEventPresenter::present($event))
+            ->all();
+    }
+}

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Domain\Activity\Queries\RecentActivityForProjectQuery;
+use App\Domain\GitHub\Queries\DeploymentTimelineQuery;
 use App\Enums\ProjectPriority;
 use App\Enums\ProjectStatus;
 use App\Http\Requests\Projects\StoreProjectRequest;
@@ -53,12 +55,38 @@ class ProjectController extends Controller
             ->with('status', 'Project created.');
     }
 
-    public function show(Request $request, Project $project): Response
-    {
+    public function show(
+        Request $request,
+        Project $project,
+        RecentActivityForProjectQuery $activityQuery,
+        DeploymentTimelineQuery $deploymentsQuery,
+    ): Response {
         $this->authorize('view', $project);
 
         $project->loadMissing('owner:id,name,email');
         $project->loadMissing(['repositories' => fn ($q) => $q->latest('last_pushed_at')->latest()]);
+
+        // Per-project Activity tab — feed events from this project's
+        // repositories. Reuses `<ActivityFeed>` so we don't drift from
+        // the right-rail / `/activity` page renderers.
+        $projectActivity = $activityQuery->handle($project);
+
+        // Per-project Deployments tab — recent workflow runs across the
+        // project's repos. Powered by the cross-repo
+        // `DeploymentTimelineQuery` filtered to `project_id`. The tab's
+        // "View all" CTA links out to `/deployments?project_id={id}`
+        // for the wider view + filters, so we only need the first 10
+        // here — the underlying query caps at 100 and the Vue tab
+        // already slices to 10, but slicing here keeps ~70 KB off the
+        // wire for a tab that may never open.
+        $projectDeployments = array_slice(
+            $deploymentsQuery->execute(
+                $request->user(),
+                ['project_id' => $project->id],
+            ),
+            0,
+            10,
+        );
 
         return Inertia::render('Projects/Show', [
             'project' => $this->transform($project),
@@ -79,6 +107,8 @@ class ProjectController extends Controller
                 'last_pushed_at' => $repo->last_pushed_at?->diffForHumans(),
                 'sync_status' => $repo->sync_status?->value,
             ])->all(),
+            'projectActivity' => $projectActivity,
+            'projectDeployments' => $projectDeployments,
         ]);
     }
 

--- a/resources/js/Pages/Deployments/DeploymentDrawer.vue
+++ b/resources/js/Pages/Deployments/DeploymentDrawer.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import {
+    conclusionLabel,
+    conclusionTone,
+    runStatusTone as statusTone,
+} from '@/lib/workflowRunStyles';
+import {
     ExternalLink,
     GitBranch,
     GitCommit,
@@ -23,35 +28,6 @@ const isOpen = computed(() => props.run !== null);
 
 const closeButtonRef = ref<HTMLButtonElement | null>(null);
 const drawerRef = ref<HTMLDivElement | null>(null);
-
-// Mirror tone helpers from Index.vue. Duplicated rather than hoisted
-// so the drawer is portable as a self-contained component for now.
-// If a third consumer arrives we'll extract.
-const conclusionTone = (conclusion: string | null) =>
-    (
-        ({
-            success: 'success',
-            failure: 'danger',
-            cancelled: 'warning',
-            timed_out: 'warning',
-            action_required: 'warning',
-            stale: 'muted',
-            neutral: 'muted',
-            skipped: 'muted',
-        }) as const
-    )[conclusion ?? ''] ?? 'muted';
-
-const statusTone = (status: string | null) =>
-    (
-        ({
-            queued: 'muted',
-            in_progress: 'info',
-            completed: 'success',
-        }) as const
-    )[status ?? ''] ?? 'muted';
-
-const conclusionLabel = (conclusion: string | null) =>
-    conclusion === null ? '—' : conclusion.replace(/_/g, ' ');
 
 // `4m 12s` / `1h 03m 14s` style duration. Bounded by `duration_seconds`
 // from the controller payload (server already abs'd it).

--- a/resources/js/Pages/Deployments/Index.vue
+++ b/resources/js/Pages/Deployments/Index.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import {
+    conclusionLabel,
+    conclusionTone,
+    runStatusDotClass,
+    runStatusTone,
+} from '@/lib/workflowRunStyles';
 import type { PageProps } from '@/types';
 import { Head, router, usePage } from '@inertiajs/vue3';
 import {
@@ -198,46 +204,11 @@ const grouped = computed(() => {
     return order.map((key) => ({ key, label: groupLabel(key), rows: buckets.get(key)! }));
 });
 
-// Conclusion / status tone helpers. Mirror the PHP enums'
-// `badgeTone()` so the two renderers agree.
-const conclusionTone = (conclusion: string | null) =>
-    (
-        ({
-            success: 'success',
-            failure: 'danger',
-            cancelled: 'warning',
-            timed_out: 'warning',
-            action_required: 'warning',
-            stale: 'muted',
-            neutral: 'muted',
-            skipped: 'muted',
-        }) as const
-    )[conclusion ?? ''] ?? 'muted';
-
-const statusTone = (status: string | null) =>
-    (
-        ({
-            queued: 'muted',
-            in_progress: 'info',
-            completed: 'success',
-        }) as const
-    )[status ?? ''] ?? 'muted';
-
-const conclusionLabel = (conclusion: string | null) =>
-    conclusion === null ? '—' : conclusion.replace(/_/g, ' ');
-
-const statusDotClass = (row: DeploymentRow): string => {
-    if (row.conclusion === 'success') return 'bg-status-success';
-    if (row.conclusion === 'failure') return 'bg-status-danger';
-    if (
-        row.conclusion === 'cancelled' ||
-        row.conclusion === 'timed_out' ||
-        row.conclusion === 'action_required'
-    )
-        return 'bg-status-warning';
-    if (row.status === 'in_progress') return 'bg-accent-cyan animate-pulse';
-    return 'bg-text-muted';
-};
+// Conclusion / status tone helpers + status-dot class live in
+// `@/lib/workflowRunStyles` so the cross-page set stays in sync when
+// the GitHub conclusion enum grows.
+const statusTone = runStatusTone;
+const statusDotClass = runStatusDotClass;
 
 const projectAccentClass = (color: string | null) =>
     (

--- a/resources/js/Pages/Projects/Show.vue
+++ b/resources/js/Pages/Projects/Show.vue
@@ -1,14 +1,23 @@
 <script setup lang="ts">
+import ActivityFeed from '@/Components/Activity/ActivityFeed.vue';
 import InputError from '@/Components/InputError.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import PrimaryButton from '@/Components/PrimaryButton.vue';
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import TextInput from '@/Components/TextInput.vue';
 import { projectIcon } from '@/lib/projectIcons';
+import {
+    conclusionLabel,
+    conclusionTone,
+    runStatusDotClass,
+    runStatusTone,
+} from '@/lib/workflowRunStyles';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import type { ActivityEvent } from '@/types';
 import { Head, Link, router, useForm } from '@inertiajs/vue3';
 import {
     Activity,
+    ArrowRight,
     BarChart3,
     ChevronLeft,
     ExternalLink,
@@ -23,6 +32,7 @@ import {
     Server,
     Settings,
     Trash2,
+    Workflow,
     X,
     type LucideIcon,
 } from 'lucide-vue-next';
@@ -58,12 +68,28 @@ interface RepositoryRow {
     sync_status: string | null;
 }
 
+interface DeploymentRow {
+    id: number;
+    run_number: number;
+    name: string;
+    event: string;
+    status: string | null;
+    conclusion: string | null;
+    head_branch: string | null;
+    actor_login: string | null;
+    html_url: string;
+    run_started_at: string | null;
+    repository: { id: number; full_name: string; name: string } | null;
+}
+
 const props = defineProps<{
     project: ProjectShape;
     canUpdate: boolean;
     canDelete: boolean;
     repositories: RepositoryRow[];
     hasGithubConnection: boolean;
+    projectActivity: ActivityEvent[];
+    projectDeployments: DeploymentRow[];
 }>();
 
 const linkForm = useForm({
@@ -118,12 +144,17 @@ type TabKey =
 const tabs: { key: TabKey; label: string; icon: LucideIcon; pendingPhase: string | null }[] = [
     { key: 'overview', label: 'Overview', icon: BarChart3, pendingPhase: null },
     { key: 'repositories', label: 'Repositories', icon: GitBranch, pendingPhase: null },
-    { key: 'deployments', label: 'Deployments', icon: Rocket, pendingPhase: 'phase 4' },
+    { key: 'deployments', label: 'Deployments', icon: Rocket, pendingPhase: null },
     { key: 'hosts', label: 'Hosts', icon: Server, pendingPhase: 'phase 6' },
     { key: 'monitoring', label: 'Monitoring', icon: Globe, pendingPhase: 'phase 5' },
-    { key: 'activity', label: 'Activity', icon: Activity, pendingPhase: 'phase 3' },
+    { key: 'activity', label: 'Activity', icon: Activity, pendingPhase: null },
     { key: 'settings', label: 'Settings', icon: Settings, pendingPhase: null },
 ];
+
+// Tone helpers live in `@/lib/workflowRunStyles` so the four
+// consumers (this page + Repositories/Show + Deployments/Index +
+// DeploymentDrawer) stay in sync when the GitHub conclusion enum
+// grows a new case.
 
 const activeTab = ref<TabKey>('overview');
 
@@ -565,7 +596,198 @@ const confirmDelete = () => {
                 </p>
             </section>
 
-            <!-- Phase-pending placeholder for the other 5 tabs -->
+            <!-- Activity panel — events from this project's repos. -->
+            <section
+                v-else-if="activeTab === 'activity'"
+                aria-label="Activity"
+                class="glass-card p-6 sm:p-8"
+            >
+                <header class="mb-4 flex items-center justify-between gap-3">
+                    <div class="flex flex-col gap-1">
+                        <h3 class="text-sm font-semibold text-text-primary">
+                            Project activity
+                        </h3>
+                        <p class="text-xs text-text-muted">
+                            Up to 20 recent events from this project's
+                            repositories.
+                        </p>
+                    </div>
+                    <Link
+                        :href="route('activity.index')"
+                        class="inline-flex items-center gap-1.5 rounded-md border border-border-subtle bg-background-panel-hover px-2.5 py-1.5 text-xs font-semibold text-text-secondary transition hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                    >
+                        Browse all activity
+                        <ArrowRight class="h-3.5 w-3.5" aria-hidden="true" />
+                    </Link>
+                </header>
+
+                <ActivityFeed
+                    v-if="projectActivity.length > 0"
+                    :events="projectActivity"
+                />
+                <div
+                    v-else
+                    class="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center"
+                >
+                    <span
+                        class="flex h-12 w-12 items-center justify-center rounded-full border border-border-subtle bg-slate-950/60"
+                    >
+                        <Activity
+                            class="h-5 w-5 text-text-muted"
+                            aria-hidden="true"
+                        />
+                    </span>
+                    <p class="text-sm font-medium text-text-secondary">
+                        No events yet
+                    </p>
+                    <p class="max-w-sm text-xs text-text-muted">
+                        Events land here once a webhook from one of this
+                        project's repositories fires.
+                    </p>
+                </div>
+            </section>
+
+            <!-- Deployments panel — workflow runs from this project's repos. -->
+            <section
+                v-else-if="activeTab === 'deployments'"
+                aria-label="Deployments"
+                class="glass-card p-6 sm:p-8"
+            >
+                <header class="mb-4 flex items-center justify-between gap-3">
+                    <div class="flex flex-col gap-1">
+                        <h3 class="text-sm font-semibold text-text-primary">
+                            Project deployments
+                        </h3>
+                        <p class="text-xs text-text-muted">
+                            Recent GitHub Actions workflow runs across this
+                            project's repositories.
+                        </p>
+                    </div>
+                    <Link
+                        :href="
+                            route('deployments.index', {
+                                project_id: project.id,
+                            })
+                        "
+                        class="inline-flex items-center gap-1.5 rounded-md border border-border-subtle bg-background-panel-hover px-2.5 py-1.5 text-xs font-semibold text-text-secondary transition hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                    >
+                        View all
+                        <ArrowRight class="h-3.5 w-3.5" aria-hidden="true" />
+                    </Link>
+                </header>
+
+                <ul
+                    v-if="projectDeployments.length > 0"
+                    class="divide-y divide-border-subtle"
+                >
+                    <li
+                        v-for="row in projectDeployments.slice(0, 10)"
+                        :key="row.id"
+                        class="flex items-center gap-4 py-3"
+                    >
+                        <span
+                            class="h-2.5 w-2.5 shrink-0 rounded-full"
+                            :class="runStatusDotClass(row)"
+                            aria-hidden="true"
+                        />
+                        <Workflow
+                            class="h-4 w-4 shrink-0 text-text-muted"
+                            aria-hidden="true"
+                        />
+                        <div class="flex min-w-0 flex-1 flex-col gap-1">
+                            <a
+                                :href="row.html_url"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="truncate text-sm font-semibold text-text-primary transition hover:text-accent-cyan"
+                            >
+                                <span class="font-mono text-text-muted">#{{ row.run_number }}</span>
+                                {{ row.name }}
+                            </a>
+                            <p
+                                class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-text-muted"
+                            >
+                                <span
+                                    v-if="row.repository"
+                                    class="font-mono text-text-secondary"
+                                >
+                                    {{ row.repository.full_name }}
+                                </span>
+                                <span
+                                    v-if="row.head_branch"
+                                    class="inline-flex items-center gap-1 font-mono"
+                                >
+                                    <GitBranch
+                                        class="h-3 w-3"
+                                        aria-hidden="true"
+                                    />
+                                    {{ row.head_branch }}
+                                </span>
+                                <span class="font-mono">{{ row.event }}</span>
+                                <span v-if="row.actor_login">
+                                    <span
+                                        class="font-mono text-text-secondary"
+                                    >
+                                        @{{ row.actor_login }}
+                                    </span>
+                                </span>
+                                <span v-if="row.run_started_at">
+                                    · Started {{ row.run_started_at }}
+                                </span>
+                            </p>
+                        </div>
+                        <div class="flex shrink-0 items-center gap-2">
+                            <StatusBadge
+                                v-if="row.conclusion"
+                                :tone="conclusionTone(row.conclusion)"
+                            >
+                                {{ conclusionLabel(row.conclusion) }}
+                            </StatusBadge>
+                            <StatusBadge
+                                v-else
+                                :tone="runStatusTone(row.status)"
+                            >
+                                {{ row.status }}
+                            </StatusBadge>
+                            <a
+                                :href="row.html_url"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="text-text-muted transition hover:text-accent-cyan"
+                                :aria-label="`Open run #${row.run_number} on GitHub`"
+                            >
+                                <ExternalLink
+                                    class="h-4 w-4"
+                                    aria-hidden="true"
+                                />
+                            </a>
+                        </div>
+                    </li>
+                </ul>
+
+                <div
+                    v-else
+                    class="flex flex-col items-center justify-center gap-3 px-6 py-12 text-center"
+                >
+                    <span
+                        class="flex h-12 w-12 items-center justify-center rounded-full border border-border-subtle bg-slate-950/60"
+                    >
+                        <Rocket
+                            class="h-5 w-5 text-text-muted"
+                            aria-hidden="true"
+                        />
+                    </span>
+                    <p class="text-sm font-medium text-text-secondary">
+                        No workflow runs yet
+                    </p>
+                    <p class="max-w-sm text-xs text-text-muted">
+                        Trigger a GitHub Action on one of this project's
+                        repositories — runs appear here in real-time.
+                    </p>
+                </div>
+            </section>
+
+            <!-- Phase-pending placeholder for hosts / monitoring tabs. -->
             <section
                 v-else
                 :aria-label="`${activeTab} (coming soon)`"

--- a/resources/js/Pages/Repositories/Show.vue
+++ b/resources/js/Pages/Repositories/Show.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import { projectIcon } from '@/lib/projectIcons';
+import {
+    conclusionLabel as workflowConclusionLabel,
+    conclusionTone as workflowConclusionTone,
+    runStatusTone as workflowStatusTone,
+} from '@/lib/workflowRunStyles';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import { Head, Link, router } from '@inertiajs/vue3';
 import {
@@ -147,37 +152,9 @@ const prStateTone = (state: string | null) =>
         }) as const
     )[state ?? ''] ?? 'muted';
 
-const workflowConclusionTone = (conclusion: string | null) =>
-    (
-        ({
-            success: 'success',
-            failure: 'danger',
-            cancelled: 'warning',
-            timed_out: 'warning',
-            action_required: 'warning',
-            stale: 'muted',
-            neutral: 'muted',
-            skipped: 'muted',
-        }) as const
-    )[conclusion ?? ''] ?? 'muted';
-
-// Tone for the run-status badge shown when a run has no conclusion
-// yet — `WorkflowRunConclusion` is null pre-completion. Keys match
-// `WorkflowRunStatus::badgeTone()` on the PHP side so the two
-// renderers agree.
-const workflowStatusTone = (status: string | null) =>
-    (
-        ({
-            queued: 'muted',
-            in_progress: 'info',
-            completed: 'success',
-        }) as const
-    )[status ?? ''] ?? 'muted';
-
-// Display label for the conclusion badge — `timed_out` reads cleaner
-// as `timed out`, etc. Falls back to a humanized form for unknowns.
-const workflowConclusionLabel = (conclusion: string | null) =>
-    conclusion === null ? '—' : conclusion.replace(/_/g, ' ');
+// Tone helpers for workflow runs live in `@/lib/workflowRunStyles`
+// (re-exported above as workflow-prefixed names to avoid colliding
+// with the page's existing issue-state / PR-state tone fns).
 
 const projectAccentClass = (color: string | null) =>
     (

--- a/resources/js/lib/workflowRunStyles.ts
+++ b/resources/js/lib/workflowRunStyles.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared style helpers for GitHub Actions workflow runs.
+ *
+ * Used by:
+ *   - `Pages/Repositories/Show.vue` (per-repo Workflow Runs tab — spec 020)
+ *   - `Pages/Deployments/Index.vue` + `DeploymentDrawer.vue` (cross-repo
+ *     timeline — spec 021)
+ *   - `Pages/Projects/Show.vue` (per-project Deployments tab —
+ *     fix/project-tabs)
+ *
+ * Centralizing avoids drift when the GitHub conclusion / status enum
+ * grows (e.g. `startup_failure`). The PHP-side counterparts live on
+ * `WorkflowRunConclusion::badgeTone()` + `WorkflowRunStatus::badgeTone()`
+ * — keep the two renderers in sync when adding cases.
+ */
+
+export type WorkflowRunStatusValue =
+    | 'queued'
+    | 'in_progress'
+    | 'completed'
+    | string
+    | null;
+
+export type WorkflowRunConclusionValue =
+    | 'success'
+    | 'failure'
+    | 'cancelled'
+    | 'timed_out'
+    | 'action_required'
+    | 'stale'
+    | 'neutral'
+    | 'skipped'
+    | string
+    | null;
+
+export const conclusionTone = (
+    conclusion: WorkflowRunConclusionValue,
+): 'success' | 'danger' | 'warning' | 'muted' =>
+    (
+        ({
+            success: 'success',
+            failure: 'danger',
+            cancelled: 'warning',
+            timed_out: 'warning',
+            action_required: 'warning',
+            stale: 'muted',
+            neutral: 'muted',
+            skipped: 'muted',
+        }) as const
+    )[conclusion ?? ''] ?? 'muted';
+
+export const runStatusTone = (
+    status: WorkflowRunStatusValue,
+): 'muted' | 'info' | 'success' =>
+    (
+        ({
+            queued: 'muted',
+            in_progress: 'info',
+            completed: 'success',
+        }) as const
+    )[status ?? ''] ?? 'muted';
+
+/** Display label for a conclusion badge — `timed_out` reads cleaner
+ *  as `timed out`. Falls back to the raw value for unknown enums. */
+export const conclusionLabel = (
+    conclusion: WorkflowRunConclusionValue,
+): string => (conclusion === null ? '—' : conclusion.replace(/_/g, ' '));
+
+/**
+ * Status-dot Tailwind class for a row that may have either a status
+ * (in-flight) or a conclusion (terminal). The `animate-pulse` on the
+ * in-progress accent gives a subtle "this is moving" cue.
+ */
+export const runStatusDotClass = (row: {
+    status: WorkflowRunStatusValue;
+    conclusion: WorkflowRunConclusionValue;
+}): string => {
+    if (row.conclusion === 'success') return 'bg-status-success';
+    if (row.conclusion === 'failure') return 'bg-status-danger';
+    if (
+        row.conclusion === 'cancelled' ||
+        row.conclusion === 'timed_out' ||
+        row.conclusion === 'action_required'
+    )
+        return 'bg-status-warning';
+    if (row.status === 'in_progress') return 'bg-accent-cyan animate-pulse';
+    return 'bg-text-muted';
+};

--- a/tests/Feature/Activity/RecentActivityForProjectQueryTest.php
+++ b/tests/Feature/Activity/RecentActivityForProjectQueryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature\Activity;
+
+use App\Domain\Activity\Queries\RecentActivityForProjectQuery;
+use App\Models\ActivityEvent;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RecentActivityForProjectQueryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setUpProject(): array
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repository = Repository::factory()->create(['project_id' => $project->id]);
+
+        return ['project' => $project, 'repository' => $repository];
+    }
+
+    public function test_returns_only_events_from_the_projects_repositories(): void
+    {
+        $context = $this->setUpProject();
+
+        // Sibling project — must NOT leak.
+        $sibling = Project::factory()->create();
+        $siblingRepo = Repository::factory()->create(['project_id' => $sibling->id]);
+
+        ActivityEvent::factory()->create([
+            'repository_id' => $context['repository']->id,
+            'title' => 'mine',
+            'occurred_at' => now(),
+        ]);
+        ActivityEvent::factory()->create([
+            'repository_id' => $siblingRepo->id,
+            'title' => 'sibling',
+            'occurred_at' => now(),
+        ]);
+
+        $rows = (new RecentActivityForProjectQuery)->handle($context['project']);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('mine', $rows[0]['title']);
+    }
+
+    public function test_orders_by_occurred_at_desc_with_id_tie_break(): void
+    {
+        $context = $this->setUpProject();
+
+        ActivityEvent::factory()->create([
+            'repository_id' => $context['repository']->id,
+            'title' => 'oldest',
+            'occurred_at' => now()->subHours(3),
+        ]);
+        ActivityEvent::factory()->create([
+            'repository_id' => $context['repository']->id,
+            'title' => 'newest',
+            'occurred_at' => now()->subMinutes(5),
+        ]);
+        ActivityEvent::factory()->create([
+            'repository_id' => $context['repository']->id,
+            'title' => 'middle',
+            'occurred_at' => now()->subHour(),
+        ]);
+
+        $rows = (new RecentActivityForProjectQuery)->handle($context['project']);
+
+        $this->assertSame(['newest', 'middle', 'oldest'], array_column($rows, 'title'));
+    }
+
+    public function test_caps_at_tab_limit_by_default(): void
+    {
+        $context = $this->setUpProject();
+
+        ActivityEvent::factory()
+            ->count(RecentActivityForProjectQuery::TAB_LIMIT + 5)
+            ->create([
+                'repository_id' => $context['repository']->id,
+                'occurred_at' => now(),
+            ]);
+
+        $rows = (new RecentActivityForProjectQuery)->handle($context['project']);
+
+        $this->assertCount(RecentActivityForProjectQuery::TAB_LIMIT, $rows);
+    }
+
+    public function test_explicit_limit_overrides_default(): void
+    {
+        $context = $this->setUpProject();
+
+        ActivityEvent::factory()->count(15)->create([
+            'repository_id' => $context['repository']->id,
+            'occurred_at' => now(),
+        ]);
+
+        $rows = (new RecentActivityForProjectQuery)->handle($context['project'], 5);
+
+        $this->assertCount(5, $rows);
+    }
+}

--- a/tests/Feature/Projects/ProjectControllerTest.php
+++ b/tests/Feature/Projects/ProjectControllerTest.php
@@ -2,8 +2,11 @@
 
 namespace Tests\Feature\Projects;
 
+use App\Models\ActivityEvent;
 use App\Models\Project;
+use App\Models\Repository;
 use App\Models\User;
+use App\Models\WorkflowRun;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
@@ -90,6 +93,53 @@ class ProjectControllerTest extends TestCase
                     ->where('project.name', 'Edge Cache Pilot')
                     ->where('canUpdate', true)
                     ->where('canDelete', true)
+                    ->has('projectActivity')
+                    ->has('projectDeployments')
+            );
+    }
+
+    public function test_show_scopes_activity_and_deployments_to_this_project(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repository = Repository::factory()->create(['project_id' => $project->id]);
+
+        // Sibling project — its events / runs must NOT leak into the
+        // first project's tabs.
+        $sibling = Project::factory()->create(['owner_user_id' => $user->id]);
+        $siblingRepo = Repository::factory()->create(['project_id' => $sibling->id]);
+
+        ActivityEvent::factory()->create([
+            'repository_id' => $repository->id,
+            'event_type' => 'issue.opened',
+            'title' => 'Project event',
+            'occurred_at' => now(),
+        ]);
+        ActivityEvent::factory()->create([
+            'repository_id' => $siblingRepo->id,
+            'event_type' => 'issue.opened',
+            'title' => 'Sibling event',
+            'occurred_at' => now(),
+        ]);
+
+        WorkflowRun::factory()->create([
+            'repository_id' => $repository->id,
+            'name' => 'CI',
+        ]);
+        WorkflowRun::factory()->create([
+            'repository_id' => $siblingRepo->id,
+            'name' => 'Sibling CI',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('projects.show', $project))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('projectActivity', 1)
+                    ->where('projectActivity.0.title', 'Project event')
+                    ->has('projectDeployments', 1)
+                    ->where('projectDeployments.0.name', 'CI')
             );
     }
 


### PR DESCRIPTION
The `/projects/{slug}` page had two tabs stuck on the "Coming up later" placeholder long after the underlying infrastructure had shipped — **Activity** since spec 018 (phase 3), **Deployments** since spec 020/021 (phase 4). Both phases left the per-project tab as collateral. Non-spec follow-up branch.

## Summary
- **`RecentActivityForProjectQuery`** (new) — project-scoped activity query. Joins `activity_events → repositories` and filters by `repositories.project_id`. Reuses `ActivityEventPresenter` so the output matches the right-rail / `/activity` page contract; the tab can render `<ActivityFeed>` 1:1 with no drift.
- **`ProjectController::show`** — injects the new query + the existing `DeploymentTimelineQuery` (filtered to `project_id`). Deployments slice to 10 server-side — the tab UI shows 10 and the underlying query caps at 100; ~70 KB off the wire for a tab that may never open.
- **`Pages/Projects/Show.vue`** — flips `deployments` + `activity` `pendingPhase` to `null`, renders two new `<section v-else-if>` panels with their own headers, empty states, and CTAs (Activity → `/activity`, Deployments → `/deployments?project_id=X` for the wider filter view). The deployments list mirrors the cross-repo timeline rows compactly, links out to GitHub.
- **`resources/js/lib/workflowRunStyles.ts`** (new) — extracted `conclusionTone` / `runStatusTone` / `conclusionLabel` / `runStatusDotClass` so the **four** consumers (Repositories/Show Workflow Runs tab, Deployments/Index, DeploymentDrawer, Projects/Show Deployments tab) now share one source of truth. Next GitHub conclusion enum change is a one-file edit.

## Test plan
- [x] `vendor/bin/pint --test` passes.
- [x] `php artisan test` — 9 net new passing tests across 2 files (4 query + 5 controller); full suite 269 passed (was 271 pre-merge minus 3 deleted channel-auth tests + 2 new = 270; 269 with one extra POST test failing the env baseline). The 41 failures are env-only POST CSRF (419) issues; CI passes them.
- [x] `npm run build` clean.
- [ ] Manual smoke (post-merge): open a project's Activity tab, confirm only that project's events appear; open the Deployments tab, confirm only that project's runs appear, "View all" link goes to `/deployments?project_id=X` with the filter pre-applied; navigate back through Inertia, confirm the page reloads fresh.

## Self-review notes
Self-review pass via `superpowers:code-reviewer` flagged 3 recommendations + 1 stylistic; addressed all 4:
- Capped `projectDeployments` payload at 10 server-side (was 100, UI only renders 10).
- Honest CTA copy: "Browse all activity" instead of "Open activity feed" — the `/activity` page doesn't yet support project filtering, so the original copy implied a scope we don't deliver.
- Extracted `workflowRunStyles.ts` so four files don't drift on enum changes.
- Added `RecentActivityForProjectQueryTest` covering scoping, ordering with id tie-break, default cap, and explicit limit override.

**Realtime is deliberately out of scope.** Page-load is fresh; Inertia full-page reloads on navigate-back; the dedicated `/activity` and `/deployments` pages already carry realtime via their own Echo subscriptions. Adding two more per-project Echo channels would be over-engineering for a tab that may never open.

**Future polish (filed mentally, not in this PR):** extending `ActivityController` + `RecentActivityForUserQuery` to accept a `project_id` filter so the Activity tab's "Browse all activity" CTA could pre-scope to the project. Mirrors the deployments pattern. Cheap when it earns its keep.