### PR TITLE
Spec 025 — Overview uptime KPI + Reverb live updates + perf chart (closes phase 5)

### DIFF
--- a/app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php
+++ b/app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\Dashboard\Queries;
 
+use App\Domain\Monitoring\Queries\GetMonitoringUptimeKpiQuery;
 use App\Models\ActivityEvent;
 use App\Models\Project;
 use App\Models\Repository;
@@ -34,9 +35,13 @@ use Illuminate\Support\Collection;
  *     `activity_events.occurred_at` over the last 90 days. Bucketing
  *     happens in PHP so the query stays cross-DB without `DAYOFWEEK()` /
  *     `HOUR()` polyfills.
+ *   - dashboard.uptime.{overall,change,sparkline,status} — Spec 025;
+ *     `GetMonitoringUptimeKpiQuery` aggregates `website_checks`
+ *     volume-weighted across all of the user's monitors over 24h
+ *     (vs prior 24h) plus a 12-day daily sparkline.
  *
  * Still mock (extracted to MOCK_* constants — clearly marked):
- *   - dashboard.{services,alerts,uptime}              → MOCK_KPIS
+ *   - dashboard.{services,alerts}                    → MOCK_KPIS
  *
  * The right-rail activity feed is no longer surfaced from this query —
  * the AppLayout consumes the shared `activity.recent` Inertia prop
@@ -64,6 +69,7 @@ class GetOverviewDashboardQuery
                 'projects' => $this->projects(),
                 'hosts' => $this->hosts(),
                 'deployments' => $this->deploymentsKpi(),
+                'uptime' => app(GetMonitoringUptimeKpiQuery::class)->execute(),
                 'topRepositories' => $this->topRepositories(),
             ]),
             'activityHeatmap' => $this->activityHeatmap(),
@@ -364,7 +370,7 @@ class GetOverviewDashboardQuery
     // that ships the real source.
     // ──────────────────────────────────────────────────────────────────
 
-    /** Phase 5/6 (Services/Hosts), phase 7 (Alerts), phase 8 (Uptime). */
+    /** Phase 5/6 (Services/Hosts), phase 7 (Alerts). */
     private const MOCK_KPIS = [
         'services' => [
             'running' => 47,
@@ -377,12 +383,6 @@ class GetOverviewDashboardQuery
             'critical' => 1,
             'sparkline' => [1, 0, 1, 2, 1, 1, 2, 2, 3, 2, 3, 3],
             'status' => 'danger',
-        ],
-        'uptime' => [
-            'overall' => 99.98,
-            'change' => 0.01,
-            'sparkline' => [99.92, 99.93, 99.95, 99.94, 99.96, 99.97, 99.96, 99.97, 99.98, 99.98, 99.97, 99.98],
-            'status' => 'success',
         ],
     ];
 }

--- a/app/Domain/Monitoring/Actions/RecordWebsiteCheckAction.php
+++ b/app/Domain/Monitoring/Actions/RecordWebsiteCheckAction.php
@@ -7,6 +7,7 @@ use App\Domain\Monitoring\Probes\WebsiteProbeResult;
 use App\Enums\ActivitySeverity;
 use App\Enums\WebsiteCheckStatus;
 use App\Enums\WebsiteStatus;
+use App\Events\WebsiteCheckRecorded;
 use App\Models\Website;
 use App\Models\WebsiteCheck;
 use Illuminate\Support\Carbon;
@@ -35,6 +36,12 @@ use Illuminate\Support\Carbon;
  * `metadata.website_id → website → project → owner_user_id` (since
  * monitoring rows have `repository_id = null` and would otherwise
  * silently fail to broadcast). Realtime fan-out reaches the right rail.
+ *
+ * Spec 025: dispatches `WebsiteCheckRecorded` after every persisted
+ * check (steady-state runs included, not just transitions) so the
+ * per-website Show page reflects every probe in realtime — the
+ * transition path above only fires on healthy↔failed swings, which
+ * leaves "still up, response time changed" updates invisible.
  */
 class RecordWebsiteCheckAction
 {
@@ -72,6 +79,17 @@ class RecordWebsiteCheckAction
         $website->forceFill($updates)->save();
 
         $this->maybeEmitTransitionActivity($website, $previousStatus, $result, $checkedAt);
+
+        // Spec 025 — broadcast every persisted check so the Show page
+        // reflects steady-state runs too. Pre-resolve the owner id
+        // here so the event's broadcaster doesn't lazy-load
+        // website→project relations during fan-out.
+        $website->loadMissing('project:id,owner_user_id');
+        WebsiteCheckRecorded::dispatch(
+            $check->id,
+            $website->id,
+            $website->project?->owner_user_id,
+        );
 
         return $check;
     }

