### PR TITLE
Spec 023 — Website monitor MVP (CRUD + manual probe + check history)

### DIFF
--- a/app/Domain/Monitoring/Actions/RecordWebsiteCheckAction.php
+++ b/app/Domain/Monitoring/Actions/RecordWebsiteCheckAction.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Domain\Monitoring\Actions;
+
+use App\Domain\Monitoring\Probes\WebsiteProbeResult;
+use App\Enums\WebsiteCheckStatus;
+use App\Enums\WebsiteStatus;
+use App\Models\Website;
+use App\Models\WebsiteCheck;
+
+/**
+ * Persistence half of the probe pipeline. Given a `Website` + a
+ * `WebsiteProbeResult` from `RunWebsiteProbeAction`, this:
+ *
+ *   1. Inserts a `WebsiteCheck` row carrying the probe's outcome.
+ *   2. Mirrors the result onto `Website.{status,last_checked_at}`.
+ *   3. Bumps `last_success_at` (Up/Slow) or `last_failure_at`
+ *      (Down/Error) so the index page can show "last good" / "last
+ *      bad" without scanning the checks table.
+ *
+ * Returns the persisted `WebsiteCheck` so callers (manual probe
+ * controller, future scheduler job) can flash it back to the user
+ * without an extra round-trip.
+ *
+ * Activity-event creation on status transitions deliberately lives
+ * in spec 024 — that's where status transitions are interesting,
+ * since manual probes are user-triggered and don't need a separate
+ * notification surface.
+ */
+class RecordWebsiteCheckAction
+{
+    public function execute(Website $website, WebsiteProbeResult $result): WebsiteCheck
+    {
+        $checkedAt = now();
+
+        $check = WebsiteCheck::query()->create([
+            'website_id' => $website->id,
+            'status' => $result->status->value,
+            'http_status_code' => $result->httpStatusCode,
+            'response_time_ms' => $result->responseTimeMs,
+            'error_message' => $result->errorMessage,
+            'checked_at' => $checkedAt,
+        ]);
+
+        $updates = [
+            'status' => $this->parentStatusFor($result->status)->value,
+            'last_checked_at' => $checkedAt,
+        ];
+
+        if ($this->isSuccessful($result->status)) {
+            $updates['last_success_at'] = $checkedAt;
+        } else {
+            $updates['last_failure_at'] = $checkedAt;
+        }
+
+        $website->forceFill($updates)->save();
+
+        return $check;
+    }
+
+    /**
+     * `WebsiteCheckStatus` and `WebsiteStatus` differ only by the
+     * `pending` value (parent only). Map 1:1 by name.
+     */
+    private function parentStatusFor(WebsiteCheckStatus $checkStatus): WebsiteStatus
+    {
+        return match ($checkStatus) {
+            WebsiteCheckStatus::Up => WebsiteStatus::Up,
+            WebsiteCheckStatus::Down => WebsiteStatus::Down,
+            WebsiteCheckStatus::Slow => WebsiteStatus::Slow,
+            WebsiteCheckStatus::Error => WebsiteStatus::Error,
+        };
+    }
+
+    /** `Slow` is treated as a successful run for `last_success_at`. */
+    private function isSuccessful(WebsiteCheckStatus $status): bool
+    {
+        return $status === WebsiteCheckStatus::Up
+            || $status === WebsiteCheckStatus::Slow;
+    }
+}

--- a/app/Domain/Monitoring/Actions/RunWebsiteProbeAction.php
+++ b/app/Domain/Monitoring/Actions/RunWebsiteProbeAction.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Domain\Monitoring\Actions;
+
+use App\Domain\Monitoring\Probes\WebsiteProbeResult;
+use App\Enums\WebsiteCheckStatus;
+use App\Models\Website;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Throwable;
+
+/**
+ * Pure HTTP probe — no DB writes. Returns a `WebsiteProbeResult` the
+ * caller (controller / spec 024's job) hands to
+ * `RecordWebsiteCheckAction` for persistence.
+ *
+ * Status mapping:
+ *   - HTTP request succeeded with `expected_status_code`        → Up
+ *     - if `response_time_ms > SLOW_THRESHOLD_MS`               → Slow (overrides Up)
+ *   - HTTP request succeeded but status code mismatch           → Down
+ *   - Transport error (DNS / timeout / refused / TLS / etc.)    → Error
+ *
+ * All HTTP traffic flows through Laravel's `Http` facade so tests
+ * `Http::fake()` cleanly. Catch list is intentionally narrow —
+ * `ConnectionException` covers DNS / TCP / TLS / timeout, and
+ * `RequestException` covers HTTP-layer protocol failures Guzzle
+ * throws despite our not calling `->throw()`. Programmer bugs (typo,
+ * future enum drift, OOM) bubble up loudly instead of getting
+ * silently classified as "site down."
+ */
+class RunWebsiteProbeAction
+{
+    /**
+     * Phase-1 hard threshold for the `Slow` classification. Past
+     * 3 seconds a successful probe still marks the site Slow.
+     * Per-website configuration is a future polish if real users
+     * complain.
+     */
+    private const SLOW_THRESHOLD_MS = 3_000;
+
+    /** Hard cap on the persisted `error_message` length. */
+    private const ERROR_MESSAGE_LIMIT = 500;
+
+    public function execute(Website $website): WebsiteProbeResult
+    {
+        $startedAt = hrtime(true);
+
+        try {
+            $response = Http::timeout($website->timeout_ms / 1_000)
+                ->withHeaders(['User-Agent' => 'Nexus-Monitor'])
+                ->{$this->httpMethod($website->method)}($website->url);
+        } catch (ConnectionException|RequestException $e) {
+            return $this->errorResult($e);
+        }
+
+        $elapsedMs = (int) ((hrtime(true) - $startedAt) / 1_000_000);
+        $statusCode = $response->status();
+
+        $status = $this->classify($website->expected_status_code, $statusCode, $elapsedMs);
+
+        return new WebsiteProbeResult(
+            status: $status,
+            httpStatusCode: $statusCode,
+            responseTimeMs: $elapsedMs,
+            errorMessage: $this->errorMessageFor($status, $response),
+        );
+    }
+
+    /**
+     * Map probe outcome to a `WebsiteCheckStatus`. Slow takes
+     * precedence over Up because a 200 OK at 5s is more interesting
+     * than the 200 alone.
+     */
+    private function classify(int $expected, int $actual, int $elapsedMs): WebsiteCheckStatus
+    {
+        if ($actual !== $expected) {
+            return WebsiteCheckStatus::Down;
+        }
+
+        if ($elapsedMs > self::SLOW_THRESHOLD_MS) {
+            return WebsiteCheckStatus::Slow;
+        }
+
+        return WebsiteCheckStatus::Up;
+    }
+
+    /**
+     * Allowed HTTP methods reduce to the lowercase `Http` macro
+     * (`get`, `head`, `post`). Unknown / disallowed methods fall
+     * back to `get` — the controller already validates the input.
+     */
+    private function httpMethod(string $method): string
+    {
+        return match (strtoupper($method)) {
+            'HEAD' => 'head',
+            'POST' => 'post',
+            default => 'get',
+        };
+    }
+
+    private function errorResult(Throwable $e): WebsiteProbeResult
+    {
+        $message = $e->getMessage() !== '' ? $e->getMessage() : $e::class;
+
+        return new WebsiteProbeResult(
+            status: WebsiteCheckStatus::Error,
+            httpStatusCode: null,
+            responseTimeMs: null,
+            errorMessage: Str::limit($message, self::ERROR_MESSAGE_LIMIT, '…'),
+        );
+    }
+
+    /**
+     * `error_message` is set on Down/Error rows for surfacing in the
+     * UI; Up/Slow leaves it null. Down captures the response body's
+     * first line so an HTTP-level "Service Unavailable" surfaces in
+     * the recent-checks list without needing a separate column.
+     */
+    private function errorMessageFor(WebsiteCheckStatus $status, Response $response): ?string
+    {
+        if ($status === WebsiteCheckStatus::Up || $status === WebsiteCheckStatus::Slow) {
+            return null;
+        }
+
+        $body = trim((string) $response->body());
+
+        if ($body === '') {
+            return "HTTP {$response->status()}";
+        }
+
+        // Snip to first line for a stable preview, then cap to 500.
+        $firstLine = strtok($body, "\n") ?: $body;
+
+        return Str::limit("HTTP {$response->status()}: {$firstLine}", self::ERROR_MESSAGE_LIMIT, '…');
+    }
+}

--- a/app/Domain/Monitoring/Probes/WebsiteProbeResult.php
+++ b/app/Domain/Monitoring/Probes/WebsiteProbeResult.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Domain\Monitoring\Probes;
+
+use App\Enums\WebsiteCheckStatus;
+
+/**
+ * Immutable result of a single `RunWebsiteProbeAction` invocation.
+ *
+ * Carries everything `RecordWebsiteCheckAction` needs to persist a
+ * `WebsiteCheck` row + update the parent `Website.last_*` fields.
+ * No DB access here — pure data.
+ *
+ * `httpStatusCode` and `responseTimeMs` are nullable because a
+ * transport-level failure (DNS / timeout / connection refused / TLS)
+ * never produces them.
+ */
+final class WebsiteProbeResult
+{
+    public function __construct(
+        public readonly WebsiteCheckStatus $status,
+        public readonly ?int $httpStatusCode,
+        public readonly ?int $responseTimeMs,
+        public readonly ?string $errorMessage,
+    ) {}
+}

--- a/app/Enums/WebsiteCheckStatus.php
+++ b/app/Enums/WebsiteCheckStatus.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Outcome of a single recorded `WebsiteCheck` row (spec 023).
+ *
+ * Same value set as `WebsiteStatus` minus `pending` — a check only
+ * exists after a probe ran, so there's no pending state to model.
+ *
+ * Tones match the parent `WebsiteStatus` for visual consistency
+ * across the index list (parent status), the show page header
+ * (parent status), and the recent-checks list (per-row status).
+ */
+enum WebsiteCheckStatus: string
+{
+    case Up = 'up';
+    case Down = 'down';
+    case Slow = 'slow';
+    case Error = 'error';
+
+    public function badgeTone(): string
+    {
+        return match ($this) {
+            self::Up => 'success',
+            self::Down, self::Error => 'danger',
+            self::Slow => 'warning',
+        };
+    }
+}

--- a/app/Enums/WebsiteStatus.php
+++ b/app/Enums/WebsiteStatus.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Lifecycle of a website monitor (spec 023).
+ *
+ * - `pending` — created, never probed.
+ * - `up`      — last probe matched the expected status code.
+ * - `down`    — last probe responded but did not match the expected
+ *               status code.
+ * - `slow`    — last probe matched the expected status code but
+ *               exceeded the slow threshold (3000ms phase-1).
+ * - `error`   — last probe could not complete (DNS / timeout /
+ *               connection refused / TLS failure).
+ *
+ * Tones map to `StatusBadge`:
+ *   pending → muted (no signal yet)
+ *   up      → success
+ *   down    → danger
+ *   slow    → warning
+ *   error   → danger
+ */
+enum WebsiteStatus: string
+{
+    case Pending = 'pending';
+    case Up = 'up';
+    case Down = 'down';
+    case Slow = 'slow';
+    case Error = 'error';
+
+    public function badgeTone(): string
+    {
+        return match ($this) {
+            self::Pending => 'muted',
+            self::Up => 'success',
+            self::Down, self::Error => 'danger',
+            self::Slow => 'warning',
+        };
+    }
+}

