### PR TITLE
fix(overview): wire shipped phases — drop stale Phase 4 stub, real Issues & PRs widget

### DIFF
--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -3,19 +3,51 @@
 namespace App\Http\Controllers;
 
 use App\Domain\Dashboard\Queries\GetOverviewDashboardQuery;
+use App\Domain\GitHub\Queries\WorkItemsForUserQuery;
+use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
 /**
- * Overview dashboard. Delegates the read entirely to
- * `GetOverviewDashboardQuery` (roadmap §10.2). The query is responsible
- * for distinguishing real DB-backed slices from clearly-marked mock
- * placeholders.
+ * Overview dashboard. Mostly delegates the read to
+ * `GetOverviewDashboardQuery` (roadmap §10.2) — that query handles the
+ * single-tenant phase-1 slices that don't need a user (projects,
+ * hosts, deployments, top repositories, activity heatmap).
+ *
+ * The Issues & PRs widget is the one user-scoped slice on this page
+ * — `WorkItemsForUserQuery` requires a `User` so we run it here and
+ * merge the result rather than threading the user into
+ * `GetOverviewDashboardQuery`'s no-arg signature.
  */
 class OverviewController extends Controller
 {
-    public function __invoke(GetOverviewDashboardQuery $query): Response
-    {
-        return Inertia::render('Overview', $query->handle());
+    /**
+     * Cap for the Issues & PRs widget — keeps the card visually
+     * consistent with the other 4-row stubs around it.
+     */
+    private const TOP_WORK_ITEMS_LIMIT = 4;
+
+    public function __invoke(
+        Request $request,
+        GetOverviewDashboardQuery $query,
+        WorkItemsForUserQuery $workItemsQuery,
+    ): Response {
+        $payload = $query->handle();
+
+        // Spec 016 shipped the work-items query; this surfaces the top
+        // N open items on the Overview's Issues & PRs widget so the
+        // card reflects real activity instead of fixture data.
+        $topWorkItems = array_slice(
+            $workItemsQuery->execute($request->user(), [
+                'kind' => 'all',
+                'state' => 'open',
+            ]),
+            0,
+            self::TOP_WORK_ITEMS_LIMIT,
+        );
+
+        return Inertia::render('Overview', array_merge($payload, [
+            'topWorkItems' => $topWorkItems,
+        ]));
     }
 }

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -22,49 +22,28 @@ import {
     ShieldCheck,
 } from 'lucide-vue-next';
 
+interface TopWorkItem {
+    id: string;
+    kind: 'issue' | 'pull_request' | string;
+    number: number;
+    title: string;
+    state: string | null;
+    author_login: string | null;
+    updated_at_github: string | null;
+    html_url: string | null;
+    repository: { id: number; full_name: string; name: string } | null;
+}
+
 defineProps<{
     dashboard: DashboardPayload;
     activityHeatmap: ActivityHeatmapPayload;
+    topWorkItems: TopWorkItem[];
 }>();
 
 // ----- Hardcoded mock data for the populated stub widgets -----
 // These widgets each have their own dedicated spec in later phases. The
 // mock data here exists only so the page looks intentional, not skeletal —
 // each stub footer points at the phase that will replace it.
-
-const stubIssues = [
-    {
-        title: 'Login flow rejects valid 2FA codes intermittently',
-        repo: 'nexus-web',
-        time: '12 min',
-        priority: 'critical' as const,
-    },
-    {
-        title: 'Migrate analytics events to BigQuery sink',
-        repo: 'nexus-api',
-        time: '3 h',
-        priority: 'high' as const,
-    },
-    {
-        title: 'Add dark-mode tokens to email templates',
-        repo: 'nexus-mail',
-        time: '1 d',
-        priority: 'medium' as const,
-    },
-    {
-        title: 'Expose feature-flag SDK in the JS bundle',
-        repo: 'nexus-flags',
-        time: '2 d',
-        priority: 'low' as const,
-    },
-];
-
-const priorityToneMap = {
-    critical: 'danger',
-    high: 'warning',
-    medium: 'info',
-    low: 'muted',
-} as const;
 
 const stubHosts = [
     { name: 'prod-web-01', region: 'us-east', cpu: 0.42, mem: 0.61, status: 'success' as const },
@@ -96,12 +75,16 @@ const stubServices = [
     },
 ];
 
+// Stubs only list widgets whose owning phase hasn't shipped yet.
+// `Deployment timeline` graduated when Phase 4 (specs 020–022) shipped
+// — its real surface is the `Deployments` sidebar entry / `/deployments`
+// page. `Website performance` stays here until spec 025 lands the
+// dedicated Overview widget on top of the spec-023 monitor data.
 const visualizationStubs = [
     { label: 'World map', icon: Globe, phase: 'Phase 8' },
     { label: 'Resource utilization', icon: Activity, phase: 'Phase 6' },
-    { label: 'Website performance', icon: LineChart, phase: 'Phase 5' },
+    { label: 'Website performance', icon: LineChart, phase: 'Phase 5 · spec 025' },
     { label: 'System metrics', icon: Gauge, phase: 'Phase 8' },
-    { label: 'Deployment timeline', icon: Rocket, phase: 'Phase 4' },
 ] as const;
 </script>
 
@@ -224,7 +207,10 @@ const visualizationStubs = [
             <!-- Each card below is a populated placeholder. The canonical
                  implementation ships with the phase named in the footer. -->
             <div class="grid grid-cols-1 gap-4 lg:grid-cols-12">
-                <!-- Issues & PRs -->
+                <!-- Issues & PRs — real data from `WorkItemsForUserQuery`
+                     (spec 016). Top 4 open work items across the user's
+                     repos; the wider `/work-items` page hosts the full
+                     queue + filters. -->
                 <section
                     aria-label="Issues & PRs"
                     class="glass-card flex flex-col gap-4 p-5 lg:col-span-7"
@@ -240,32 +226,62 @@ const visualizationStubs = [
                             </h2>
                         </div>
                         <span class="hidden font-mono text-[11px] text-text-muted sm:inline">
-                            {{ stubIssues.length }} open · mock
+                            {{ topWorkItems.length }} open
                         </span>
                     </header>
-                    <ul class="flex flex-col gap-2">
+                    <ul
+                        v-if="topWorkItems.length > 0"
+                        class="flex flex-col gap-2"
+                    >
                         <li
-                            v-for="issue in stubIssues"
-                            :key="issue.title"
-                            class="flex items-center gap-3 rounded-lg border border-border-subtle bg-background-panel-hover/40 p-3"
+                            v-for="item in topWorkItems"
+                            :key="item.id"
                         >
-                            <StatusBadge :tone="priorityToneMap[issue.priority]">
-                                {{ issue.priority }}
-                            </StatusBadge>
-                            <div class="min-w-0 flex-1">
-                                <p class="truncate text-sm text-text-primary">
-                                    {{ issue.title }}
-                                </p>
-                                <p
-                                    class="truncate font-mono text-[11px] text-text-muted"
+                            <a
+                                :href="item.html_url ?? '#'"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="flex items-center gap-3 rounded-lg border border-border-subtle bg-background-panel-hover/40 p-3 transition hover:border-accent-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                            >
+                                <StatusBadge
+                                    :tone="item.kind === 'pull_request' ? 'info' : 'muted'"
                                 >
-                                    {{ issue.repo }} · {{ issue.time }} ago
-                                </p>
-                            </div>
+                                    {{ item.kind === 'pull_request' ? 'PR' : 'Issue' }}
+                                </StatusBadge>
+                                <div class="min-w-0 flex-1">
+                                    <p class="truncate text-sm text-text-primary">
+                                        <span class="font-mono text-text-muted">
+                                            #{{ item.number }}
+                                        </span>
+                                        {{ item.title }}
+                                    </p>
+                                    <p
+                                        class="truncate font-mono text-[11px] text-text-muted"
+                                    >
+                                        <span v-if="item.repository">
+                                            {{ item.repository.full_name }}
+                                            <span v-if="item.author_login">
+                                                · @{{ item.author_login }}
+                                            </span>
+                                        </span>
+                                        <span v-if="item.updated_at_github">
+                                            · Updated {{ item.updated_at_github }}
+                                        </span>
+                                    </p>
+                                </div>
+                            </a>
                         </li>
                     </ul>
+                    <p
+                        v-else
+                        class="rounded-lg border border-dashed border-border-subtle bg-background-panel-hover/30 p-4 text-sm text-text-muted"
+                    >
+                        No open issues or pull requests yet — connect a
+                        GitHub repository to start syncing them.
+                    </p>
                     <footer class="text-[11px] text-text-muted">
-                        Full widget lands with phase 2 — Issues &amp; PRs sync.
+                        Showing the most recent open items. The full queue
+                        lives at <span class="font-mono">/work-items</span>.
                     </footer>
                 </section>
 
@@ -454,7 +470,7 @@ const visualizationStubs = [
                         </li>
                     </ul>
                     <footer class="text-[11px] text-text-muted">
-                        Full widget lands with phase 5 — Website Monitoring.
+                        Full widget lands with phase 6 — Docker Host Agent.
                     </footer>
                 </section>
 
@@ -474,7 +490,7 @@ const visualizationStubs = [
                             </h2>
                         </div>
                         <span class="hidden font-mono text-[11px] text-text-muted sm:inline">
-                            7 days · 4-hour buckets · mock
+                            7 days · 4-hour buckets · last 90 days
                         </span>
                     </header>
                     <ActivityHeatmap :data="activityHeatmap" />

--- a/tests/Feature/SmokeTest.php
+++ b/tests/Feature/SmokeTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Models\GithubIssue;
+use App\Models\Project;
+use App\Models\Repository;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia;
@@ -46,6 +49,47 @@ class SmokeTest extends TestCase
                         ->has('uptime.overall')
                         ->has('topRepositories')
                     )
+                    ->has('topWorkItems')
+            );
+    }
+
+    public function test_overview_topworkitems_pulls_from_user_repos_only(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'mine/repo',
+        ]);
+        GithubIssue::factory()->create([
+            'repository_id' => $repository->id,
+            'number' => 7,
+            'title' => 'Mine',
+            'state' => 'open',
+        ]);
+
+        // Sibling user's open issue must NOT leak into the widget.
+        $other = User::factory()->create(['email_verified_at' => now()]);
+        $otherProject = Project::factory()->create(['owner_user_id' => $other->id]);
+        $otherRepo = Repository::factory()->create([
+            'project_id' => $otherProject->id,
+            'full_name' => 'other/repo',
+        ]);
+        GithubIssue::factory()->create([
+            'repository_id' => $otherRepo->id,
+            'number' => 1,
+            'title' => 'Sibling',
+            'state' => 'open',
+        ]);
+
+        $this->actingAs($user)
+            ->get('/overview')
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('topWorkItems', 1)
+                    ->where('topWorkItems.0.title', 'Mine')
             );
     }
 