--- a/app/Domain/Monitoring/Queries/GetMonitoringUptimeKpiQuery.php
+++ b/app/Domain/Monitoring/Queries/GetMonitoringUptimeKpiQuery.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Domain\Monitoring\Queries;
+
+use App\Models\WebsiteCheck;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+/**
+ * Cross-website uptime aggregate for the Overview's Uptime KpiCard
+ * (spec 025). Replaces the long-standing `MOCK_KPIS['uptime']`
+ * placeholder with real data from `website_checks`.
+ *
+ * **Volume-weighted definition** (locked decision B): rate is
+ * `successful_checks / total_checks * 100` across **all** websites
+ * over the last 24h. A busy website with one failure contributes
+ * more to the system-wide rate than a quiet website with one success
+ * — the truest "are my services up" measure.
+ *
+ * Returned shape mirrors `MOCK_KPIS['uptime']` exactly so the
+ * `KpiCard` props in `Overview.vue` need no rename:
+ *   overall   → 24h volume-weighted % (or null when no checks anywhere)
+ *   change    → overall - previous-24h overall (or 0 when either side empty)
+ *   sparkline → 12 daily uptime % values, oldest-first
+ *   status    → muted | success (≥99) | warning (≥95) | danger
+ *
+ * **Sparkline empty-day default of 100.0** — a fresh account with no
+ * checks before today shouldn't render as a 0-percent flatline (would
+ * read as "everything was down"). 100 reads as "no failures observed"
+ * which is the honest interpretation of zero data. Document the
+ * caveat; future polish can switch to null + `Sparkline` gap rendering.
+ *
+ * Phase-1 single-tenant scoping — handle takes no `User` arg, matches
+ * the rest of `GetOverviewDashboardQuery`'s slices.
+ */
+class GetMonitoringUptimeKpiQuery
+{
+    /** Match the rest of the dashboard's sparkline cadence. */
+    private const SPARKLINE_DAYS = 12;
+
+    /**
+     * @return array{
+     *     overall: float|null,
+     *     change: float,
+     *     sparkline: array<int, float>,
+     *     status: 'success'|'warning'|'danger'|'muted',
+     * }
+     */
+    public function execute(): array
+    {
+        $now = now();
+        $currentStart = $now->copy()->subDay();
+        $previousStart = $now->copy()->subDays(2);
+
+        $overall = $this->uptimeFor($currentStart, $now);
+        $previous = $this->uptimeFor($previousStart, $currentStart);
+
+        $change = ($overall === null || $previous === null)
+            ? 0.0
+            : round($overall - $previous, 2);
+
+        return [
+            'overall' => $overall,
+            'change' => $change,
+            'sparkline' => $this->sparkline(),
+            'status' => $this->statusFor($overall),
+        ];
+    }
+
+    /**
+     * Volume-weighted uptime % over the half-open window `[from, to)`.
+     * Null when the window is empty.
+     */
+    private function uptimeFor(Carbon $from, Carbon $to): ?float
+    {
+        $total = WebsiteCheck::query()
+            ->where('checked_at', '>=', $from)
+            ->where('checked_at', '<', $to)
+            ->count();
+
+        if ($total === 0) {
+            return null;
+        }
+
+        $successful = WebsiteCheck::query()
+            ->where('checked_at', '>=', $from)
+            ->where('checked_at', '<', $to)
+            ->whereIn('status', ['up', 'slow'])
+            ->count();
+
+        return round(($successful / $total) * 100, 2);
+    }
+
+    /**
+     * 12-entry daily uptime sparkline. Days with no checks default to
+     * 100.0 so a fresh account doesn't render as a 0-percent flatline.
+     *
+     * One DB query (grouped by date) — beats 12 round-trips for a
+     * cheap read.
+     *
+     * @return array<int, float>
+     */
+    private function sparkline(): array
+    {
+        $start = now()->startOfDay()->subDays(self::SPARKLINE_DAYS - 1);
+
+        /** @var Collection<int, object{date: string, total: int, successful: int}> $rows */
+        $rows = WebsiteCheck::query()
+            ->where('checked_at', '>=', $start)
+            ->selectRaw(
+                'DATE(checked_at) as date, COUNT(*) as total,'
+                .'SUM(CASE WHEN status IN (?, ?) THEN 1 ELSE 0 END) as successful',
+                ['up', 'slow'],
+            )
+            ->groupBy('date')
+            ->get()
+            ->keyBy(fn ($row) => (string) $row->date);
+
+        $series = [];
+        for ($i = 0; $i < self::SPARKLINE_DAYS; $i++) {
+            $day = $start->copy()->addDays($i)->toDateString();
+            $row = $rows->get($day);
+
+            if ($row === null || (int) $row->total === 0) {
+                // Empty day → "no failures observed" interpretation.
+                $series[] = 100.0;
+
+                continue;
+            }
+
+            $series[] = round(((int) $row->successful / (int) $row->total) * 100, 2);
+        }
+
+        return $series;
+    }
+
+    /**
+     * Map overall rate → status tone.
+     *
+     * @return 'success'|'warning'|'danger'|'muted'
+     */
+    private function statusFor(?float $overall): string
+    {
+        if ($overall === null) {
+            return 'muted';
+        }
+        if ($overall >= 99.0) {
+            return 'success';
+        }
+        if ($overall >= 95.0) {
+            return 'warning';
+        }
+
+        return 'danger';
+    }
+}

--- a/app/Events/WebsiteCheckRecorded.php
+++ b/app/Events/WebsiteCheckRecorded.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Real-time pulse emitted whenever a `website_checks` row is persisted
+ * (spec 025). The Vue `Pages/Monitoring/Websites/Show` page subscribes
+ * via Echo and triggers a partial Inertia reload of the website /
+ * summary / checks props on receipt — server-side query logic
+ * re-applies naturally, so we never replicate filter or aggregation
+ * logic in JS.
+ *
+ * Spec 024's transition events (`website.down` / `website.up`) ride
+ * the activity feed via `ActivityEventCreated` and surface on the
+ * AppLayout right rail. This event is **on top of that** — it fires
+ * for every check (steady-state runs included) so the per-website
+ * Show page reflects every probe in realtime, not just transitions.
+ *
+ * Pre-resolved owner id in the constructor (mirrors spec 021's
+ * `WorkflowRunUpserted` decision) — avoids the broadcaster lazy-
+ * loading the website / project relations during fan-out.
+ *
+ * `ShouldBroadcastNow` so the broadcast hits Reverb synchronously —
+ * matches the rest of the event family.
+ */
+class WebsiteCheckRecorded implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $checkId,
+        public readonly int $websiteId,
+        public readonly ?int $ownerUserId,
+    ) {}
+
+    /**
+     * Broadcast on the project owner's private monitoring channel.
+     * `users.{userId}.monitoring` is authorized in `routes/channels.php`.
+     *
+     * Returns no channels when the owner can't be resolved (orphan
+     * project, system-emitted check) — Laravel skips the publish.
+     *
+     * **Channel choice trade-off:** a per-user channel means the Show
+     * page receives pulses for ALL of the user's monitors and filters
+     * client-side by `website_id`. A per-website channel
+     * (`websites.{id}.checks`) would eliminate the filter but adds
+     * channel-auth proliferation and subscription churn on navigation.
+     * Phase-1 picks the per-user channel for simplicity. Revisit if
+     * monitor counts cross ~1k or check intervals drop below 30s.
+     *
+     * @return list<PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        if ($this->ownerUserId === null) {
+            return [];
+        }
+
+        return [
+            new PrivateChannel("users.{$this->ownerUserId}.monitoring"),
+        ];
+    }
+
+    /**
+     * Light-weight pulse — the client uses this as a trigger, not as
+     * the source of truth. The Show page partial-reloads the website
+     * + summary + checks props after receiving any pulse for its own
+     * website id.
+     *
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'check_id' => $this->checkId,
+            'website_id' => $this->websiteId,
+        ];
+    }
+
+    /**
+     * Stable event name for Echo subscribers:
+     * `Echo.private('users.{id}.monitoring').listen('.WebsiteCheckRecorded', ...)`.
+     */
+    public function broadcastAs(): string
+    {
+        return 'WebsiteCheckRecorded';
+    }
+}