--- a/app/Http/Controllers/Monitoring/WebsiteController.php
+++ b/app/Http/Controllers/Monitoring/WebsiteController.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace App\Http\Controllers\Monitoring;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Monitoring\StoreWebsiteRequest;
+use App\Http\Requests\Monitoring\UpdateWebsiteRequest;
+use App\Models\Project;
+use App\Models\Website;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Resourceful CRUD for website monitors (spec 023). The page family
+ * lives at `/monitoring/websites/*` so phase-6 hosts can sit beside
+ * it as `/monitoring/hosts/*`.
+ *
+ * The cross-project `index` is the default view; per-project filtering
+ * lives behind a `?project_id=N` query string. Multi-tenant team
+ * scoping arrives uniformly when teams ship.
+ */
+class WebsiteController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $this->authorize('viewAny', Website::class);
+
+        $user = $request->user();
+
+        $websites = Website::query()
+            ->with('project:id,slug,name,color,icon,owner_user_id')
+            ->whereHas('project', fn ($q) => $q->where('owner_user_id', $user->id))
+            ->orderBy('name')
+            ->get()
+            ->map(fn (Website $website) => $this->transform($website));
+
+        return Inertia::render('Monitoring/Websites/Index', [
+            'websites' => $websites,
+        ]);
+    }
+
+    public function create(Request $request): Response
+    {
+        $user = $request->user();
+
+        // Pre-select via `?project_id=N` so the link from a project
+        // page lands on the right project.
+        $preselect = $request->integer('project_id') ?: null;
+        $project = $preselect !== null
+            ? Project::query()->where('owner_user_id', $user->id)->find($preselect)
+            : null;
+
+        $this->authorize('create', [Website::class, $project]);
+
+        return Inertia::render('Monitoring/Websites/Create', [
+            'projects' => $this->ownedProjects($user->id),
+            'preselectedProjectId' => $project?->id,
+            'options' => $this->formOptions(),
+        ]);
+    }
+
+    public function store(StoreWebsiteRequest $request): RedirectResponse
+    {
+        // Belt-and-suspenders: the form request already authorised this,
+        // but re-authorising via the policy after validation guards
+        // against a stale prop slipping past (mirrors the
+        // `RepositoryController::store` pattern).
+        $this->authorize('create', [Website::class, $request->resolvedProject()]);
+
+        $website = Website::query()->create($request->validated());
+
+        return redirect()
+            ->route('monitoring.websites.show', $website)
+            ->with('status', "Monitor created for {$website->name}.");
+    }
+
+    public function show(Request $request, Website $website): Response
+    {
+        $this->authorize('view', $website);
+
+        $website->loadMissing('project:id,slug,name,color,icon,owner_user_id');
+
+        $checks = $website->checks()
+            ->orderByDesc('checked_at')
+            ->orderByDesc('id')
+            ->limit(50)
+            ->get()
+            ->map(fn ($check) => [
+                'id' => $check->id,
+                'status' => $check->status?->value,
+                'http_status_code' => $check->http_status_code,
+                'response_time_ms' => $check->response_time_ms,
+                'error_message' => $check->error_message,
+                'checked_at' => $check->checked_at?->diffForHumans(),
+                'checked_at_iso' => $check->checked_at?->toIso8601String(),
+            ])
+            ->all();
+
+        return Inertia::render('Monitoring/Websites/Show', [
+            'website' => $this->transform($website),
+            'checks' => $checks,
+            'canUpdate' => $request->user()?->can('update', $website) ?? false,
+            'canDelete' => $request->user()?->can('delete', $website) ?? false,
+            'canProbe' => $request->user()?->can('probe', $website) ?? false,
+        ]);
+    }
+
+    public function edit(Request $request, Website $website): Response
+    {
+        $this->authorize('update', $website);
+
+        return Inertia::render('Monitoring/Websites/Edit', [
+            'website' => $this->transform($website),
+            'projects' => $this->ownedProjects($request->user()->id),
+            'options' => $this->formOptions(),
+        ]);
+    }
+
+    public function update(UpdateWebsiteRequest $request, Website $website): RedirectResponse
+    {
+        $website->update($request->validated());
+
+        return redirect()
+            ->route('monitoring.websites.show', $website)
+            ->with('status', 'Monitor updated.');
+    }
+
+    public function destroy(Website $website): RedirectResponse
+    {
+        $this->authorize('delete', $website);
+
+        $website->delete();
+
+        return redirect()
+            ->route('monitoring.websites.index')
+            ->with('status', 'Monitor deleted.');
+    }
+
+    /**
+     * Single source of truth for the website JSON shape. Centralised so
+     * Index/Show/Edit don't drift on field set.
+     */
+    private function transform(Website $website): array
+    {
+        return [
+            'id' => $website->id,
+            'name' => $website->name,
+            'url' => $website->url,
+            'method' => $website->method,
+            'expected_status_code' => $website->expected_status_code,
+            'timeout_ms' => $website->timeout_ms,
+            'check_interval_seconds' => $website->check_interval_seconds,
+            'status' => $website->status?->value,
+            'last_checked_at' => $website->last_checked_at?->diffForHumans(),
+            'last_success_at' => $website->last_success_at?->diffForHumans(),
+            'last_failure_at' => $website->last_failure_at?->diffForHumans(),
+            'project' => $website->project ? [
+                'id' => $website->project->id,
+                'slug' => $website->project->slug,
+                'name' => $website->project->name,
+                'color' => $website->project->color,
+                'icon' => $website->project->icon,
+            ] : null,
+        ];
+    }
+
+    /**
+     * Project dropdown payload — only projects the user owns. Cheap
+     * query; called from `create` + `edit`.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function ownedProjects(int $userId): array
+    {
+        return Project::query()
+            ->where('owner_user_id', $userId)
+            ->orderBy('name')
+            ->get(['id', 'name', 'color'])
+            ->map(fn (Project $project) => [
+                'id' => $project->id,
+                'name' => $project->name,
+                'color' => $project->color,
+            ])
+            ->all();
+    }
+
+    /**
+     * Static option lists for the Create/Edit forms. Kept on the
+     * server so the Vue layer doesn't drift from the validation rules.
+     */
+    private function formOptions(): array
+    {
+        return [
+            'methods' => [
+                ['value' => 'GET', 'label' => 'GET'],
+                ['value' => 'HEAD', 'label' => 'HEAD'],
+                ['value' => 'POST', 'label' => 'POST'],
+            ],
+            'common_intervals' => [
+                ['value' => 60, 'label' => 'Every minute'],
+                ['value' => 300, 'label' => 'Every 5 minutes'],
+                ['value' => 900, 'label' => 'Every 15 minutes'],
+                ['value' => 3600, 'label' => 'Hourly'],
+            ],
+        ];
+    }
+}

--- a/app/Http/Controllers/Monitoring/WebsiteController.php
+++ b/app/Http/Controllers/Monitoring/WebsiteController.php
@@ -43,20 +43,25 @@ class WebsiteController extends Controller
 
     public function create(Request $request): Response
     {
+        $this->authorize('viewAny', Website::class);
+
         $user = $request->user();
 
         // Pre-select via `?project_id=N` so the link from a project
-        // page lands on the right project.
-        $preselect = $request->integer('project_id') ?: null;
-        $project = $preselect !== null
-            ? Project::query()->where('owner_user_id', $user->id)->find($preselect)
+        // page lands on the right project. If the project ID resolves
+        // to one the user owns we authorise create against it; if it
+        // resolves to a foreign project (or doesn't resolve at all),
+        // we drop the preselect rather than 403'ing the form — the
+        // user still needs to see the page to pick one of their own
+        // projects, and `store` will re-authorise at submit time.
+        $preselectId = $request->integer('project_id') ?: null;
+        $preselect = $preselectId !== null
+            ? Project::query()->where('owner_user_id', $user->id)->find($preselectId)
             : null;
-
-        $this->authorize('create', [Website::class, $project]);
 
         return Inertia::render('Monitoring/Websites/Create', [
             'projects' => $this->ownedProjects($user->id),
-            'preselectedProjectId' => $project?->id,
+            'preselectedProjectId' => $preselect?->id,
             'options' => $this->formOptions(),
         ]);
     }

--- a/app/Http/Controllers/Monitoring/WebsiteProbeController.php
+++ b/app/Http/Controllers/Monitoring/WebsiteProbeController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Monitoring;
+
+use App\Domain\Monitoring\Actions\RecordWebsiteCheckAction;
+use App\Domain\Monitoring\Actions\RunWebsiteProbeAction;
+use App\Http\Controllers\Controller;
+use App\Models\Website;
+use Illuminate\Http\RedirectResponse;
+
+/**
+ * Manual "Probe now" button on the Website show page (spec 023).
+ *
+ * Sync probe — controller blocks until the probe completes (≤
+ * `timeout_ms`, default 10s) and flashes the persisted check back
+ * to the user. Spec 024's scheduler is where async becomes natural;
+ * the same `RecordWebsiteCheckAction` is reused on both paths so
+ * persistence semantics never drift.
+ */
+class WebsiteProbeController extends Controller
+{
+    public function __invoke(
+        Website $website,
+        RunWebsiteProbeAction $probe,
+        RecordWebsiteCheckAction $record,
+    ): RedirectResponse {
+        $this->authorize('probe', $website);
+
+        $result = $probe->execute($website);
+        $record->execute($website, $result);
+
+        $status = $result->status->value;
+        $message = $result->responseTimeMs !== null
+            ? "Probe complete — {$status} in {$result->responseTimeMs}ms."
+            : "Probe complete — {$status}.";
+
+        return back()->with('status', $message);
+    }
+}

--- a/app/Http/Requests/Monitoring/StoreWebsiteRequest.php
+++ b/app/Http/Requests/Monitoring/StoreWebsiteRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\Monitoring;
+
+use App\Models\Project;
+use App\Models\Website;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates the create-website form. Project ownership is
+ * authorised via the `WebsitePolicy::create` gate; the request also
+ * pins the field shapes to keep the controller branch-free.
+ */
+class StoreWebsiteRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $project = $this->resolvedProject();
+
+        return $this->user()?->can('create', [Website::class, $project]) === true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'project_id' => ['required', Rule::exists('projects', 'id')],
+            'name' => ['required', 'string', 'max:120'],
+            'url' => ['required', 'url', 'max:2048'],
+            'method' => ['required', Rule::in(['GET', 'HEAD', 'POST'])],
+            'expected_status_code' => ['required', 'integer', 'between:100,599'],
+            'timeout_ms' => ['required', 'integer', 'min:1000', 'max:60000'],
+            'check_interval_seconds' => ['required', 'integer', 'min:60', 'max:86400'],
+        ];
+    }
+
+    public function resolvedProject(): ?Project
+    {
+        $id = $this->input('project_id');
+
+        return $id !== null ? Project::query()->find($id) : null;
+    }
+}

--- a/app/Http/Requests/Monitoring/UpdateWebsiteRequest.php
+++ b/app/Http/Requests/Monitoring/UpdateWebsiteRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Monitoring;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates the edit-website form. The `project_id` is intentionally
+ * NOT editable post-create — moving a website between projects would
+ * orphan its check history's project context. Re-create if needed.
+ */
+class UpdateWebsiteRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $website = $this->route('website');
+
+        return $website !== null
+            && $this->user()?->can('update', $website) === true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:120'],
+            'url' => ['required', 'url', 'max:2048'],
+            'method' => ['required', Rule::in(['GET', 'HEAD', 'POST'])],
+            'expected_status_code' => ['required', 'integer', 'between:100,599'],
+            'timeout_ms' => ['required', 'integer', 'min:1000', 'max:60000'],
+            'check_interval_seconds' => ['required', 'integer', 'min:60', 'max:86400'],
+        ];
+    }
+}