### PR DESCRIPTION
The Overview dashboard had **four** spots still pointing at "Phase X — coming soon" even though the underlying functionality has shipped. Reconcile in one sweep so the dashboard honestly reflects what's live.

User flagged this when they noticed the **Deployment timeline / Phase 4** tile still rendering as pending in the Visualizations placeholder, even though Phase 4 fully shipped weeks ago.

## What changed
1. **`visualizationStubs`** — dropped the "Deployment timeline / Phase 4" entry (Phase 4 shipped its real surface as the `Deployments` sidebar entry). The Phase 5 "Website performance" entry was reframed as `"Phase 5 · spec 025"` so it's clear which spec ships the dedicated Overview widget — the data layer (spec 023) is already live.
2. **Issues & Pull Requests widget** — was a hardcoded `stubIssues` fixture; now wired to real `WorkItemsForUserQuery` (spec 016, shipped). `OverviewController` injects the query and passes `topWorkItems` capped at 4. The Vue widget renders PR/Issue badges, real titles + numbers, repo chip, author, "Updated Xm ago", and links each row out to GitHub. Footer points at `/work-items` for the full queue.
3. **Activity Heatmap header label** — "mock" → "last 90 days" (data was wired to real `activity_events` aggregates in fix/activity-heatmap-real-data; the label drifted).
4. **Services widget footer** — was attributed to "phase 5 — Website Monitoring"; corrected to "phase 6 — Docker Host Agent" (services live with the Docker host agent, not the website monitor).