--- a/resources/js/Pages/Monitoring/Websites/Show.vue
+++ b/resources/js/Pages/Monitoring/Websites/Show.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import Sparkline from '@/Components/Dashboard/Sparkline.vue';
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import { websiteStatusTone as statusTone } from '@/lib/websiteStyles';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import { Head, Link, router } from '@inertiajs/vue3';
+import type { PageProps } from '@/types';
+import { Head, Link, router, usePage } from '@inertiajs/vue3';
 import {
     AlertTriangle,
     ChevronLeft,
@@ -10,7 +12,9 @@ import {
     Pencil,
     Play,
     Trash2,
+    WifiOff,
 } from 'lucide-vue-next';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 
 interface ProjectChip {
     id: number;
@@ -61,6 +65,11 @@ const props = defineProps<{
     canProbe: boolean;
 }>();
 
+// `usePage` is a setup-time composition hook; calling it inside
+// `onMounted` works today but is idiomatically wrong (Inertia could
+// validate the call site at any release).
+const page = usePage<PageProps>();
+
 const formatUptime = (rate: number | null): string =>
     rate === null ? '—%' : `${rate}%`;
 
@@ -99,6 +108,106 @@ const confirmDelete = () => {
     }
     router.delete(route('monitoring.websites.destroy', props.website.id));
 };
+
+// ─── Response-time Sparkline (spec 025) ──────────────────────────────
+// Render the last 50 checks' `response_time_ms` as a tiny line chart.
+// `props.checks` is ordered newest-first by the controller; reverse
+// it so the line reads left → right oldest → newest.
+//
+// Null handling: a null `response_time_ms` (Error rows where the
+// probe never got a response) is rare. We skip leading nulls — a 0ms
+// floor at the chart's left edge would make the Sparkline's
+// min/max-normalized rendering pull the whole line to the baseline
+// and misrepresent the data. Once we have a real point, subsequent
+// nulls inherit the previous value to keep the line continuous.
+const responseTimeSeries = computed<number[]>(() => {
+    const ordered = [...props.checks].reverse();
+    const points: number[] = [];
+    let last: number | null = null;
+    for (const check of ordered) {
+        if (check.response_time_ms !== null) {
+            last = check.response_time_ms;
+        }
+        if (last === null) continue; // skip leading nulls
+        points.push(last);
+    }
+    return points;
+});
+
+// ─── Reverb subscription (spec 025) ──────────────────────────────────
+// Listen for `WebsiteCheckRecorded` pulses on the user's monitoring
+// channel. Filter client-side by website_id so we only react to pulses
+// for the page's own monitor. Each matching pulse triggers a partial
+// reload of the website / summary / checks props — server-side aggregate
+// re-applies naturally, no JS-side merge.
+const realtimeConnected = ref<boolean | null>(null);
+let teardown: (() => void) | null = null;
+
+onMounted(() => {
+    if (typeof window === 'undefined' || !window.Echo) {
+        return;
+    }
+    const userId = page.props.auth?.user?.id;
+    if (userId == null) return;
+
+    const channelName = `users.${userId}.monitoring`;
+    const channel = window.Echo.private(channelName);
+
+    channel.listen(
+        '.WebsiteCheckRecorded',
+        (payload: { check_id: number; website_id: number }) => {
+            // Only react to pulses for our own website. Other monitors'
+            // pulses arrive on the same channel.
+            if (payload.website_id !== props.website.id) return;
+            router.reload({ only: ['website', 'summary', 'checks'] });
+        },
+    );
+
+    const connector = window.Echo.connector;
+    const pusher = (
+        connector as {
+            pusher?: {
+                connection?: {
+                    state?: string;
+                    bind: (e: string, cb: () => void) => void;
+                    unbind: (e: string, cb: () => void) => void;
+                };
+            };
+        }
+    )?.pusher;
+
+    const onConnect = () => {
+        realtimeConnected.value = true;
+    };
+    const onDisconnect = () => {
+        realtimeConnected.value = false;
+    };
+
+    if (pusher?.connection) {
+        if (pusher.connection.state === 'connected') {
+            realtimeConnected.value = true;
+        }
+        pusher.connection.bind('connected', onConnect);
+        pusher.connection.bind('disconnected', onDisconnect);
+        pusher.connection.bind('unavailable', onDisconnect);
+        pusher.connection.bind('failed', onDisconnect);
+    }
+
+    teardown = () => {
+        channel.stopListening('.WebsiteCheckRecorded');
+        window.Echo?.leave(`users.${userId}.monitoring`);
+        if (pusher?.connection) {
+            pusher.connection.unbind('connected', onConnect);
+            pusher.connection.unbind('disconnected', onDisconnect);
+            pusher.connection.unbind('unavailable', onDisconnect);
+            pusher.connection.unbind('failed', onDisconnect);
+        }
+    };
+});
+
+onBeforeUnmount(() => {
+    teardown?.();
+});
 </script>
 
 <template>
@@ -151,6 +260,14 @@ const confirmDelete = () => {
                         </a>
                     </div>
                     <div class="flex items-center gap-2">
+                        <span
+                            v-if="realtimeConnected === false"
+                            class="inline-flex items-center gap-1.5 rounded-full border border-status-warning/40 bg-status-warning/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-status-warning"
+                            title="Live updates offline. Probes still record on the schedule; refresh to see them."
+                        >
+                            <WifiOff class="h-3 w-3" aria-hidden="true" />
+                            Live offline
+                        </span>
                         <button
                             v-if="canProbe"
                             type="button"
@@ -282,6 +399,31 @@ const confirmDelete = () => {
                         Up to 50 most recent
                     </span>
                 </header>
+
+                <div
+                    v-if="responseTimeSeries.length >= 2"
+                    class="mt-4 flex flex-col gap-2"
+                >
+                    <div
+                        class="flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                    >
+                        <span>Response time · last 50 probes</span>
+                        <span class="text-text-secondary">
+                            {{ responseTimeSeries[responseTimeSeries.length - 1] }}ms
+                        </span>
+                    </div>
+                    <Sparkline
+                        :points="responseTimeSeries"
+                        accent="cyan"
+                        :height="48"
+                    />
+                </div>
+                <p
+                    v-else-if="checks.length > 0"
+                    class="mt-4 text-xs text-text-muted"
+                >
+                    Not enough data points for a chart yet.
+                </p>
 
                 <ul
                     v-if="checks.length > 0"

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -21,3 +21,12 @@ Broadcast::channel('users.{userId}.activity', function ($user, $userId) {
 Broadcast::channel('users.{userId}.deployments', function ($user, $userId) {
     return (int) $user->id === (int) $userId;
 });
+
+// Spec 025 — per-user monitoring channel. `WebsiteCheckRecorded`
+// broadcasts here on every persisted check so the Show page reflects
+// realtime probe results. Spec 024's transition events still ride
+// the activity channel above; this is the per-check pulse on top of
+// that, scoped to the monitoring page only.
+Broadcast::channel('users.{userId}.monitoring', function ($user, $userId) {
+    return (int) $user->id === (int) $userId;
+});

--- a/specs/README.md
+++ b/specs/README.md
@@ -40,7 +40,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 2 | GitHub Integration MVP | 🟢 | 4/4 specs done (013–016). Phase complete. |
 | 3 | GitHub Webhooks & Activity Feed | 🟢 | 3/3 specs done (017–019). Phase complete. |
 | 4 | Deployments & CI/CD | 🟢 | 3/3 specs done (020–022). Phase complete. |
-| 5 | Website Monitoring | 🟡 | 2/3 specs done (023–024). 025 next. |
+| 5 | Website Monitoring | 🟢 | 3/3 specs done (023–025). Phase complete. |
 | 6 | Docker Host Agent MVP | ⬜ | — |
 | 7 | Alerts Engine | ⬜ | — |
 | 8 | Analytics & Health Scores | ⬜ | — |

--- a/specs/phase-5-monitoring/025-overview-and-realtime.md
+++ b/specs/phase-5-monitoring/025-overview-and-realtime.md
@@ -1,0 +1,133 @@
+---
+spec: overview-and-realtime
+phase: 5-monitoring
+status: in-progress
+owner: yoany
+created: 2026-04-30
+updated: 2026-04-30
+issue: https://github.com/Copxer/nexus/issues/75
+branch: spec/025-overview-and-realtime
+---
+
+# 025 — Overview integration + Reverb live updates + perf charts
+
+## Goal
+Close out phase 5 by surfacing website monitoring on Overview (replacing the long-standing `MOCK_KPIS['uptime']` placeholder with a real cross-website aggregate), wiring Reverb broadcasts on every persisted check so the Show page reflects live data, and rendering a response-time line chart on the Show page using the existing `Sparkline` component. After this spec, Phase 5 ships end-to-end: data layer (023) → automation (024) → user-facing dashboard surfaces (025).
+
+Roadmap reference: §8.8 Website Performance Monitoring (Overview Widget bullets), §19 Phase 5 acceptance ("Performance widget uses real data").
+
+## Scope
+**In scope:**
+
+- **`App\Domain\Monitoring\Queries\GetMonitoringUptimeKpiQuery`** — cross-website aggregate driving the Overview Uptime KPI card.
+    - `execute(): array` returns:
+        ```
+        [
+            'overall' => float|null,   // 24h volume-weighted uptime % across all checks
+            'change' => float,         // delta vs prior 24h; 0 if either window empty
+            'sparkline' => array<int, float>,  // length 12, daily uptime % oldest-first
+            'status' => 'success'|'warning'|'danger'|'muted',
+        ]
+        ```
+    - **`overall`** — `successful_checks / total_checks * 100` over **all** websites in the last 24h, rounded to 2 decimals. Volume-weighted (a busy website with one failure matters more than a quiet website with one success). `null` when no checks landed in the window.
+    - **`change`** — overall − previous-24h overall, rounded to 2 decimals. `0.0` when either window is empty (no signal to compare).
+    - **`sparkline`** — daily uptime % for each of the last 12 days, oldest-first. Days with no checks at all default to `100.0` ("no news is good news") so a fresh account doesn't render as a 0-percent flatline. Document the limitation; future polish can switch to null + `Sparkline` gap rendering.
+    - **`status`** — `muted` when `overall` is null; `success` when ≥ 99.0; `warning` when ≥ 95.0; `danger` otherwise.
+    - **Phase-1 single-tenant scoping** — query handle takes no `User` arg; matches the rest of `GetOverviewDashboardQuery`'s slices. Multi-tenant scoping arrives uniformly when teams ship.
+    - Returned shape mirrors the existing `MOCK_KPIS['uptime']` exactly so `Overview.vue`'s `KpiCard` wiring needs no other changes.
+
+- **Wire it in.** `GetOverviewDashboardQuery::handle()` calls `app(GetMonitoringUptimeKpiQuery::class)->execute()` for the `'uptime'` slice. Drop the `'uptime'` entry from `MOCK_KPIS`. Update the class doc-comment so `dashboard.uptime` graduates from "still mock" to "real today".
+
+- **`App\Events\WebsiteCheckRecorded`** — `ShouldBroadcastNow` Reverb event on every persisted check.
+    - Constructor: `(int $checkId, int $websiteId, int $ownerUserId)` — pre-resolved ints (matches spec 021's `WorkflowRunUpserted` pattern: don't lazy-load relations during broadcast).
+    - `broadcastOn()` returns `[new PrivateChannel("users.{$ownerUserId}.monitoring")]`. Empty when `ownerUserId` is null (orphan website).
+    - `broadcastWith()` returns `{ check_id, website_id }` — light-weight pulse. Client uses it as a trigger, not as a source of truth.
+    - `broadcastAs()` returns `'WebsiteCheckRecorded'` — stable dotted name for Echo subscribers.
+
+- **Channel authorization** in `routes/channels.php`:
+    ```php
+    Broadcast::channel('users.{userId}.monitoring', function ($user, $userId) {
+        return (int) $user->id === (int) $userId;
+    });
+    ```
+    Mirrors specs 019 (activity) and 021 (deployments) exactly.
+
+- **`RecordWebsiteCheckAction` extension.** After the existing persistence + transition-event paths, dispatch `WebsiteCheckRecorded` with the pre-resolved owner id (via `$website->project->owner_user_id`, loaded eagerly to avoid the N+1 some broadcast pipelines hit). Skip the dispatch when the owner can't be resolved (orphan project).
+
+- **Show page realtime subscription.**
+    - `Pages/Monitoring/Websites/Show.vue` subscribes via `window.Echo.private("users.{auth.user.id}.monitoring")` on mount, listens for `.WebsiteCheckRecorded`, and on each pulse calls `router.reload({ only: ['summary', 'checks', 'website'] })` so the uptime stats, recent-checks list, and the parent website's `last_*` timestamps all refresh atomically. Filter client-side by the pulse's `website_id` matching the page's loaded website id — other websites' pulses don't trigger a reload on this page.
+    - Tracks `realtimeConnected: Ref<boolean | null>` and renders an offline pill when the connection drops, mirroring `useActivityFeed.ts`'s pattern.
+    - Tear down the subscription in `onBeforeUnmount`.
+
+- **Response-time line chart on the Show page.**
+    - Render the last 50 checks' `response_time_ms` as a `Sparkline` (already a `KpiCard` building block; reuse standalone). Header strip in the existing Recent-checks card gains the chart inline above the list.
+    - Skip checks with null `response_time_ms` (Error rows where the probe didn't get a response time) — they'd render as gaps. Carry-forward the previous value when null is encountered to keep the line continuous.
+    - Compact `Sparkline` props: `accent="cyan"`, `height={48}`, no labels.
+    - When fewer than 2 data points exist, render a small "Not enough data yet" placeholder instead of the chart.
+
+- **Tests:**
+    - `GetMonitoringUptimeKpiQueryTest` — empty state returns null `overall` + muted; mixed checks compute volume-weighted percentage; 12-entry sparkline ordering; days with no checks default to 100; status thresholds at 99 / 95 boundaries.
+    - `WebsiteCheckRecordedTest` — implements `ShouldBroadcastNow`, `broadcastOn()` returns the right channel for the supplied owner id, payload + dotted name match.
+    - `RecordWebsiteCheckActionTest` — extend with `Event::fake([WebsiteCheckRecorded::class])` to assert the event dispatches on every check (incident, recovery, AND steady-state runs that don't emit transition events).
+    - `GetOverviewDashboardQueryTest` — extend the existing payload-shape test to include the new `uptime.overall` real-data assertion (no longer pinned to the mock 99.98).
+
+**Out of scope:**
+
+- Per-website status-page generator → roadmap §8.8 Future.
+- SLA target configuration → polish.
+- Per-region probes / Lighthouse / DNS / TLS / TTFB timings → §8.8 Future.
+- Hourly aggregated response-time chart with 24h / 7d / 30d toggle (option B from the scope check) — phase-1 keeps the simple line of last-50-checks; revisit if real users find the raw points too noisy.
+- Show page incident timeline (correlated transitions list) → polish.
+- Channel auth integration test — same brittle `/broadcasting/auth` env-CSRF baseline that affected spec 021's drop; channel callback correctness is already covered by the event-level "broadcasts on the right channel" assertion.
+
+## Plan
+1. **`GetMonitoringUptimeKpiQuery`** + tests — pure aggregate, no model dependencies beyond `WebsiteCheck`.
+2. **Wire it into `GetOverviewDashboardQuery`** + drop `MOCK_KPIS['uptime']`. Update class docblock.
+3. **`WebsiteCheckRecorded` event** + tests — pre-resolved owner pattern from spec 021.
+4. **`routes/channels.php`** authorize the new channel.
+5. **`RecordWebsiteCheckAction`** dispatches the event after persistence. Tests — `Event::fake` assertion on every kind of run.
+6. **`Show.vue` subscribes via Echo** and partial-reloads on the right pulse. Add `realtimeConnected` offline pill.
+7. **Response-time `Sparkline`** in the Recent-checks card header. Carry-forward null handling.
+8. **Self-review pass via `superpowers:code-reviewer`**.
+9. **Open the PR**.
+
+## Acceptance criteria
+- [ ] `GetMonitoringUptimeKpiQuery` returns the documented shape; volume-weighted across all websites; null `overall` + muted status on empty windows.
+- [ ] `GetOverviewDashboardQuery::handle()` exposes the real `dashboard.uptime` slice; `MOCK_KPIS['uptime']` removed; class docblock updated.
+- [ ] `WebsiteCheckRecorded` implements `ShouldBroadcastNow`, broadcasts on `users.{ownerUserId}.monitoring` with payload `{ check_id, website_id }`.
+- [ ] `routes/channels.php` rejects users other than the website's project owner.
+- [ ] `RecordWebsiteCheckAction` dispatches `WebsiteCheckRecorded` on every persisted check (independent of transition emission).
+- [ ] `Pages/Monitoring/Websites/Show.vue` subscribes via Echo on mount, partial-reloads on each pulse matching the page's website id, leaves on unmount.
+- [ ] Show page renders a response-time `Sparkline` of the last 50 checks; null response times carry forward; <2 data points renders the placeholder.
+- [ ] Pint + `php artisan test` (full suite) + `npm run build` clean. CI green.
+- [ ] Self-review pass with `superpowers:code-reviewer`; material findings addressed before opening the PR.
+
+## Files touched
+- `app/Domain/Monitoring/Queries/GetMonitoringUptimeKpiQuery.php` — new.
+- `app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php` — call the new query; drop `MOCK_KPIS['uptime']`; update docblock.
+- `app/Events/WebsiteCheckRecorded.php` — new (broadcast event).
+- `routes/channels.php` — `users.{userId}.monitoring` per-user auth.
+- `app/Domain/Monitoring/Actions/RecordWebsiteCheckAction.php` — dispatch the event after persistence.
+- `resources/js/Pages/Monitoring/Websites/Show.vue` — Echo subscription + offline pill + response-time Sparkline.
+- `tests/Feature/Monitoring/GetMonitoringUptimeKpiQueryTest.php` — new.
+- `tests/Feature/Events/WebsiteCheckRecordedTest.php` — new.
+- `tests/Feature/Monitoring/RecordWebsiteCheckActionTest.php` — extend with broadcast-event assertion.
+- `tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php` — extend `mock_kpis_remain_consistent_with_phase_0_values` to drop the uptime line + add a real-uptime test.
+
+## Work log
+Dated notes as work progresses.
+
+### 2026-04-30
+- Spec drafted.
+- Opened issue [#75](https://github.com/Copxer/nexus/issues/75) and branch `spec/025-overview-and-realtime` off `main`.
+
+## Decisions (locked 2026-04-30)
+- **Volume-weighted uptime (option B).** `successful_checks / total_checks` across all websites — truest "system-wide uptime" measure.
+- **Sparkline of last-50 response times (option A).** Reuses the existing component; matches the recent-checks data the user is already looking at. Hourly aggregation is a future polish.
+- **Broadcast every persisted check (option A).** Mirrors spec 021's `WorkflowRunUpserted`; the right rail still gets transition events for free from spec 024.
+- **Days with no checks → 100% on the sparkline.** A flat 100 line for a fresh account reads as "no failures observed" rather than "everything was down." Document the limitation.
+- **Pre-resolved owner id in event constructor.** Avoids broadcast-time relation walking — matches spec 021's `WorkflowRunUpserted` decision.
+
+## Open questions / blockers
+- **`null` response times in Sparkline.** `Sparkline.vue` accepts `number[]`. Carry-forward the previous value when a null is encountered; if the first point is null fall back to 0. Confirm during implementation that the rendered line stays readable.
+- **Scaling read of `WebsiteCheck::query()->count()` over 24h.** At phase-1 row counts (≤100 monitors × 1440 minutes / interval) under 50k rows; cheap. Cache only if a slow-query log flags it.

--- a/specs/phase-5-monitoring/025-overview-and-realtime.md
+++ b/specs/phase-5-monitoring/025-overview-and-realtime.md
@@ -1,7 +1,7 @@
 ---
 spec: overview-and-realtime
 phase: 5-monitoring
-status: in-progress
+status: done
 owner: yoany
 created: 2026-04-30
 updated: 2026-04-30
@@ -120,6 +120,10 @@ Dated notes as work progresses.
 ### 2026-04-30
 - Spec drafted.
 - Opened issue [#75](https://github.com/Copxer/nexus/issues/75) and branch `spec/025-overview-and-realtime` off `main`.
+- Implementation complete. New `GetMonitoringUptimeKpiQuery` (volume-weighted 24h uptime + change vs prior 24h + 12-day daily sparkline + status thresholds at 99 / 95). Wired into `GetOverviewDashboardQuery`; `MOCK_KPIS['uptime']` removed; class docblock graduates uptime to "real today". New `WebsiteCheckRecorded` `ShouldBroadcastNow` event with pre-resolved owner id, broadcasts on `users.{ownerUserId}.monitoring` with light pulse `{ check_id, website_id }`. `routes/channels.php` authorizes the new channel. `RecordWebsiteCheckAction` dispatches the event after every persisted check (steady-state runs included; transition events stay separate per spec 024). `Show.vue` subscribes via Echo, filters client-side by `website_id`, partial-reloads on matching pulses; offline pill via `realtimeConnected` ref; response-time `Sparkline` of last 50 checks with leading-null skip and carry-forward fill.
+- 18 net new passing tests across 3 new files + 2 extended; full suite 357 passed (was 339).
+- Self-review pass via `superpowers:code-reviewer` flagged 3 recommendations, all addressed: hoisted `usePage()` to setup top-level (idiomatic Inertia), skipped leading-null Error checks in the sparkline so the line doesn't anchor at the 0ms floor, and added a docblock note on `WebsiteCheckRecorded::broadcastOn()` documenting the per-user-channel-vs-per-website-channel trade-off for when monitor counts cross ~1k.
+- **Phase 5 complete (3/3 specs done).** Phase-pending tabs and stubs related to website monitoring are all wired; the only remaining `MOCK_KPIS` slices are `services` (phase 6) and `alerts` (phase 7).
 
 ## Decisions (locked 2026-04-30)
 - **Volume-weighted uptime (option B).** `successful_checks / total_checks` across all websites — truest "system-wide uptime" measure.

--- a/specs/phase-5-monitoring/README.md
+++ b/specs/phase-5-monitoring/README.md
@@ -11,7 +11,7 @@ Stand up website uptime + response-time monitoring end-to-end. By the end of pha
 |---|------|--------|
 | 023 | Website monitor MVP (CRUD + manual probe + check history) | 🟢 |
 | 024 | Scheduled checks + uptime calc + activity events | 🟢 |
-| 025 | Overview integration + Reverb live updates + perf charts | ⬜ |
+| 025 | Overview integration + Reverb live updates + perf charts | 🟢 |
 
 ## Acceptance criteria (phase-level)
 - [ ] User can add / edit / delete a website monitor under a project.

--- a/tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php
+++ b/tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php
@@ -149,18 +149,28 @@ class GetOverviewDashboardQueryTest extends TestCase
 
     public function test_mock_kpis_remain_consistent_with_phase_0_values(): void
     {
-        // Deployments graduated to a real query in spec 022; remaining
-        // mocked slices (services/alerts/uptime) still pin to the
-        // phase-0 fixture values.
+        // Deployments graduated to a real query in spec 022 and uptime
+        // graduated in spec 025; remaining mocked slices (services /
+        // alerts) still pin to the phase-0 fixture values.
         $payload = (new GetOverviewDashboardQuery)->handle();
 
         $this->assertSame(47, $payload['dashboard']['services']['running']);
         $this->assertSame(3, $payload['dashboard']['alerts']['active']);
         $this->assertSame('danger', $payload['dashboard']['alerts']['status']);
-        $this->assertSame(99.98, $payload['dashboard']['uptime']['overall']);
 
         $this->assertCount(7, $payload['activityHeatmap']);
         $this->assertCount(6, $payload['activityHeatmap'][0]);
+    }
+
+    public function test_uptime_kpi_is_wired_to_the_real_query(): void
+    {
+        // No checks anywhere → muted + null overall (matches the
+        // GetMonitoringUptimeKpiQuery contract verified in its own test).
+        $payload = (new GetOverviewDashboardQuery)->handle();
+
+        $this->assertNull($payload['dashboard']['uptime']['overall']);
+        $this->assertSame('muted', $payload['dashboard']['uptime']['status']);
+        $this->assertCount(12, $payload['dashboard']['uptime']['sparkline']);
     }
 
     // ────────────────────────────────────────────────────────────────

--- a/tests/Feature/Events/WebsiteCheckRecordedTest.php
+++ b/tests/Feature/Events/WebsiteCheckRecordedTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature\Events;
+
+use App\Events\WebsiteCheckRecorded;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Tests\TestCase;
+
+class WebsiteCheckRecordedTest extends TestCase
+{
+    public function test_implements_should_broadcast_now(): void
+    {
+        $event = new WebsiteCheckRecorded(checkId: 1, websiteId: 2, ownerUserId: 3);
+
+        $this->assertInstanceOf(ShouldBroadcastNow::class, $event);
+    }
+
+    public function test_broadcasts_on_owner_monitoring_channel(): void
+    {
+        $event = new WebsiteCheckRecorded(checkId: 1, websiteId: 2, ownerUserId: 99);
+
+        $channels = $event->broadcastOn();
+
+        $this->assertCount(1, $channels);
+        $this->assertInstanceOf(PrivateChannel::class, $channels[0]);
+        // PrivateChannel internally prefixes with "private-"; assert
+        // by the suffix the JS client subscribes to.
+        $this->assertStringEndsWith('users.99.monitoring', $channels[0]->name);
+    }
+
+    public function test_no_channels_when_owner_user_id_is_null(): void
+    {
+        $event = new WebsiteCheckRecorded(checkId: 1, websiteId: 2, ownerUserId: null);
+
+        $this->assertSame([], $event->broadcastOn());
+    }
+
+    public function test_broadcast_with_payload_carries_just_the_pulse(): void
+    {
+        $event = new WebsiteCheckRecorded(checkId: 42, websiteId: 7, ownerUserId: 1);
+
+        $this->assertSame(
+            ['check_id' => 42, 'website_id' => 7],
+            $event->broadcastWith(),
+        );
+    }
+
+    public function test_broadcast_as_uses_stable_dotted_name(): void
+    {
+        $event = new WebsiteCheckRecorded(checkId: 1, websiteId: 2, ownerUserId: 3);
+
+        $this->assertSame('WebsiteCheckRecorded', $event->broadcastAs());
+    }
+}

--- a/tests/Feature/Monitoring/GetMonitoringUptimeKpiQueryTest.php
+++ b/tests/Feature/Monitoring/GetMonitoringUptimeKpiQueryTest.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Tests\Feature\Monitoring;
+
+use App\Domain\Monitoring\Queries\GetMonitoringUptimeKpiQuery;
+use App\Enums\WebsiteCheckStatus;
+use App\Models\Project;
+use App\Models\User;
+use App\Models\Website;
+use App\Models\WebsiteCheck;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GetMonitoringUptimeKpiQueryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeWebsite(): Website
+    {
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+
+        return Website::factory()->create(['project_id' => $project->id]);
+    }
+
+    public function test_empty_state_returns_null_overall_and_muted_status(): void
+    {
+        $kpi = (new GetMonitoringUptimeKpiQuery)->execute();
+
+        $this->assertNull($kpi['overall']);
+        $this->assertSame(0.0, $kpi['change']);
+        $this->assertSame('muted', $kpi['status']);
+        $this->assertCount(12, $kpi['sparkline']);
+        // Empty days default to 100.0 so a fresh account doesn't read
+        // as "everything was down."
+        $this->assertSame(array_fill(0, 12, 100.0), $kpi['sparkline']);
+    }
+
+    public function test_volume_weighted_rate_across_all_websites(): void
+    {
+        $w1 = $this->makeWebsite();
+        $w2 = $this->makeWebsite();
+
+        // Website 1: 9 successful, 1 failed (90%).
+        WebsiteCheck::factory()->count(9)->create([
+            'website_id' => $w1->id,
+            'status' => WebsiteCheckStatus::Up->value,
+            'checked_at' => now()->subHour(),
+        ]);
+        WebsiteCheck::factory()->create([
+            'website_id' => $w1->id,
+            'status' => WebsiteCheckStatus::Down->value,
+            'checked_at' => now()->subHour(),
+        ]);
+
+        // Website 2: 1 successful, 0 failed (100%).
+        WebsiteCheck::factory()->create([
+            'website_id' => $w2->id,
+            'status' => WebsiteCheckStatus::Up->value,
+            'checked_at' => now()->subHour(),
+        ]);
+
+        $kpi = (new GetMonitoringUptimeKpiQuery)->execute();
+
+        // Volume-weighted: 10 / 11 = 90.91 (B-style averaging — busy
+        // website with a failure dominates the quiet 100% website).
+        $this->assertSame(90.91, $kpi['overall']);
+    }
+
+    public function test_slow_counts_as_successful(): void
+    {
+        $website = $this->makeWebsite();
+
+        WebsiteCheck::factory()->count(2)->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Up->value,
+            'checked_at' => now()->subHour(),
+        ]);
+        WebsiteCheck::factory()->count(2)->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Slow->value,
+            'checked_at' => now()->subHour(),
+        ]);
+
+        $kpi = (new GetMonitoringUptimeKpiQuery)->execute();
+
+        $this->assertSame(100.0, $kpi['overall']);
+    }
+
+    public function test_change_compares_to_previous_24h_window(): void
+    {
+        $website = $this->makeWebsite();
+
+        // Previous 24h: 1 success, 1 failure → 50%.
+        WebsiteCheck::factory()->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Up->value,
+            'checked_at' => now()->subHours(36),
+        ]);
+        WebsiteCheck::factory()->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Down->value,
+            'checked_at' => now()->subHours(36),
+        ]);
+
+        // Current 24h: 4 success, 1 failure → 80%.
+        WebsiteCheck::factory()->count(4)->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Up->value,
+            'checked_at' => now()->subHour(),
+        ]);
+        WebsiteCheck::factory()->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Down->value,
+            'checked_at' => now()->subHour(),
+        ]);
+
+        $kpi = (new GetMonitoringUptimeKpiQuery)->execute();
+
+        $this->assertSame(80.0, $kpi['overall']);
+        $this->assertSame(30.0, $kpi['change']);
+    }
+
+    public function test_change_is_zero_when_either_window_is_empty(): void
+    {
+        $website = $this->makeWebsite();
+
+        // Only current window has data.
+        WebsiteCheck::factory()->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Up->value,
+            'checked_at' => now()->subHour(),
+        ]);
+
+        $kpi = (new GetMonitoringUptimeKpiQuery)->execute();
+
+        $this->assertSame(100.0, $kpi['overall']);
+        $this->assertSame(0.0, $kpi['change']);
+    }
+
+    public function test_status_threshold_at_99_is_success(): void
+    {
+        $website = $this->makeWebsite();
+
+        // Exactly 99% — 99 successes, 1 failure.
+        WebsiteCheck::factory()->count(99)->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Up->value,
+            'checked_at' => now()->subHour(),
+        ]);
+        WebsiteCheck::factory()->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Down->value,
+            'checked_at' => now()->subHour(),
+        ]);
+
+        $kpi = (new GetMonitoringUptimeKpiQuery)->execute();
+
+        $this->assertSame(99.0, $kpi['overall']);
+        $this->assertSame('success', $kpi['status']);
+    }
+
+    public function test_status_threshold_at_95_is_warning(): void
+    {
+        $website = $this->makeWebsite();
+
+        // Exactly 95% — 19 successes, 1 failure.
+        WebsiteCheck::factory()->count(19)->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Up->value,
+            'checked_at' => now()->subHour(),
+        ]);
+        WebsiteCheck::factory()->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Down->value,
+            'checked_at' => now()->subHour(),
+        ]);
+
+        $kpi = (new GetMonitoringUptimeKpiQuery)->execute();
+
+        $this->assertSame(95.0, $kpi['overall']);
+        $this->assertSame('warning', $kpi['status']);
+    }
+
+    public function test_status_below_95_is_danger(): void
+    {
+        $website = $this->makeWebsite();
+
+        // 90% — 9 successes, 1 failure.
+        WebsiteCheck::factory()->count(9)->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Up->value,
+            'checked_at' => now()->subHour(),
+        ]);
+        WebsiteCheck::factory()->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Down->value,
+            'checked_at' => now()->subHour(),
+        ]);
+
+        $kpi = (new GetMonitoringUptimeKpiQuery)->execute();
+
+        $this->assertSame(90.0, $kpi['overall']);
+        $this->assertSame('danger', $kpi['status']);
+    }
+
+    public function test_sparkline_includes_today_at_last_index(): void
+    {
+        $website = $this->makeWebsite();
+
+        // Today: 1 success.
+        WebsiteCheck::factory()->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Up->value,
+            'checked_at' => now()->startOfDay()->addHours(10),
+        ]);
+
+        $kpi = (new GetMonitoringUptimeKpiQuery)->execute();
+
+        $this->assertSame(100.0, $kpi['sparkline'][11]);
+        // Days 0..10 are empty → defaulted to 100.0.
+        $this->assertSame(array_fill(0, 11, 100.0), array_slice($kpi['sparkline'], 0, 11));
+    }
+
+    public function test_sparkline_empty_day_defaults_to_100(): void
+    {
+        $website = $this->makeWebsite();
+
+        // 5 days ago: 1 failure.
+        WebsiteCheck::factory()->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Down->value,
+            'checked_at' => now()->startOfDay()->subDays(5)->addHours(10),
+        ]);
+
+        $kpi = (new GetMonitoringUptimeKpiQuery)->execute();
+
+        // Today (index 11) is empty → 100.
+        $this->assertSame(100.0, $kpi['sparkline'][11]);
+        // 5 days ago (index 6 = 11 - 5) had only the failure → 0.0.
+        $this->assertSame(0.0, $kpi['sparkline'][6]);
+    }
+}