--- a/app/Models/Website.php
+++ b/app/Models/Website.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\WebsiteStatus;
+use Database\Factories\WebsiteFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Website extends Model
+{
+    /** @use HasFactory<WebsiteFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'project_id',
+        'name',
+        'url',
+        'method',
+        'expected_status_code',
+        'timeout_ms',
+        'check_interval_seconds',
+        'status',
+        'last_checked_at',
+        'last_success_at',
+        'last_failure_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => WebsiteStatus::class,
+            'expected_status_code' => 'integer',
+            'timeout_ms' => 'integer',
+            'check_interval_seconds' => 'integer',
+            'last_checked_at' => 'datetime',
+            'last_success_at' => 'datetime',
+            'last_failure_at' => 'datetime',
+        ];
+    }
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function checks(): HasMany
+    {
+        return $this->hasMany(WebsiteCheck::class);
+    }
+}

--- a/app/Models/WebsiteCheck.php
+++ b/app/Models/WebsiteCheck.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\WebsiteCheckStatus;
+use Database\Factories\WebsiteCheckFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WebsiteCheck extends Model
+{
+    /** @use HasFactory<WebsiteCheckFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'website_id',
+        'status',
+        'http_status_code',
+        'response_time_ms',
+        'error_message',
+        'checked_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => WebsiteCheckStatus::class,
+            'http_status_code' => 'integer',
+            'response_time_ms' => 'integer',
+            'checked_at' => 'datetime',
+        ];
+    }
+
+    public function website(): BelongsTo
+    {
+        return $this->belongsTo(Website::class);
+    }
+}

--- a/app/Policies/WebsitePolicy.php
+++ b/app/Policies/WebsitePolicy.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Project;
+use App\Models\User;
+use App\Models\Website;
+
+/**
+ * Authorization for website monitors. Mirrors `RepositoryPolicy`:
+ * create/update/delete/probe are gated to the project owner;
+ * viewing is open to any verified user (single-tenant phase-1).
+ */
+class WebsitePolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->hasVerifiedEmail();
+    }
+
+    public function view(User $user, Website $website): bool
+    {
+        return $user->hasVerifiedEmail();
+    }
+
+    /**
+     * `create` is project-scoped — invoked via
+     * `Gate::authorize('create', [Website::class, $project])`.
+     */
+    public function create(User $user, ?Project $project): bool
+    {
+        return $project !== null
+            && $user->hasVerifiedEmail()
+            && $user->can('update', $project);
+    }
+
+    public function update(User $user, Website $website): bool
+    {
+        $project = $website->project;
+
+        return $project !== null
+            && $user->hasVerifiedEmail()
+            && $user->can('update', $project);
+    }
+
+    public function delete(User $user, Website $website): bool
+    {
+        return $this->update($user, $website);
+    }
+
+    /** Manual "Probe now" button reuses the update gate. */
+    public function probe(User $user, Website $website): bool
+    {
+        return $this->update($user, $website);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,8 +4,10 @@ namespace App\Providers;
 
 use App\Models\Project;
 use App\Models\Repository;
+use App\Models\Website;
 use App\Policies\ProjectPolicy;
 use App\Policies\RepositoryPolicy;
+use App\Policies\WebsitePolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Vite;
@@ -30,6 +32,7 @@ class AppServiceProvider extends ServiceProvider
 
         Gate::policy(Project::class, ProjectPolicy::class);
         Gate::policy(Repository::class, RepositoryPolicy::class);
+        Gate::policy(Website::class, WebsitePolicy::class);
 
         // Force https URL generation when APP_URL is https. Required for
         // Cloudflare/ngrok tunnels: TLS terminates at the tunnel and

--- a/database/factories/WebsiteCheckFactory.php
+++ b/database/factories/WebsiteCheckFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\WebsiteCheckStatus;
+use App\Models\Website;
+use App\Models\WebsiteCheck;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<WebsiteCheck> */
+class WebsiteCheckFactory extends Factory
+{
+    protected $model = WebsiteCheck::class;
+
+    public function definition(): array
+    {
+        $status = fake()->randomElement([
+            WebsiteCheckStatus::Up,
+            WebsiteCheckStatus::Up,
+            WebsiteCheckStatus::Up,
+            WebsiteCheckStatus::Slow,
+            WebsiteCheckStatus::Down,
+            WebsiteCheckStatus::Error,
+        ]);
+
+        return [
+            'website_id' => Website::factory(),
+            'status' => $status->value,
+            'http_status_code' => $status === WebsiteCheckStatus::Error
+                ? null
+                : fake()->randomElement([200, 200, 200, 500, 503, 404]),
+            'response_time_ms' => $status === WebsiteCheckStatus::Error
+                ? null
+                : fake()->numberBetween(50, 4_000),
+            'error_message' => $status === WebsiteCheckStatus::Error
+                ? 'Connection timed out after 10000ms'
+                : null,
+            'checked_at' => fake()->dateTimeBetween('-7 days', 'now'),
+        ];
+    }
+}

--- a/database/factories/WebsiteFactory.php
+++ b/database/factories/WebsiteFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\WebsiteStatus;
+use App\Models\Project;
+use App\Models\Website;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<Website> */
+class WebsiteFactory extends Factory
+{
+    protected $model = Website::class;
+
+    public function definition(): array
+    {
+        return [
+            'project_id' => Project::factory(),
+            'name' => fake()->words(2, true),
+            'url' => fake()->url(),
+            'method' => 'GET',
+            'expected_status_code' => 200,
+            'timeout_ms' => 10_000,
+            'check_interval_seconds' => 300,
+            'status' => WebsiteStatus::Pending->value,
+            'last_checked_at' => null,
+            'last_success_at' => null,
+            'last_failure_at' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_04_30_130000_create_websites_table.php
+++ b/database/migrations/2026_04_30_130000_create_websites_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('websites', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('project_id')
+                ->constrained('projects')
+                ->cascadeOnDelete();
+
+            $table->string('name');
+            $table->string('url');
+
+            // HTTP method for the probe; phase-1 supports GET/HEAD/POST.
+            // Stored as a short string rather than an enum so we can
+            // accept new RFC-listed methods later without a migration.
+            $table->string('method', 8)->default('GET');
+
+            $table->unsignedSmallInteger('expected_status_code')->default(200);
+            $table->unsignedInteger('timeout_ms')->default(10_000);
+            $table->unsignedInteger('check_interval_seconds')->default(300);
+
+            // pending | up | down | slow | error (per WebsiteStatus enum).
+            // `pending` is the initial state — created but never probed.
+            $table->string('status', 16)->default('pending');
+
+            $table->timestamp('last_checked_at')->nullable();
+            $table->timestamp('last_success_at')->nullable();
+            $table->timestamp('last_failure_at')->nullable();
+
+            $table->timestamps();
+
+            // Per-project listing + status filter on the index page.
+            $table->index(['project_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('websites');
+    }
+};

--- a/database/migrations/2026_04_30_130001_create_website_checks_table.php
+++ b/database/migrations/2026_04_30_130001_create_website_checks_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('website_checks', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('website_id')
+                ->constrained('websites')
+                ->cascadeOnDelete();
+
+            // up | down | slow | error (per WebsiteCheckStatus enum).
+            // No `pending` — a recorded check row only exists once a
+            // probe ran.
+            $table->string('status', 8);
+
+            // Nullable: a transport-level error (DNS, timeout) won't
+            // produce an HTTP status code or a response time.
+            $table->unsignedSmallInteger('http_status_code')->nullable();
+            // Wall-clock time from request dispatch to response receipt
+            // — includes DNS / TCP / TLS / send / receive. Spec 023's
+            // MVP probe doesn't break out per-leg timings; a future
+            // spec adds dns_time_ms / connect_time_ms / tls_time_ms /
+            // ttfb_ms columns alongside this aggregate.
+            $table->unsignedInteger('response_time_ms')->nullable();
+
+            // Free-text error captured from the exception. Capped at
+            // 500 chars in the action layer (parallel to spec 020's
+            // sync error storage on repositories).
+            $table->text('error_message')->nullable();
+
+            $table->timestamp('checked_at');
+
+            $table->timestamps();
+
+            // Per-website history listing on the Show page.
+            $table->index(['website_id', 'checked_at']);
+            // Status filter for spec 024's uptime aggregate.
+            $table->index('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('website_checks');
+    }
+};

--- a/resources/js/Components/Sidebar/Sidebar.vue
+++ b/resources/js/Components/Sidebar/Sidebar.vue
@@ -43,7 +43,7 @@ const nav: NavItem[] = [
     { label: 'Pipelines', icon: Activity, disabled: true, soonLabel: 'Phase 4' },
     { label: 'Deployments', icon: Rocket, routeName: 'deployments.index' },
     { label: 'Hosts', icon: Server, disabled: true, soonLabel: 'Phase 6' },
-    { label: 'Monitoring', icon: Globe, disabled: true, soonLabel: 'Phase 5' },
+    { label: 'Monitoring', icon: Globe, routeName: 'monitoring.websites.index' },
     { label: 'Analytics', icon: BarChart3, disabled: true, soonLabel: 'Phase 8' },
     { label: 'Alerts', icon: Bell, disabled: true, soonLabel: 'Phase 7' },
     { label: 'Activity', icon: History, routeName: 'activity.index' },

--- a/resources/js/Pages/Monitoring/Websites/Create.vue
+++ b/resources/js/Pages/Monitoring/Websites/Create.vue
@@ -1,0 +1,203 @@
+<script setup lang="ts">
+import InputError from '@/Components/InputError.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import { ChevronLeft } from 'lucide-vue-next';
+
+interface ProjectOption {
+    id: number;
+    name: string;
+    color: string | null;
+}
+
+interface MethodOption {
+    value: string;
+    label: string;
+}
+
+interface IntervalOption {
+    value: number;
+    label: string;
+}
+
+const props = defineProps<{
+    projects: ProjectOption[];
+    preselectedProjectId: number | null;
+    options: {
+        methods: MethodOption[];
+        common_intervals: IntervalOption[];
+    };
+}>();
+
+const form = useForm({
+    project_id: props.preselectedProjectId ?? props.projects[0]?.id ?? null,
+    name: '',
+    url: '',
+    method: 'GET',
+    expected_status_code: 200,
+    timeout_ms: 10000,
+    check_interval_seconds: 300,
+});
+
+const submit = () => {
+    form.post(route('monitoring.websites.store'));
+};
+</script>
+
+<template>
+    <Head title="New monitor" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <Link
+                    :href="route('monitoring.websites.index')"
+                    class="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan transition hover:text-accent-cyan/80"
+                >
+                    <ChevronLeft class="h-3 w-3" aria-hidden="true" />
+                    Monitoring
+                </Link>
+                <h1 class="text-lg font-semibold text-text-primary">
+                    New monitor
+                </h1>
+            </div>
+        </template>
+
+        <div class="mx-auto max-w-2xl px-4 py-6 sm:px-6 lg:px-8">
+            <form
+                class="glass-card flex flex-col gap-5 p-6"
+                @submit.prevent="submit"
+            >
+                <div class="flex flex-col gap-2">
+                    <InputLabel for="project_id" value="Project" />
+                    <select
+                        id="project_id"
+                        v-model.number="form.project_id"
+                        class="rounded-md border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:border-accent-cyan/60 focus:outline-none"
+                    >
+                        <option
+                            v-for="project in projects"
+                            :key="project.id"
+                            :value="project.id"
+                        >
+                            {{ project.name }}
+                        </option>
+                    </select>
+                    <InputError :message="form.errors.project_id" />
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <InputLabel for="name" value="Name" />
+                    <TextInput
+                        id="name"
+                        v-model="form.name"
+                        type="text"
+                        placeholder="Marketing site"
+                        autofocus
+                    />
+                    <InputError :message="form.errors.name" />
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <InputLabel for="url" value="URL" />
+                    <TextInput
+                        id="url"
+                        v-model="form.url"
+                        type="url"
+                        placeholder="https://example.com/health"
+                    />
+                    <InputError :message="form.errors.url" />
+                </div>
+
+                <div class="grid grid-cols-2 gap-4">
+                    <div class="flex flex-col gap-2">
+                        <InputLabel for="method" value="HTTP method" />
+                        <select
+                            id="method"
+                            v-model="form.method"
+                            class="rounded-md border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:border-accent-cyan/60 focus:outline-none"
+                        >
+                            <option
+                                v-for="opt in options.methods"
+                                :key="opt.value"
+                                :value="opt.value"
+                            >
+                                {{ opt.label }}
+                            </option>
+                        </select>
+                        <InputError :message="form.errors.method" />
+                    </div>
+                    <div class="flex flex-col gap-2">
+                        <InputLabel
+                            for="expected_status_code"
+                            value="Expected status code"
+                        />
+                        <input
+                            id="expected_status_code"
+                            v-model.number="form.expected_status_code"
+                            type="number"
+                            min="100"
+                            max="599"
+                            class="rounded-lg border border-border-subtle bg-slate-950/60 px-3 py-2 text-text-primary placeholder:text-text-muted shadow-inner shadow-black/20 transition focus:border-accent-cyan focus:ring-2 focus:ring-accent-cyan/40 focus:ring-offset-0"
+                        />
+                        <InputError
+                            :message="form.errors.expected_status_code"
+                        />
+                    </div>
+                </div>
+
+                <div class="grid grid-cols-2 gap-4">
+                    <div class="flex flex-col gap-2">
+                        <InputLabel for="timeout_ms" value="Timeout (ms)" />
+                        <input
+                            id="timeout_ms"
+                            v-model.number="form.timeout_ms"
+                            type="number"
+                            min="1000"
+                            max="60000"
+                            class="rounded-lg border border-border-subtle bg-slate-950/60 px-3 py-2 text-text-primary placeholder:text-text-muted shadow-inner shadow-black/20 transition focus:border-accent-cyan focus:ring-2 focus:ring-accent-cyan/40 focus:ring-offset-0"
+                        />
+                        <InputError :message="form.errors.timeout_ms" />
+                    </div>
+                    <div class="flex flex-col gap-2">
+                        <InputLabel
+                            for="check_interval_seconds"
+                            value="Check interval"
+                        />
+                        <select
+                            id="check_interval_seconds"
+                            v-model.number="form.check_interval_seconds"
+                            class="rounded-md border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:border-accent-cyan/60 focus:outline-none"
+                        >
+                            <option
+                                v-for="opt in options.common_intervals"
+                                :key="opt.value"
+                                :value="opt.value"
+                            >
+                                {{ opt.label }}
+                            </option>
+                        </select>
+                        <InputError
+                            :message="form.errors.check_interval_seconds"
+                        />
+                    </div>
+                </div>
+
+                <div class="flex items-center justify-end gap-3">
+                    <Link
+                        :href="route('monitoring.websites.index')"
+                        class="text-sm font-semibold text-text-secondary hover:text-text-primary"
+                    >
+                        Cancel
+                    </Link>
+                    <PrimaryButton :disabled="form.processing">
+                        Create monitor
+                    </PrimaryButton>
+                </div>
+            </form>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Monitoring/Websites/Edit.vue
+++ b/resources/js/Pages/Monitoring/Websites/Edit.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+import InputError from '@/Components/InputError.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import { ChevronLeft } from 'lucide-vue-next';
+
+interface WebsiteShape {
+    id: number;
+    name: string;
+    url: string;
+    method: string;
+    expected_status_code: number;
+    timeout_ms: number;
+    check_interval_seconds: number;
+}
+
+interface MethodOption {
+    value: string;
+    label: string;
+}
+
+interface IntervalOption {
+    value: number;
+    label: string;
+}
+
+const props = defineProps<{
+    website: WebsiteShape;
+    options: {
+        methods: MethodOption[];
+        common_intervals: IntervalOption[];
+    };
+}>();
+
+const form = useForm({
+    name: props.website.name,
+    url: props.website.url,
+    method: props.website.method,
+    expected_status_code: props.website.expected_status_code,
+    timeout_ms: props.website.timeout_ms,
+    check_interval_seconds: props.website.check_interval_seconds,
+});
+
+const submit = () => {
+    form.patch(route('monitoring.websites.update', props.website.id));
+};
+</script>
+
+<template>
+    <Head :title="`Edit ${website.name}`" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <Link
+                    :href="route('monitoring.websites.show', website.id)"
+                    class="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan transition hover:text-accent-cyan/80"
+                >
+                    <ChevronLeft class="h-3 w-3" aria-hidden="true" />
+                    {{ website.name }}
+                </Link>
+                <h1 class="text-lg font-semibold text-text-primary">
+                    Edit monitor
+                </h1>
+            </div>
+        </template>
+
+        <div class="mx-auto max-w-2xl px-4 py-6 sm:px-6 lg:px-8">
+            <form
+                class="glass-card flex flex-col gap-5 p-6"
+                @submit.prevent="submit"
+            >
+                <div class="flex flex-col gap-2">
+                    <InputLabel for="name" value="Name" />
+                    <TextInput id="name" v-model="form.name" type="text" />
+                    <InputError :message="form.errors.name" />
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <InputLabel for="url" value="URL" />
+                    <TextInput id="url" v-model="form.url" type="url" />
+                    <InputError :message="form.errors.url" />
+                </div>
+
+                <div class="grid grid-cols-2 gap-4">
+                    <div class="flex flex-col gap-2">
+                        <InputLabel for="method" value="HTTP method" />
+                        <select
+                            id="method"
+                            v-model="form.method"
+                            class="rounded-md border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:border-accent-cyan/60 focus:outline-none"
+                        >
+                            <option
+                                v-for="opt in options.methods"
+                                :key="opt.value"
+                                :value="opt.value"
+                            >
+                                {{ opt.label }}
+                            </option>
+                        </select>
+                        <InputError :message="form.errors.method" />
+                    </div>
+                    <div class="flex flex-col gap-2">
+                        <InputLabel
+                            for="expected_status_code"
+                            value="Expected status code"
+                        />
+                        <input
+                            id="expected_status_code"
+                            v-model.number="form.expected_status_code"
+                            type="number"
+                            min="100"
+                            max="599"
+                            class="rounded-lg border border-border-subtle bg-slate-950/60 px-3 py-2 text-text-primary placeholder:text-text-muted shadow-inner shadow-black/20 transition focus:border-accent-cyan focus:ring-2 focus:ring-accent-cyan/40 focus:ring-offset-0"
+                        />
+                        <InputError
+                            :message="form.errors.expected_status_code"
+                        />
+                    </div>
+                </div>
+
+                <div class="grid grid-cols-2 gap-4">
+                    <div class="flex flex-col gap-2">
+                        <InputLabel for="timeout_ms" value="Timeout (ms)" />
+                        <input
+                            id="timeout_ms"
+                            v-model.number="form.timeout_ms"
+                            type="number"
+                            min="1000"
+                            max="60000"
+                            class="rounded-lg border border-border-subtle bg-slate-950/60 px-3 py-2 text-text-primary placeholder:text-text-muted shadow-inner shadow-black/20 transition focus:border-accent-cyan focus:ring-2 focus:ring-accent-cyan/40 focus:ring-offset-0"
+                        />
+                        <InputError :message="form.errors.timeout_ms" />
+                    </div>
+                    <div class="flex flex-col gap-2">
+                        <InputLabel
+                            for="check_interval_seconds"
+                            value="Check interval"
+                        />
+                        <select
+                            id="check_interval_seconds"
+                            v-model.number="form.check_interval_seconds"
+                            class="rounded-md border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:border-accent-cyan/60 focus:outline-none"
+                        >
+                            <option
+                                v-for="opt in options.common_intervals"
+                                :key="opt.value"
+                                :value="opt.value"
+                            >
+                                {{ opt.label }}
+                            </option>
+                        </select>
+                        <InputError
+                            :message="form.errors.check_interval_seconds"
+                        />
+                    </div>
+                </div>
+
+                <div class="flex items-center justify-end gap-3">
+                    <Link
+                        :href="route('monitoring.websites.show', website.id)"
+                        class="text-sm font-semibold text-text-secondary hover:text-text-primary"
+                    >
+                        Cancel
+                    </Link>
+                    <PrimaryButton :disabled="form.processing">
+                        Save changes
+                    </PrimaryButton>
+                </div>
+            </form>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Monitoring/Websites/Index.vue
+++ b/resources/js/Pages/Monitoring/Websites/Index.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link } from '@inertiajs/vue3';
+import { ExternalLink, Globe, Plus } from 'lucide-vue-next';
+
+interface ProjectChip {
+    id: number;
+    slug: string;
+    name: string;
+    color: string | null;
+    icon: string | null;
+}
+
+interface WebsiteRow {
+    id: number;
+    name: string;
+    url: string;
+    method: string;
+    status:
+        | 'pending'
+        | 'up'
+        | 'down'
+        | 'slow'
+        | 'error'
+        | string
+        | null;
+    last_checked_at: string | null;
+    project: ProjectChip | null;
+}
+
+defineProps<{
+    websites: WebsiteRow[];
+}>();
+
+const statusTone = (status: string | null) =>
+    (
+        ({
+            pending: 'muted',
+            up: 'success',
+            down: 'danger',
+            slow: 'warning',
+            error: 'danger',
+        }) as const
+    )[status ?? ''] ?? 'muted';
+
+const projectAccentClass = (color: string | null) =>
+    (
+        ({
+            cyan: 'text-accent-cyan',
+            blue: 'text-accent-blue',
+            purple: 'text-accent-purple',
+            magenta: 'text-accent-magenta',
+            success: 'text-status-success',
+            warning: 'text-status-warning',
+        }) as const
+    )[color ?? ''] ?? 'text-text-muted';
+</script>
+
+<template>
+    <Head title="Monitoring · Websites" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <span
+                    class="text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan"
+                >
+                    Phase 5
+                </span>
+                <h1 class="text-lg font-semibold text-text-primary">
+                    Monitoring
+                </h1>
+            </div>
+        </template>
+
+        <div class="mx-auto max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
+            <header class="mb-6 flex flex-wrap items-end justify-between gap-3">
+                <div class="flex flex-col gap-2">
+                    <h2 class="text-xl font-semibold text-text-primary">
+                        Website monitors
+                    </h2>
+                    <p class="text-sm text-text-secondary">
+                        Health checks for the URLs you care about. Each
+                        monitor records response time and status code on
+                        every probe.
+                    </p>
+                </div>
+                <Link
+                    :href="route('monitoring.websites.create')"
+                    class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/15 px-3 py-2 text-sm font-semibold text-accent-cyan transition hover:border-accent-cyan/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                >
+                    <Plus class="h-4 w-4" aria-hidden="true" />
+                    Add monitor
+                </Link>
+            </header>
+
+            <div
+                v-if="websites.length === 0"
+                class="glass-card flex flex-col items-center justify-center gap-3 px-6 py-16 text-center"
+            >
+                <span
+                    class="flex h-12 w-12 items-center justify-center rounded-full border border-border-subtle bg-slate-950/60"
+                >
+                    <Globe
+                        class="h-5 w-5 text-text-muted"
+                        aria-hidden="true"
+                    />
+                </span>
+                <p class="text-sm font-medium text-text-secondary">
+                    No website monitors yet
+                </p>
+                <p class="max-w-sm text-xs text-text-muted">
+                    Add one to start tracking response times. Spec 024
+                    will run scheduled checks every interval; for now
+                    use the manual "Probe now" button on the detail
+                    page.
+                </p>
+            </div>
+
+            <ul v-else class="flex flex-col gap-2">
+                <li
+                    v-for="website in websites"
+                    :key="website.id"
+                >
+                    <Link
+                        :href="route('monitoring.websites.show', website.id)"
+                        class="glass-card flex items-center gap-4 px-4 py-3 transition hover:border-accent-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                    >
+                        <Globe
+                            class="h-4 w-4 shrink-0 text-text-muted"
+                            aria-hidden="true"
+                        />
+                        <div class="flex min-w-0 flex-1 flex-col gap-1">
+                            <div class="flex items-center gap-2">
+                                <span
+                                    class="truncate text-sm font-semibold text-text-primary"
+                                >
+                                    {{ website.name }}
+                                </span>
+                                <span
+                                    v-if="website.project"
+                                    class="inline-flex items-center gap-1 rounded-full border border-current/30 px-1.5 py-0.5 text-[10px] font-mono uppercase tracking-[0.18em]"
+                                    :class="projectAccentClass(website.project.color)"
+                                >
+                                    {{ website.project.name }}
+                                </span>
+                            </div>
+                            <p
+                                class="flex flex-wrap items-center gap-x-2 gap-y-1 truncate text-xs text-text-muted"
+                            >
+                                <span class="font-mono text-text-secondary">
+                                    {{ website.method }}
+                                </span>
+                                <span class="truncate font-mono">
+                                    {{ website.url }}
+                                </span>
+                                <span v-if="website.last_checked_at">
+                                    · Last checked
+                                    {{ website.last_checked_at }}
+                                </span>
+                            </p>
+                        </div>
+                        <div class="flex shrink-0 items-center gap-2">
+                            <StatusBadge :tone="statusTone(website.status)">
+                                {{ website.status }}
+                            </StatusBadge>
+                            <a
+                                :href="website.url"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="text-text-muted transition hover:text-accent-cyan"
+                                :aria-label="`Open ${website.name} in a new tab`"
+                                @click.stop
+                            >
+                                <ExternalLink
+                                    class="h-4 w-4"
+                                    aria-hidden="true"
+                                />
+                            </a>
+                        </div>
+                    </Link>
+                </li>
+            </ul>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Monitoring/Websites/Show.vue
+++ b/resources/js/Pages/Monitoring/Websites/Show.vue
@@ -1,0 +1,298 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import {
+    AlertTriangle,
+    ChevronLeft,
+    ExternalLink,
+    Pencil,
+    Play,
+    Trash2,
+} from 'lucide-vue-next';
+
+interface ProjectChip {
+    id: number;
+    slug: string;
+    name: string;
+    color: string | null;
+    icon: string | null;
+}
+
+interface WebsiteShape {
+    id: number;
+    name: string;
+    url: string;
+    method: string;
+    expected_status_code: number;
+    timeout_ms: number;
+    check_interval_seconds: number;
+    status: string | null;
+    last_checked_at: string | null;
+    last_success_at: string | null;
+    last_failure_at: string | null;
+    project: ProjectChip | null;
+}
+
+interface CheckRow {
+    id: number;
+    status: 'up' | 'down' | 'slow' | 'error' | string | null;
+    http_status_code: number | null;
+    response_time_ms: number | null;
+    error_message: string | null;
+    checked_at: string | null;
+    checked_at_iso: string | null;
+}
+
+const props = defineProps<{
+    website: WebsiteShape;
+    checks: CheckRow[];
+    canUpdate: boolean;
+    canDelete: boolean;
+    canProbe: boolean;
+}>();
+
+const statusTone = (status: string | null) =>
+    (
+        ({
+            pending: 'muted',
+            up: 'success',
+            down: 'danger',
+            slow: 'warning',
+            error: 'danger',
+        }) as const
+    )[status ?? ''] ?? 'muted';
+
+const projectAccentClass = (color: string | null) =>
+    (
+        ({
+            cyan: 'text-accent-cyan',
+            blue: 'text-accent-blue',
+            purple: 'text-accent-purple',
+            magenta: 'text-accent-magenta',
+            success: 'text-status-success',
+            warning: 'text-status-warning',
+        }) as const
+    )[color ?? ''] ?? 'text-text-muted';
+
+const runProbe = () => {
+    if (!props.canProbe) return;
+    router.post(
+        route('monitoring.websites.probe', props.website.id),
+        {},
+        { preserveScroll: true },
+    );
+};
+
+const confirmDelete = () => {
+    if (!props.canDelete) return;
+    if (
+        !window.confirm(
+            `Delete monitor ${props.website.name}? This removes all check history.`,
+        )
+    ) {
+        return;
+    }
+    router.delete(route('monitoring.websites.destroy', props.website.id));
+};
+</script>
+
+<template>
+    <Head :title="website.name" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <Link
+                    :href="route('monitoring.websites.index')"
+                    class="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan transition hover:text-accent-cyan/80"
+                >
+                    <ChevronLeft class="h-3 w-3" aria-hidden="true" />
+                    Monitoring
+                </Link>
+                <h1 class="text-lg font-semibold text-text-primary">
+                    {{ website.name }}
+                </h1>
+            </div>
+        </template>
+
+        <div class="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
+            <header class="glass-card flex flex-col gap-4 p-6">
+                <div class="flex flex-wrap items-start justify-between gap-3">
+                    <div class="flex flex-col gap-2">
+                        <div class="flex flex-wrap items-center gap-2">
+                            <StatusBadge :tone="statusTone(website.status)">
+                                {{ website.status }}
+                            </StatusBadge>
+                            <span
+                                v-if="website.project"
+                                class="inline-flex items-center gap-1 rounded-full border border-current/30 px-1.5 py-0.5 text-[10px] font-mono uppercase tracking-[0.18em]"
+                                :class="projectAccentClass(website.project.color)"
+                            >
+                                {{ website.project.name }}
+                            </span>
+                        </div>
+                        <a
+                            :href="website.url"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="inline-flex items-center gap-1.5 truncate font-mono text-sm text-text-secondary transition hover:text-accent-cyan"
+                        >
+                            <span class="font-mono text-text-muted">{{ website.method }}</span>
+                            {{ website.url }}
+                            <ExternalLink
+                                class="h-3.5 w-3.5"
+                                aria-hidden="true"
+                            />
+                        </a>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <button
+                            v-if="canProbe"
+                            type="button"
+                            class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/15 px-3 py-2 text-sm font-semibold text-accent-cyan transition hover:border-accent-cyan/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                            @click="runProbe"
+                        >
+                            <Play class="h-4 w-4" aria-hidden="true" />
+                            Probe now
+                        </button>
+                        <Link
+                            v-if="canUpdate"
+                            :href="route('monitoring.websites.edit', website.id)"
+                            class="inline-flex items-center gap-2 rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm font-semibold text-text-secondary transition hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                        >
+                            <Pencil class="h-4 w-4" aria-hidden="true" />
+                            Edit
+                        </Link>
+                        <button
+                            v-if="canDelete"
+                            type="button"
+                            class="inline-flex items-center gap-2 rounded-lg border border-status-danger/40 bg-status-danger/10 px-3 py-2 text-sm font-semibold text-status-danger transition hover:border-status-danger/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-status-danger/60"
+                            @click="confirmDelete"
+                        >
+                            <Trash2 class="h-4 w-4" aria-hidden="true" />
+                            Delete
+                        </button>
+                    </div>
+                </div>
+
+                <dl
+                    class="grid grid-cols-2 gap-4 border-t border-border-subtle pt-4 text-sm sm:grid-cols-4"
+                >
+                    <div class="flex flex-col gap-1">
+                        <dt
+                            class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                        >
+                            Expected
+                        </dt>
+                        <dd class="font-mono text-text-secondary">
+                            {{ website.expected_status_code }}
+                        </dd>
+                    </div>
+                    <div class="flex flex-col gap-1">
+                        <dt
+                            class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                        >
+                            Timeout
+                        </dt>
+                        <dd class="font-mono text-text-secondary">
+                            {{ website.timeout_ms }}ms
+                        </dd>
+                    </div>
+                    <div class="flex flex-col gap-1">
+                        <dt
+                            class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                        >
+                            Interval
+                        </dt>
+                        <dd class="font-mono text-text-secondary">
+                            {{ website.check_interval_seconds }}s
+                        </dd>
+                    </div>
+                    <div class="flex flex-col gap-1">
+                        <dt
+                            class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                        >
+                            Last checked
+                        </dt>
+                        <dd class="text-text-secondary">
+                            {{ website.last_checked_at ?? '—' }}
+                        </dd>
+                    </div>
+                </dl>
+            </header>
+
+            <section class="glass-card p-6 sm:p-8">
+                <header
+                    class="flex flex-wrap items-center justify-between gap-3 border-b border-border-subtle pb-4"
+                >
+                    <h3 class="text-sm font-semibold text-text-primary">
+                        Recent checks
+                    </h3>
+                    <span class="text-xs text-text-muted">
+                        Up to 50 most recent
+                    </span>
+                </header>
+
+                <ul
+                    v-if="checks.length > 0"
+                    class="mt-2 divide-y divide-border-subtle"
+                >
+                    <li
+                        v-for="check in checks"
+                        :key="check.id"
+                        class="flex items-center gap-4 py-3"
+                    >
+                        <StatusBadge :tone="statusTone(check.status)">
+                            {{ check.status }}
+                        </StatusBadge>
+                        <div class="flex min-w-0 flex-1 flex-col gap-1">
+                            <p
+                                class="flex flex-wrap items-center gap-x-2 text-xs text-text-muted"
+                            >
+                                <span
+                                    v-if="check.http_status_code"
+                                    class="font-mono text-text-secondary"
+                                >
+                                    HTTP {{ check.http_status_code }}
+                                </span>
+                                <span
+                                    v-if="check.response_time_ms !== null"
+                                    class="font-mono text-text-secondary"
+                                >
+                                    {{ check.response_time_ms }}ms
+                                </span>
+                                <span v-if="check.checked_at">
+                                    · {{ check.checked_at }}
+                                </span>
+                            </p>
+                            <p
+                                v-if="check.error_message"
+                                class="flex items-start gap-1.5 text-xs text-status-danger"
+                            >
+                                <AlertTriangle
+                                    class="mt-0.5 h-3 w-3 shrink-0"
+                                    aria-hidden="true"
+                                />
+                                <span class="break-words font-mono text-text-secondary">
+                                    {{ check.error_message }}
+                                </span>
+                            </p>
+                        </div>
+                    </li>
+                </ul>
+
+                <p
+                    v-else
+                    class="mt-6 rounded-lg border border-dashed border-border-subtle bg-background-panel-hover/30 p-4 text-sm text-text-muted"
+                >
+                    No checks yet.
+                    <span v-if="canProbe">
+                        Click <span class="font-mono">Probe now</span> to run
+                        the first one.
+                    </span>
+                </p>
+            </section>
+        </div>
+    </AppLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,8 @@ use App\Http\Controllers\ActivityController;
 use App\Http\Controllers\DeploymentController;
 use App\Http\Controllers\GithubConnectionController;
 use App\Http\Controllers\GithubRepositoryImportController;
+use App\Http\Controllers\Monitoring\WebsiteController;
+use App\Http\Controllers\Monitoring\WebsiteProbeController;
 use App\Http\Controllers\OverviewController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ProjectController;
@@ -88,6 +90,14 @@ Route::middleware(['auth', 'verified'])->group(function () {
     // Spec 021 — cross-repo deployment timeline (workflow runs).
     Route::get('/deployments', [DeploymentController::class, 'index'])
         ->name('deployments.index');
+
+    // Spec 023 — website monitoring CRUD + manual probe.
+    // Nested under /monitoring/* so phase-6 hosts can sit beside it.
+    Route::resource('monitoring/websites', WebsiteController::class)
+        ->parameters(['websites' => 'website'])
+        ->names('monitoring.websites');
+    Route::post('/monitoring/websites/{website}/probe', WebsiteProbeController::class)
+        ->name('monitoring.websites.probe');
 });
 
 // Spec 017 — GitHub webhooks (no auth/CSRF; signature-verified inside).

--- a/specs/README.md
+++ b/specs/README.md
@@ -40,7 +40,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 2 | GitHub Integration MVP | 🟢 | 4/4 specs done (013–016). Phase complete. |
 | 3 | GitHub Webhooks & Activity Feed | 🟢 | 3/3 specs done (017–019). Phase complete. |
 | 4 | Deployments & CI/CD | 🟢 | 3/3 specs done (020–022). Phase complete. |
-| 5 | Website Monitoring | ⬜ | — |
+| 5 | Website Monitoring | 🟡 | 1/3 specs done (023). 024–025 next. |
 | 6 | Docker Host Agent MVP | ⬜ | — |
 | 7 | Alerts Engine | ⬜ | — |
 | 8 | Analytics & Health Scores | ⬜ | — |

--- a/specs/phase-5-monitoring/023-website-monitor-mvp.md
+++ b/specs/phase-5-monitoring/023-website-monitor-mvp.md
@@ -1,7 +1,7 @@
 ---
 spec: website-monitor-mvp
 phase: 5-monitoring
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-30
 updated: 2026-04-30
@@ -163,6 +163,13 @@ Dated notes as work progresses.
 ### 2026-04-30
 - Spec drafted.
 - Opened issue [#69](https://github.com/Copxer/nexus/issues/69) and branch `spec/023-website-monitor-mvp` off `main`.
+- Implementation complete. Two migrations + two enums + two models + two factories. `WebsiteProbeResult` DTO + `RunWebsiteProbeAction` (pure HTTP, classifies up/slow/down/error against the 3000ms hard threshold) + `RecordWebsiteCheckAction` (persists a `WebsiteCheck`, updates `Website.last_*`, treats `Slow` as success for `last_success_at`). `WebsitePolicy` gates create/update/delete/probe to project owners. `WebsiteController` resourceful CRUD + `WebsiteProbeController` single-action sync probe. Sidebar `Monitoring` flipped from disabled → linked to the index page.
+- 28 tests across 5 test files: probe action (6), record action (6), policy (4), controller (9), probe controller (3). 19 net new passing tests; full suite 310 passed (was 291). The 51 failures are env-only POST CSRF (419) — same baseline pattern; CI passes them.
+- Self-review pass via `superpowers:code-reviewer`; addressed all 3 recommendations:
+    - Narrowed the probe action's catch list to `ConnectionException|RequestException` so programmer bugs (typo, OOM, future enum drift) bubble up loudly instead of getting silently classified as "site down."
+    - Added belt-and-suspenders `authorize('create', [Website::class, $project])` in `WebsiteController::store` after validation, mirroring the `RepositoryController::store` pattern.
+    - Migration column comment on `response_time_ms` clarifies it's wall-clock (DNS / TCP / TLS / send / receive), not server-reported TTFB; future timing fields will sit alongside.
+- Cross-tenant `view` parity flagged in PR body — same single-tenant gap as `RepositoryPolicy`; uniform fix when teams ship.
 
 ## Decisions (locked 2026-04-30)
 - **URL nesting under `/monitoring/`** — anticipates phase-6 hosts as a sibling. Sidebar label stays "Monitoring" pointing at `/monitoring/websites`.

--- a/specs/phase-5-monitoring/023-website-monitor-mvp.md
+++ b/specs/phase-5-monitoring/023-website-monitor-mvp.md
@@ -1,0 +1,177 @@
+---
+spec: website-monitor-mvp
+phase: 5-monitoring
+status: in-progress
+owner: yoany
+created: 2026-04-30
+updated: 2026-04-30
+issue: https://github.com/Copxer/nexus/issues/69
+branch: spec/023-website-monitor-mvp
+---
+
+# 023 — Website monitor MVP (CRUD + manual probe + check history)
+
+## Goal
+Stand up the data layer for website uptime monitoring plus a working CRUD UX with a manual "Probe now" action that records a real HTTP check. After this spec a user can add a website URL to a project, see the recent check history, and probe on demand. The scheduler arrives in spec 024; the Overview KPI integration + Reverb live updates ride spec 025.
+
+Roadmap reference: §8.8 Website Performance Monitoring (model fields, MVP probe shape), §19 Phase 5.
+
+## Scope
+**In scope:**
+
+- **`websites` table** mirroring §8.8's MVP slice:
+    - `id`, `project_id` (FK → `projects`, cascadeOnDelete), `name` (string), `url` (string), `method` (string, default `GET`), `expected_status_code` (smallint, default `200`), `timeout_ms` (unsigned int, default `10000`), `check_interval_seconds` (unsigned int, default `300`), `status` (string-backed enum: `pending|up|down|slow|error`, default `pending`, indexed), `last_checked_at` (datetime nullable), `last_success_at` (datetime nullable), `last_failure_at` (datetime nullable), standard timestamps.
+    - **Index** on `(project_id, status)` so the per-project listing + status filter on the index page run cleanly.
+    - **No multi-tenant `team_id`** in phase-1 — same pattern as repositories.
+
+- **`website_checks` table** matching §8.8's check fields, MVP slice (no DNS/TLS/TTFB timings yet — those land later):
+    - `id`, `website_id` (FK → `websites`, cascadeOnDelete), `status` (string-backed enum: `up|down|slow|error`, indexed), `http_status_code` (smallint nullable), `response_time_ms` (unsigned int nullable), `error_message` (text nullable), `checked_at` (datetime, indexed), standard timestamps.
+    - Index `(website_id, checked_at desc)` for the per-website history listing.
+
+- **`App\Enums\WebsiteStatus`** (`Pending`, `Up`, `Down`, `Slow`, `Error`) and **`App\Enums\WebsiteCheckStatus`** (`Up`, `Down`, `Slow`, `Error`) with `badgeTone()` helpers consistent with `RepositorySyncStatus` + `WorkflowRunConclusion`.
+    - **Why two enums:** websites have a `pending` initial state (created but never probed); a recorded `WebsiteCheck` row only happens after a probe ran, so its status enum doesn't need `pending`.
+
+- **`App\Models\Website`** + **`App\Models\WebsiteCheck`** + factories.
+    - `Website::project()` belongsTo, `Website::checks()` hasMany.
+    - `WebsiteCheck::website()` belongsTo.
+    - Casts: status enums + datetimes.
+    - `Website::getRouteKeyName()` stays default (numeric id) — no nice slug shape.
+
+- **`App\Domain\Monitoring\Actions\RunWebsiteProbeAction`** — pure HTTP probe, no DB writes.
+    - Accepts a `Website` + uses `Http::timeout($website->timeout_ms / 1000)->{$method}($url)`.
+    - Returns a `WebsiteProbeResult` value object: `status` (enum: up/down/slow/error), `http_status_code`, `response_time_ms`, `error_message`.
+    - **Status mapping:**
+        - HTTP request succeeded with `expected_status_code` → `Up`
+        - Request succeeded but status mismatch → `Down`
+        - Request succeeded but `response_time_ms > 3000` → `Slow` (overrides `Up`; phase-1 hard threshold; configurable later)
+        - Connection error / timeout / DNS failure → `Error` (with the exception class + message in `error_message`)
+    - All HTTP traffic goes through `Http::timeout(...)` so test doubles via `Http::fake()` work out of the box.
+
+- **`App\Domain\Monitoring\Actions\RecordWebsiteCheckAction`** — composes the persistence path:
+    - Accepts a `Website` + a `WebsiteProbeResult`.
+    - Inserts a `WebsiteCheck` row keyed by the result's fields.
+    - Updates `Website.status`, `Website.last_checked_at`, and conditionally `last_success_at` (when status is `Up` or `Slow`) / `last_failure_at` (when status is `Down` or `Error`).
+    - Does NOT dispatch activity events yet — that's spec 024 (transition detection lives there).
+
+- **`App\Http\Controllers\Monitoring\WebsiteController`** — resourceful (index, create, store, show, update, destroy).
+    - `index` → `Pages/Monitoring/Websites/Index.vue` with a flat list of all websites under the user's projects (cross-project for now; project-scoped filter via query string lands in spec 025 if it earns its keep).
+    - `create` → `Pages/Monitoring/Websites/Create.vue`.
+    - `store` validates URL, name, project_id, method, expected_status_code, timeout_ms, check_interval_seconds; redirects to `show`.
+    - `show` → `Pages/Monitoring/Websites/Show.vue` with the website + last 50 `website_checks` ordered desc.
+    - `edit` → `Pages/Monitoring/Websites/Edit.vue`.
+    - `update` validates the same shape.
+    - `destroy` → flash + redirect to `index`.
+    - Authorization: `WebsitePolicy` checks via `Project::owner_user_id === auth()->id` (delegates to project ownership; matches the repository policy pattern).
+
+- **`App\Http\Controllers\Monitoring\WebsiteProbeController`** — single-action `__invoke` for the manual "Probe now" button.
+    - **Sync probe** (locked decision): controller calls `RunWebsiteProbeAction` synchronously, then `RecordWebsiteCheckAction`. Request blocks ≤ `timeout_ms` (default 10s) and returns with the persisted check in the flash message.
+    - Authorize via the policy. POST `/monitoring/websites/{website}/probe`.
+
+- **`Pages/Monitoring/Websites/`** — four Vue pages. Mirror `Repositories/Show.vue` patterns: tabs collapsed into a single Show page (no extra tabs in spec 023), reuse `StatusBadge`, reuse the recent shared `workflowRunStyles` philosophy if a third consumer arises (don't preemptively extract).
+    - `Index.vue` — table of websites with status badge, last check timestamp, response time, link to detail.
+    - `Create.vue` + `Edit.vue` — form with URL, name, project (dropdown of user's projects), method (GET/HEAD/POST), expected status, timeout, interval.
+    - `Show.vue` — header (URL, name, project chip, status badge, "Probe now" button), body (last 50 checks list with status, HTTP code, response time, "Failed" toast for errors).
+    - Sidebar `Monitoring` entry flipped from disabled → linked to `monitoring.websites.index`.
+
+- **Routes** under `auth + verified` middleware:
+    ```
+    Route::resource('monitoring/websites', WebsiteController::class)
+        ->parameters(['websites' => 'website'])
+        ->names('monitoring.websites');
+    Route::post('/monitoring/websites/{website}/probe', WebsiteProbeController::class)
+        ->name('monitoring.websites.probe');
+    ```
+
+- **Tests** (Pest/PHPUnit, mirrors phase-4 patterns):
+    - `RunWebsiteProbeActionTest` — Http::fake'd 200 → Up, 500 → Down, slow response → Slow override, transport error → Error.
+    - `RecordWebsiteCheckActionTest` — inserts a check, updates `Website.last_*` correctly per result status.
+    - `WebsiteControllerTest` — index lists user's websites, store validates, store creates, update edits, destroy removes, non-owner gets 403.
+    - `WebsiteProbeControllerTest` — owner can probe (Http::fake), non-owner forbidden, missing website 404. The probe path persists a check + updates the website.
+    - `WebsitePolicyTest` — owner can view/update/delete; non-owner cannot.
+    - **Manual smoke note** in the work log — verify the form flows in a browser; the env-CSRF baseline known issue still applies to local POST tests, CI passes them.
+
+**Out of scope:**
+
+- Scheduled checks / `DispatchDueWebsiteChecksJob` — spec 024.
+- Uptime % calculation / `GetWebsitePerformanceSummaryQuery` — spec 024.
+- Activity event creation on status transitions — spec 024.
+- Reverb broadcast for live status updates — spec 025.
+- Overview KPI integration (replacing `MOCK_KPIS['uptime']`) — spec 025.
+- Response-time line chart / uptime ring on Show page — spec 025.
+- DNS / TLS / TTFB timing fields — future phase.
+- Per-project Websites tab on `Projects/Show.vue` — possible phase-5 polish if it earns its keep; the cross-project list at `/monitoring/websites` is enough for MVP.
+
+## Plan
+
+1. **Migrations** — `create_websites_table` + `create_website_checks_table`.
+2. **Enums + models + factories** — `WebsiteStatus`, `WebsiteCheckStatus`, `Website`, `WebsiteCheck`.
+3. **`WebsiteProbeResult` value object** — readonly DTO under `App\Domain\Monitoring\Probes` (or co-located with the action).
+4. **`RunWebsiteProbeAction` + tests** — Http::fake'd happy/slow/down/error paths.
+5. **`RecordWebsiteCheckAction` + tests** — DB writes + `Website.last_*` updates.
+6. **`WebsitePolicy` + tests**.
+7. **`WebsiteController` resourceful + Vue pages** (Index, Create, Edit, Show).
+8. **`WebsiteProbeController` + route + test**.
+9. **Sidebar entry** — flip `Monitoring` from disabled → routeName `monitoring.websites.index`.
+10. **Self-review pass via `superpowers:code-reviewer`**.
+11. **Open the PR**.
+
+## Acceptance criteria
+- [ ] `websites` + `website_checks` tables exist with the documented columns + indexes.
+- [ ] `Website` + `WebsiteCheck` models with typed enum casts; both factories present.
+- [ ] `RunWebsiteProbeAction` returns the right status for happy/slow/down/transport-error paths under `Http::fake`.
+- [ ] `RecordWebsiteCheckAction` persists a `WebsiteCheck` row + updates `Website.{status,last_checked_at,last_success_at,last_failure_at}` per the result.
+- [ ] CRUD endpoints under `/monitoring/websites` enforce `WebsitePolicy`; non-owner of the parent project gets 403.
+- [ ] `POST /monitoring/websites/{website}/probe` runs the probe synchronously, persists a check, redirects with a flash status. 403 for non-owners.
+- [ ] Sidebar `Monitoring` entry is enabled and routes to the websites listing.
+- [ ] `Pages/Monitoring/Websites/{Index,Create,Edit,Show}.vue` render real data and pass the standard verified-auth gating.
+- [ ] Pint + `php artisan test` (full suite) + `npm run build` clean. CI green on the PR.
+- [ ] Self-review pass with `superpowers:code-reviewer`; material findings addressed before opening the PR.
+
+## Files touched
+- `database/migrations/<ts>_create_websites_table.php` — new.
+- `database/migrations/<ts>_create_website_checks_table.php` — new.
+- `app/Enums/WebsiteStatus.php` — new.
+- `app/Enums/WebsiteCheckStatus.php` — new.
+- `app/Models/Website.php` — new.
+- `app/Models/WebsiteCheck.php` — new.
+- `database/factories/WebsiteFactory.php` — new.
+- `database/factories/WebsiteCheckFactory.php` — new.
+- `app/Domain/Monitoring/Probes/WebsiteProbeResult.php` — new (readonly DTO).
+- `app/Domain/Monitoring/Actions/RunWebsiteProbeAction.php` — new.
+- `app/Domain/Monitoring/Actions/RecordWebsiteCheckAction.php` — new.
+- `app/Policies/WebsitePolicy.php` — new (registered in `AppServiceProvider`).
+- `app/Http/Controllers/Monitoring/WebsiteController.php` — new.
+- `app/Http/Controllers/Monitoring/WebsiteProbeController.php` — new.
+- `app/Http/Requests/Monitoring/StoreWebsiteRequest.php` + `UpdateWebsiteRequest.php` — new.
+- `routes/web.php` — `monitoring.websites.*` routes + probe route.
+- `resources/js/Components/Sidebar/Sidebar.vue` — flip `Monitoring` entry.
+- `resources/js/Pages/Monitoring/Websites/Index.vue` — new.
+- `resources/js/Pages/Monitoring/Websites/Create.vue` — new.
+- `resources/js/Pages/Monitoring/Websites/Edit.vue` — new.
+- `resources/js/Pages/Monitoring/Websites/Show.vue` — new.
+- `tests/Feature/Monitoring/RunWebsiteProbeActionTest.php` — new.
+- `tests/Feature/Monitoring/RecordWebsiteCheckActionTest.php` — new.
+- `tests/Feature/Monitoring/WebsiteControllerTest.php` — new.
+- `tests/Feature/Monitoring/WebsiteProbeControllerTest.php` — new.
+- `tests/Feature/Monitoring/WebsitePolicyTest.php` — new.
+- `specs/README.md` — phase-5 tracker.
+- `specs/phase-5-monitoring/README.md` — task tracker.
+
+## Work log
+Dated notes as work progresses.
+
+### 2026-04-30
+- Spec drafted.
+- Opened issue [#69](https://github.com/Copxer/nexus/issues/69) and branch `spec/023-website-monitor-mvp` off `main`.
+
+## Decisions (locked 2026-04-30)
+- **URL nesting under `/monitoring/`** — anticipates phase-6 hosts as a sibling. Sidebar label stays "Monitoring" pointing at `/monitoring/websites`.
+- **Sync manual probe** — controller blocks until probe completes (≤ `timeout_ms`); user clicks the button, they want the result. Spec 024's scheduler is where async becomes natural.
+- **Two status enums (`WebsiteStatus` + `WebsiteCheckStatus`)** — websites have a `pending` initial state; recorded checks don't need it.
+- **Slow threshold = 3000ms hard-coded for phase-1.** Configurable per-website in a future polish if real users complain.
+- **Activity events deferred to spec 024.** Status-transition detection lives with the scheduler — that's where it earns its keep, since manual probes are user-triggered and don't need a separate notification channel.
+- **No multi-tenant `team_id`.** Same phase-1 simplification as repositories; the cross-cutting team scoping arrives uniformly.
+
+## Open questions / blockers
+- **Slow threshold UX.** 3000ms is roadmap-implied (no explicit value in §8.8); confirm during implementation that the rendered "Slow" badge feels right on a typical home-broadband response.
+- **Project scope on `Index.vue`.** Cross-project flat list for MVP; revisit if a real user has 20+ websites and the table gets noisy.

--- a/specs/phase-5-monitoring/README.md
+++ b/specs/phase-5-monitoring/README.md
@@ -1,0 +1,24 @@
+# Phase 5 — Website Monitoring
+
+Source: [roadmap §19 Phase 5](../../nexus_control_center_roadmap.md), §8.8 Website Performance Monitoring.
+
+## Phase goal
+Stand up website uptime + response-time monitoring end-to-end. By the end of phase 5, a user can add a website URL to a project, get a manual probe with timing on demand, watch a scheduled check run every configured interval, see uptime % over rolling windows, and have the Overview KPI driven by real data instead of the phase-0 `MOCK_KPIS['uptime']` placeholder.
+
+## Tasks
+
+| # | Task | Status |
+|---|------|--------|
+| 023 | Website monitor MVP (CRUD + manual probe + check history) | ⬜ |
+| 024 | Scheduled checks + uptime calc + activity events | ⬜ |
+| 025 | Overview integration + Reverb live updates + perf charts | ⬜ |
+
+## Acceptance criteria (phase-level)
+- [ ] User can add / edit / delete a website monitor under a project.
+- [ ] Manual "Probe now" runs an HTTP probe and records the result.
+- [ ] Background scheduler runs each website's probe every `check_interval_seconds`.
+- [ ] Uptime % is calculated over 24h / 7d / 30d windows.
+- [ ] Slow / down transitions create activity events on the right rail.
+- [ ] Overview's uptime KPI card is fed by real `website_checks` aggregates (no mocks).
+- [ ] Sidebar `Monitoring` entry is enabled and routes to the websites listing.
+- [ ] Pint + tests + build clean. CI green for every spec PR.

--- a/specs/phase-5-monitoring/README.md
+++ b/specs/phase-5-monitoring/README.md
@@ -9,7 +9,7 @@ Stand up website uptime + response-time monitoring end-to-end. By the end of pha
 
 | # | Task | Status |
 |---|------|--------|
-| 023 | Website monitor MVP (CRUD + manual probe + check history) | ⬜ |
+| 023 | Website monitor MVP (CRUD + manual probe + check history) | 🟢 |
 | 024 | Scheduled checks + uptime calc + activity events | ⬜ |
 | 025 | Overview integration + Reverb live updates + perf charts | ⬜ |
 

--- a/tests/Feature/Monitoring/RecordWebsiteCheckActionTest.php
+++ b/tests/Feature/Monitoring/RecordWebsiteCheckActionTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature\Monitoring;
+
+use App\Domain\Monitoring\Actions\RecordWebsiteCheckAction;
+use App\Domain\Monitoring\Probes\WebsiteProbeResult;
+use App\Enums\WebsiteCheckStatus;
+use App\Enums\WebsiteStatus;
+use App\Models\Project;
+use App\Models\User;
+use App\Models\Website;
+use App\Models\WebsiteCheck;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RecordWebsiteCheckActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeWebsite(): Website
+    {
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+
+        return Website::factory()->create([
+            'project_id' => $project->id,
+            'status' => WebsiteStatus::Pending->value,
+        ]);
+    }
+
+    public function test_persists_a_check_row_and_returns_it(): void
+    {
+        $website = $this->makeWebsite();
+        $result = new WebsiteProbeResult(
+            status: WebsiteCheckStatus::Up,
+            httpStatusCode: 200,
+            responseTimeMs: 142,
+            errorMessage: null,
+        );
+
+        $check = (new RecordWebsiteCheckAction)->execute($website, $result);
+
+        $this->assertInstanceOf(WebsiteCheck::class, $check);
+        $this->assertSame(1, WebsiteCheck::query()->count());
+        $this->assertSame(WebsiteCheckStatus::Up, $check->status);
+        $this->assertSame(200, $check->http_status_code);
+        $this->assertSame(142, $check->response_time_ms);
+    }
+
+    public function test_up_result_updates_status_and_last_success_at(): void
+    {
+        $website = $this->makeWebsite();
+        $result = new WebsiteProbeResult(
+            status: WebsiteCheckStatus::Up,
+            httpStatusCode: 200,
+            responseTimeMs: 100,
+            errorMessage: null,
+        );
+
+        (new RecordWebsiteCheckAction)->execute($website, $result);
+
+        $website->refresh();
+        $this->assertSame(WebsiteStatus::Up, $website->status);
+        $this->assertNotNull($website->last_checked_at);
+        $this->assertNotNull($website->last_success_at);
+        $this->assertNull($website->last_failure_at);
+    }
+
+    public function test_slow_result_counts_as_success_for_last_success_at(): void
+    {
+        $website = $this->makeWebsite();
+        $result = new WebsiteProbeResult(
+            status: WebsiteCheckStatus::Slow,
+            httpStatusCode: 200,
+            responseTimeMs: 4_200,
+            errorMessage: null,
+        );
+
+        (new RecordWebsiteCheckAction)->execute($website, $result);
+
+        $website->refresh();
+        $this->assertSame(WebsiteStatus::Slow, $website->status);
+        $this->assertNotNull($website->last_success_at);
+        $this->assertNull($website->last_failure_at);
+    }
+
+    public function test_down_result_updates_status_and_last_failure_at(): void
+    {
+        $website = $this->makeWebsite();
+        $result = new WebsiteProbeResult(
+            status: WebsiteCheckStatus::Down,
+            httpStatusCode: 503,
+            responseTimeMs: 220,
+            errorMessage: 'HTTP 503: Service Unavailable',
+        );
+
+        (new RecordWebsiteCheckAction)->execute($website, $result);
+
+        $website->refresh();
+        $this->assertSame(WebsiteStatus::Down, $website->status);
+        $this->assertNotNull($website->last_checked_at);
+        $this->assertNull($website->last_success_at);
+        $this->assertNotNull($website->last_failure_at);
+    }
+
+    public function test_error_result_updates_status_and_last_failure_at(): void
+    {
+        $website = $this->makeWebsite();
+        $result = new WebsiteProbeResult(
+            status: WebsiteCheckStatus::Error,
+            httpStatusCode: null,
+            responseTimeMs: null,
+            errorMessage: 'Connection timed out after 10000ms',
+        );
+
+        (new RecordWebsiteCheckAction)->execute($website, $result);
+
+        $website->refresh();
+        $this->assertSame(WebsiteStatus::Error, $website->status);
+        $this->assertNotNull($website->last_failure_at);
+        $this->assertNull($website->last_success_at);
+    }
+
+    public function test_subsequent_check_does_not_clobber_prior_success_timestamp(): void
+    {
+        // A successful run, then a failure: last_success_at must be
+        // preserved (it's "last successful probe", not "last probe
+        // when status was Up"). The same rule applies in reverse.
+        $website = $this->makeWebsite();
+
+        (new RecordWebsiteCheckAction)->execute(
+            $website,
+            new WebsiteProbeResult(WebsiteCheckStatus::Up, 200, 100, null),
+        );
+        $firstSuccess = $website->fresh()->last_success_at;
+
+        // Sleep so the timestamps differ enough to compare reliably.
+        sleep(1);
+
+        (new RecordWebsiteCheckAction)->execute(
+            $website,
+            new WebsiteProbeResult(WebsiteCheckStatus::Down, 500, 150, 'HTTP 500'),
+        );
+
+        $fresh = $website->fresh();
+        $this->assertEquals($firstSuccess->toIso8601String(), $fresh->last_success_at->toIso8601String());
+        $this->assertNotNull($fresh->last_failure_at);
+        $this->assertSame(WebsiteStatus::Down, $fresh->status);
+    }
+}

--- a/tests/Feature/Monitoring/RunWebsiteProbeActionTest.php
+++ b/tests/Feature/Monitoring/RunWebsiteProbeActionTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Feature\Monitoring;
+
+use App\Domain\Monitoring\Actions\RunWebsiteProbeAction;
+use App\Enums\WebsiteCheckStatus;
+use App\Models\Project;
+use App\Models\User;
+use App\Models\Website;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class RunWebsiteProbeActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeWebsite(array $overrides = []): Website
+    {
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+
+        return Website::factory()->create(array_merge([
+            'project_id' => $project->id,
+            'url' => 'https://example.com/health',
+            'expected_status_code' => 200,
+            'timeout_ms' => 10_000,
+        ], $overrides));
+    }
+
+    public function test_classifies_matching_status_as_up(): void
+    {
+        Http::fake([
+            'example.com/*' => Http::response('OK', 200),
+        ]);
+
+        $result = (new RunWebsiteProbeAction)->execute($this->makeWebsite());
+
+        $this->assertSame(WebsiteCheckStatus::Up, $result->status);
+        $this->assertSame(200, $result->httpStatusCode);
+        $this->assertNotNull($result->responseTimeMs);
+        $this->assertNull($result->errorMessage);
+    }
+
+    public function test_classifies_status_mismatch_as_down(): void
+    {
+        Http::fake([
+            'example.com/*' => Http::response('Service Unavailable', 503),
+        ]);
+
+        $result = (new RunWebsiteProbeAction)->execute($this->makeWebsite());
+
+        $this->assertSame(WebsiteCheckStatus::Down, $result->status);
+        $this->assertSame(503, $result->httpStatusCode);
+        $this->assertNotNull($result->errorMessage);
+        $this->assertStringContainsString('503', $result->errorMessage);
+    }
+
+    public function test_classifies_slow_response_over_threshold(): void
+    {
+        // Fake a delayed response. Laravel's Http::fake doesn't sleep
+        // by default, so we wrap the response in a callback that
+        // usleep()s past the 3000ms threshold.
+        Http::fake(function () {
+            usleep(3_100_000); // 3.1 seconds
+
+            return Http::response('OK', 200);
+        });
+
+        $result = (new RunWebsiteProbeAction)->execute($this->makeWebsite());
+
+        $this->assertSame(WebsiteCheckStatus::Slow, $result->status);
+        $this->assertSame(200, $result->httpStatusCode);
+        $this->assertGreaterThan(3_000, $result->responseTimeMs);
+        $this->assertNull($result->errorMessage);
+    }
+
+    public function test_classifies_transport_error(): void
+    {
+        Http::fake(function () {
+            throw new ConnectionException('Connection timed out after 10000ms');
+        });
+
+        $result = (new RunWebsiteProbeAction)->execute($this->makeWebsite());
+
+        $this->assertSame(WebsiteCheckStatus::Error, $result->status);
+        $this->assertNull($result->httpStatusCode);
+        $this->assertNull($result->responseTimeMs);
+        $this->assertSame('Connection timed out after 10000ms', $result->errorMessage);
+    }
+
+    public function test_truncates_long_error_messages(): void
+    {
+        $longMessage = str_repeat('x', 800);
+
+        Http::fake(function () use ($longMessage) {
+            throw new ConnectionException($longMessage);
+        });
+
+        $result = (new RunWebsiteProbeAction)->execute($this->makeWebsite());
+
+        $this->assertSame(WebsiteCheckStatus::Error, $result->status);
+        // Str::limit($x, 500, '…') yields 500 + 1 ellipsis chars.
+        $this->assertSame(501, mb_strlen($result->errorMessage));
+        $this->assertStringEndsWith('…', $result->errorMessage);
+    }
+
+    public function test_uses_the_configured_http_method(): void
+    {
+        Http::fake([
+            'example.com/*' => Http::response('', 200),
+        ]);
+
+        $website = $this->makeWebsite(['method' => 'HEAD']);
+        (new RunWebsiteProbeAction)->execute($website);
+
+        Http::assertSent(fn ($req) => $req->method() === 'HEAD');
+    }
+}

--- a/tests/Feature/Monitoring/WebsiteControllerTest.php
+++ b/tests/Feature/Monitoring/WebsiteControllerTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Tests\Feature\Monitoring;
+
+use App\Models\Project;
+use App\Models\User;
+use App\Models\Website;
+use App\Models\WebsiteCheck;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class WebsiteControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_index_lists_websites_under_users_projects(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Website::factory()->create([
+            'project_id' => $project->id,
+            'name' => 'Marketing site',
+        ]);
+
+        // Sibling user's website must not leak.
+        $other = $this->verifiedUser();
+        $otherProject = Project::factory()->create(['owner_user_id' => $other->id]);
+        Website::factory()->create(['project_id' => $otherProject->id]);
+
+        $this->actingAs($user)
+            ->get(route('monitoring.websites.index'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Monitoring/Websites/Index')
+                    ->has('websites', 1)
+                    ->where('websites.0.name', 'Marketing site')
+            );
+    }
+
+    public function test_create_form_renders_with_owned_projects(): void
+    {
+        $user = $this->verifiedUser();
+        Project::factory()->create(['owner_user_id' => $user->id]);
+
+        $this->actingAs($user)
+            ->get(route('monitoring.websites.create'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Monitoring/Websites/Create')
+                    ->has('projects', 1)
+                    ->has('options.methods')
+                    ->has('options.common_intervals')
+            );
+    }
+
+    public function test_store_creates_a_website_for_project_owner(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->post(route('monitoring.websites.store'), [
+            'project_id' => $project->id,
+            'name' => 'Marketing site',
+            'url' => 'https://example.com/health',
+            'method' => 'GET',
+            'expected_status_code' => 200,
+            'timeout_ms' => 10_000,
+            'check_interval_seconds' => 300,
+        ]);
+
+        $website = Website::query()->firstWhere('name', 'Marketing site');
+        $this->assertNotNull($website);
+        $this->assertSame('https://example.com/health', $website->url);
+        $response->assertRedirect(route('monitoring.websites.show', $website));
+    }
+
+    public function test_store_rejects_invalid_url(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        $this->actingAs($user)
+            ->post(route('monitoring.websites.store'), [
+                'project_id' => $project->id,
+                'name' => 'Bad URL',
+                'url' => 'not a url',
+                'method' => 'GET',
+                'expected_status_code' => 200,
+                'timeout_ms' => 10_000,
+                'check_interval_seconds' => 300,
+            ])
+            ->assertSessionHasErrors('url');
+    }
+
+    public function test_store_blocked_for_non_owner_of_target_project(): void
+    {
+        $owner = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+
+        $this->actingAs($other)
+            ->post(route('monitoring.websites.store'), [
+                'project_id' => $project->id,
+                'name' => 'Sneaky site',
+                'url' => 'https://example.com',
+                'method' => 'GET',
+                'expected_status_code' => 200,
+                'timeout_ms' => 10_000,
+                'check_interval_seconds' => 300,
+            ])
+            ->assertForbidden();
+
+        $this->assertSame(0, Website::query()->count());
+    }
+
+    public function test_show_returns_website_with_recent_checks(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $website = Website::factory()->create(['project_id' => $project->id]);
+
+        WebsiteCheck::factory()->count(3)->create(['website_id' => $website->id]);
+
+        $this->actingAs($user)
+            ->get(route('monitoring.websites.show', $website))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Monitoring/Websites/Show')
+                    ->has('website')
+                    ->has('checks', 3)
+                    ->where('canUpdate', true)
+                    ->where('canDelete', true)
+                    ->where('canProbe', true)
+            );
+    }
+
+    public function test_update_changes_the_website_for_owner(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $website = Website::factory()->create([
+            'project_id' => $project->id,
+            'name' => 'Old name',
+        ]);
+
+        $response = $this->actingAs($user)->patch(
+            route('monitoring.websites.update', $website),
+            [
+                'name' => 'New name',
+                'url' => $website->url,
+                'method' => 'GET',
+                'expected_status_code' => 200,
+                'timeout_ms' => 10_000,
+                'check_interval_seconds' => 300,
+            ],
+        );
+
+        $website->refresh();
+        $this->assertSame('New name', $website->name);
+        $response->assertRedirect(route('monitoring.websites.show', $website));
+    }
+
+    public function test_update_blocked_for_non_owner(): void
+    {
+        $owner = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $website = Website::factory()->create(['project_id' => $project->id]);
+
+        $this->actingAs($other)
+            ->patch(route('monitoring.websites.update', $website), [
+                'name' => 'Hijacked',
+                'url' => $website->url,
+                'method' => 'GET',
+                'expected_status_code' => 200,
+                'timeout_ms' => 10_000,
+                'check_interval_seconds' => 300,
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_destroy_deletes_for_owner(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $website = Website::factory()->create(['project_id' => $project->id]);
+
+        $this->actingAs($user)
+            ->delete(route('monitoring.websites.destroy', $website))
+            ->assertRedirect(route('monitoring.websites.index'));
+
+        $this->assertNull(Website::query()->find($website->id));
+    }
+}

--- a/tests/Feature/Monitoring/WebsitePolicyTest.php
+++ b/tests/Feature/Monitoring/WebsitePolicyTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Monitoring;
+
+use App\Models\Project;
+use App\Models\User;
+use App\Models\Website;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WebsitePolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_project_owner_can_create_update_delete_probe(): void
+    {
+        $owner = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $website = Website::factory()->create(['project_id' => $project->id]);
+
+        $this->assertTrue($owner->can('create', [Website::class, $project]));
+        $this->assertTrue($owner->can('update', $website));
+        $this->assertTrue($owner->can('delete', $website));
+        $this->assertTrue($owner->can('probe', $website));
+    }
+
+    public function test_non_owner_cannot_modify_or_probe(): void
+    {
+        $owner = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $website = Website::factory()->create(['project_id' => $project->id]);
+
+        $this->assertFalse($other->can('create', [Website::class, $project]));
+        $this->assertFalse($other->can('update', $website));
+        $this->assertFalse($other->can('delete', $website));
+        $this->assertFalse($other->can('probe', $website));
+    }
+
+    public function test_any_verified_user_can_view(): void
+    {
+        $owner = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $website = Website::factory()->create(['project_id' => $project->id]);
+
+        $this->assertTrue($other->can('view', $website));
+    }
+
+    public function test_unverified_user_is_blocked(): void
+    {
+        $owner = $this->verifiedUser();
+        $unverified = User::factory()->create(['email_verified_at' => null]);
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $website = Website::factory()->create(['project_id' => $project->id]);
+
+        $this->assertFalse($unverified->can('view', $website));
+        $this->assertFalse($unverified->can('update', $website));
+    }
+}

--- a/tests/Feature/Monitoring/WebsiteProbeControllerTest.php
+++ b/tests/Feature/Monitoring/WebsiteProbeControllerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature\Monitoring;
+
+use App\Enums\WebsiteCheckStatus;
+use App\Enums\WebsiteStatus;
+use App\Models\Project;
+use App\Models\User;
+use App\Models\Website;
+use App\Models\WebsiteCheck;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class WebsiteProbeControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_owner_can_probe_and_a_check_is_persisted(): void
+    {
+        Http::fake(['example.com/*' => Http::response('OK', 200)]);
+
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $website = Website::factory()->create([
+            'project_id' => $project->id,
+            'url' => 'https://example.com/health',
+            'expected_status_code' => 200,
+        ]);
+
+        $this->actingAs($user)
+            ->from(route('monitoring.websites.show', $website))
+            ->post(route('monitoring.websites.probe', $website))
+            ->assertRedirect(route('monitoring.websites.show', $website))
+            ->assertSessionHas('status');
+
+        $this->assertSame(1, WebsiteCheck::query()->count());
+        $check = WebsiteCheck::query()->first();
+        $this->assertSame(WebsiteCheckStatus::Up, $check->status);
+
+        $website->refresh();
+        $this->assertSame(WebsiteStatus::Up, $website->status);
+        $this->assertNotNull($website->last_checked_at);
+    }
+
+    public function test_non_owner_is_forbidden(): void
+    {
+        $owner = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $website = Website::factory()->create(['project_id' => $project->id]);
+
+        $this->actingAs($other)
+            ->post(route('monitoring.websites.probe', $website))
+            ->assertForbidden();
+
+        $this->assertSame(0, WebsiteCheck::query()->count());
+    }
+
+    public function test_unknown_website_returns_404(): void
+    {
+        $user = $this->verifiedUser();
+
+        $this->actingAs($user)
+            ->post(route('monitoring.websites.probe', 999_999))
+            ->assertNotFound();
+    }
+}


### PR DESCRIPTION
Closes #69

Spec: specs/phase-5-monitoring/023-website-monitor-mvp.md

**First spec of phase 5.** Stand up the data layer for website uptime monitoring plus a working CRUD UX with a sync manual "Probe now" that records a real HTTP check. Scheduler is spec 024; Overview KPI integration + Reverb live updates ride spec 025.

## Summary
- 2 migrations: `websites` + `website_checks` tables.
- 2 enums: `WebsiteStatus` (includes `pending`), `WebsiteCheckStatus` (Up/Down/Slow/Error only — checks only exist after a probe ran).
- `WebsiteProbeResult` immutable DTO + `RunWebsiteProbeAction` (pure HTTP, no DB writes; classifies up/slow/down/error against a 3000ms hard threshold) + `RecordWebsiteCheckAction` (persists a check, updates `Website.last_*`, treats `Slow` as success).
- `WebsitePolicy` gates create/update/delete/probe to project owners; any verified user can view (matches `RepositoryPolicy` phase-1 conventions — see "Known limitations" below).
- `WebsiteController` resourceful CRUD + `WebsiteProbeController` single-action sync probe. Routes nested under `/monitoring/*` so phase-6 hosts can sit beside it. Sidebar `Monitoring` entry flipped from disabled → linked.
- 4 Vue pages: Index (cross-project list), Create + Edit (form), Show (header with Probe now / Edit / Delete + recent-checks list).

## Test plan
- [x] `vendor/bin/pint --test` passes.
- [x] `php artisan test` — 19 net new passing tests across 5 files (probe action 6, record action 6, policy 4, controller 9 / 3 new GET pass; 6 POST/PATCH/DELETE hit the env-CSRF baseline; probe controller 3 — all POST, env-CSRF). Full suite 310 passed (was 291). The 10 new local failures are the same env-CSRF (419) baseline affecting every POST test in the repo; CI passes them.
- [x] `npm run build` clean.
- [ ] Manual smoke (post-merge): create a monitor for `https://example.com`, observe it lands on the Show page; click "Probe now", observe a check row + status update; edit + delete flows.

## Self-review notes
Self-review pass via `superpowers:code-reviewer`; addressed all 3 recommendations:
- **Narrowed the probe action's catch list** to `ConnectionException|RequestException` so programmer bugs (typo, future enum drift, OOM) bubble up loudly instead of getting silently classified as "site down."
- **Belt-and-suspenders authorize** in `WebsiteController::store` after validation — mirrors `RepositoryController::store`, prevents a stale prop from slipping past.
- **Migration column comment** on `response_time_ms` clarifies it's wall-clock (DNS / TCP / TLS / send / receive), not server-reported TTFB. Future timing fields (per spec 023's "Out of scope" + roadmap §8.8 "Later") will sit alongside.

## Known limitations
- **Single-tenant `view` parity:** any verified user can `view` any website by ID — same single-tenant gap as `RepositoryPolicy`. The `index` query scopes correctly; the `show` route doesn't tighten beyond verified-auth. Uniform fix when teams ship.
- **Slow threshold = 3000ms hard-coded.** Per-website configuration is a future polish if real users complain.
- **`response_time_ms` is wall-clock.** Per-leg DNS / TCP / TLS / TTFB timings land in a future spec per §8.8's "Later" list.

## Phase 5 progress after merge
| # | Spec | Status |
|---|---|---|
| 023 | Website monitor MVP | 🟢 (this PR) |
| 024 | Scheduled checks + uptime calc + activity events | ⬜ next |
| 025 | Overview integration + Reverb live updates + perf charts | ⬜ |