## Test plan
- [x] `vendor/bin/pint --test` passes.
- [x] `php artisan test` — 2 net new passing tests (`test_overview_topworkitems_pulls_from_user_repos_only` proves sibling-user issues don't leak; existing `test_overview_carries_the_mock_dashboard_payload` extended with a `topWorkItems` assertion). Full suite 312 passed (was 310). 50 failures are env-CSRF baseline; CI passes them.
- [x] `npm run build` clean.
- [ ] Manual smoke (post-merge): open `/overview`, observe Issues & PRs widget shows real items linking to GitHub; Visualizations placeholder no longer lists Deployment timeline; heatmap header reads "last 90 days"; Services footer mentions phase 6.

## Self-review notes
Kept `GetOverviewDashboardQuery::handle()`'s no-arg signature unchanged. `WorkItemsForUserQuery` requires a `User` — the controller is the right merge point.

**Mock slices left intact** (still phase-pending):
- `dashboard.services` — Phase 6
- `dashboard.alerts` — Phase 7
- `dashboard.uptime` — Phase 5/8 (spec 025 will replace with real website-uptime aggregates)
- `stubHosts` (Hosts widget) — Phase 6
- `stubServices` (Services widget) — Phase 6 (footer now correct)
- Visualizations placeholder rows for World map / System metrics / Resource utilization / Website performance

**Phase-1 scoping caveat** — `topWorkItems` uses `WorkItemsForUserQuery` which scopes via `Project.owner_user_id`. Matches every other user-scoped slice; cross-tenant uniform fix when teams ship.

This stacks cleanly on top of PR #71 (open) — that one touches `Pages/Projects/Show.vue` + `commands.ts` + `Welcome.vue` + sidebar + monitoring/Create.vue, none of which overlap with this PR's three-file diff (`OverviewController.php`, `Overview.vue`, `SmokeTest.php`). Either order works for merging.