--- a/tests/Feature/Monitoring/RecordWebsiteCheckActionTest.php
+++ b/tests/Feature/Monitoring/RecordWebsiteCheckActionTest.php
@@ -9,6 +9,7 @@ use App\Enums\ActivitySeverity;
 use App\Enums\WebsiteCheckStatus;
 use App\Enums\WebsiteStatus;
 use App\Events\ActivityEventCreated;
+use App\Events\WebsiteCheckRecorded;
 use App\Models\ActivityEvent;
 use App\Models\Project;
 use App\Models\User;
@@ -265,5 +266,43 @@ class RecordWebsiteCheckActionTest extends TestCase
         );
 
         $this->assertSame(0, ActivityEvent::query()->count());
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // Spec 025 — WebsiteCheckRecorded broadcasts on every persisted check.
+    // ────────────────────────────────────────────────────────────────
+
+    public function test_dispatches_website_check_recorded_on_every_persisted_check(): void
+    {
+        Event::fake([WebsiteCheckRecorded::class]);
+        $website = $this->makeWebsite(WebsiteStatus::Up);
+
+        // Steady-state run (Up → Up). No transition activity, but the
+        // realtime pulse must still fire.
+        $check = $this->action()->execute(
+            $website,
+            new WebsiteProbeResult(WebsiteCheckStatus::Up, 200, 100, null),
+        );
+
+        Event::assertDispatched(
+            WebsiteCheckRecorded::class,
+            fn (WebsiteCheckRecorded $event) => $event->checkId === $check->id
+                && $event->websiteId === $website->id
+                && $event->ownerUserId === $website->project->owner_user_id,
+        );
+    }
+
+    public function test_dispatches_website_check_recorded_on_transitions_too(): void
+    {
+        Event::fake([WebsiteCheckRecorded::class]);
+        $website = $this->makeWebsite(WebsiteStatus::Up);
+
+        // Healthy → Failed transition.
+        $this->action()->execute(
+            $website,
+            new WebsiteProbeResult(WebsiteCheckStatus::Down, 500, 200, 'HTTP 500'),
+        );
+
+        Event::assertDispatched(WebsiteCheckRecorded::class);
     }
 }


### PR DESCRIPTION
Closes #75

Spec: specs/phase-5-monitoring/025-overview-and-realtime.md

**Last spec of phase 5.** Replaces the long-standing `MOCK_KPIS['uptime']` placeholder on Overview with a real volume-weighted cross-website aggregate, broadcasts every persisted check via Reverb so the per-website Show page reflects live data, and renders a response-time Sparkline of the last 50 checks.

## Summary
- `GetMonitoringUptimeKpiQuery` — volume-weighted 24h uptime % across all websites (decision B: a busy site with one failure dominates a quiet 100% site, the truest system-wide measure). Returns `{overall, change, sparkline (12d oldest-first), status}`. Empty 24h window → `null` overall + `muted` status. Days with no checks default to 100% on the sparkline (documented "no failures observed" framing — better than rendering as a 0% flatline on fresh accounts).
- Wired into `GetOverviewDashboardQuery`; `MOCK_KPIS['uptime']` removed; docblock graduates uptime to "real today."
- New `WebsiteCheckRecorded` `ShouldBroadcastNow` event with pre-resolved owner id (mirrors spec 021's `WorkflowRunUpserted` pattern). Broadcasts on `users.{ownerUserId}.monitoring`. Light pulse `{ check_id, website_id }`.
- `routes/channels.php` authorizes the new channel (per-user gate matching activity / deployments).
- `RecordWebsiteCheckAction` dispatches the event after every persisted check (steady-state runs included). Spec 024's transition activity events still fire separately on healthy↔failed swings.
- `Show.vue` subscribes via Echo on mount, filters client-side by `website_id`, partial-reloads `website + summary + checks` on matching pulses. `realtimeConnected` ref drives an offline pill. Response-time `Sparkline` of last 50 `response_time_ms` with leading-null skip + carry-forward fill; <2 data points renders the "not enough data" placeholder.

## Test plan
- [x] `vendor/bin/pint --test` passes.
- [x] `php artisan test` — 18 net new passing tests across 3 new files (KPI query 10, event 5, dispatch + transition extensions 3) + 2 extended (record action + dashboard query). Full suite 357 passed (was 339); 50 failures are env-CSRF baseline; CI passes them.
- [x] `npm run build` clean.
- [ ] Manual smoke (post-merge): create a monitor, confirm Overview's Uptime KPI shows real % once probes accumulate; visit the Show page and confirm a `php artisan schedule:work` tick triggers a partial reload + the Sparkline updates without a manual refresh.

## Self-review notes
Self-review pass via `superpowers:code-reviewer` flagged 3 recommendations, all addressed:
- `usePage()` hoisted to setup top-level — was inside `onMounted`, idiomatically wrong (Inertia could validate the call site at any release).
- `responseTimeSeries` now skips leading null Error checks rather than carry-forwarding a `0` — the Sparkline's min/max-normalized rendering was pulling the line to the 0ms floor when the first point was a transport-error row.
- `WebsiteCheckRecorded::broadcastOn()` docblock documents the per-user-channel-vs-per-website-channel trade-off for future scaling (~1k monitors / sub-30s intervals).

## Phase-1 acknowledgements (PR-body-only)
- **Empty-day uptime sparkline = 100%.** Honest framing for fresh accounts; misleading for an active monitor whose dispatcher died and stopped reporting. Surfaced indirectly via `last_checked_at` going stale on the index/show pages and via the right rail's lost activity heartbeat. Future polish: switch to null + Sparkline gap rendering.
- **Broadcast volume.** 100 monitors × 60s ≈ 1.67 broadcasts/sec — Reverb-friendly. Revisit if monitor count crosses ~1k or interval drops below 30s.
- **Service location** of `GetMonitoringUptimeKpiQuery` from `GetOverviewDashboardQuery::handle()` via `app(...)` — matches the existing class's no-constructor pattern. Refactor opportunity for a follow-up if more queries graduate.

## Phase 5 status
| # | Spec | Status |
|---|---|---|
| 023 | Website monitor MVP | 🟢 |
| 024 | Scheduled checks + uptime + activity events | 🟢 |
| 025 | Overview integration + Reverb live updates | 🟢 (this PR) |

**Phase complete.** The only remaining `MOCK_KPIS` slices are `services` (phase 6) and `alerts` (phase 7) — they ride with their own future phases.

After merge, what's next:
- **Phase 6** — Docker Host Agent MVP (host telemetry ingestion endpoint, agent token system, container metrics).
- **Phase 7** — Alerts Engine.
- **Phase 8** — Analytics & Health Scores.