### PR TITLE
Spec 026 — Hosts + agent tokens scaffolding

### DIFF
--- a/app/Domain/Docker/Actions/AgentTokenIssueResult.php
+++ b/app/Domain/Docker/Actions/AgentTokenIssueResult.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Domain\Docker\Actions;
+
+use App\Models\AgentToken;
+
+/**
+ * Pair returned by {@see IssueAgentTokenAction}. The plaintext lives
+ * here so it travels exactly once — from the action to the controller
+ * to the session flash — and never gets persisted, logged, or
+ * serialised by accident.
+ */
+final readonly class AgentTokenIssueResult
+{
+    public function __construct(
+        public AgentToken $token,
+        public string $plaintext,
+    ) {}
+}

--- a/app/Domain/Docker/Actions/ArchiveHostAction.php
+++ b/app/Domain/Docker/Actions/ArchiveHostAction.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Domain\Docker\Actions;
+
+use App\Enums\HostStatus;
+use App\Models\Host;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Soft-archive: mark the host as archived, freeze its status, and
+ * revoke every active agent token so a stale agent on a decommissioned
+ * box can't keep ingesting. Telemetry history is kept around so the
+ * host can show up in historical reports later.
+ */
+class ArchiveHostAction
+{
+    public function execute(Host $host): Host
+    {
+        return DB::transaction(function () use ($host): Host {
+            $host->forceFill([
+                'status' => HostStatus::Archived->value,
+                'archived_at' => now(),
+            ])->save();
+
+            $host->agentTokens()
+                ->whereNull('revoked_at')
+                ->update(['revoked_at' => now()]);
+
+            return $host;
+        });
+    }
+}

--- a/app/Domain/Docker/Actions/ArchiveHostAction.php
+++ b/app/Domain/Docker/Actions/ArchiveHostAction.php
@@ -16,6 +16,14 @@ class ArchiveHostAction
 {
     public function execute(Host $host): Host
     {
+        // Idempotent: a second archive call leaves `archived_at`
+        // pinned to the original timestamp instead of overwriting it.
+        // Active tokens still get a revoke pass — there should be none
+        // by then, but the `whereNull` filter makes that a no-op.
+        if ($host->archived_at !== null) {
+            return $host;
+        }
+
         return DB::transaction(function () use ($host): Host {
             $host->forceFill([
                 'status' => HostStatus::Archived->value,

--- a/app/Domain/Docker/Actions/CreateHostAction.php
+++ b/app/Domain/Docker/Actions/CreateHostAction.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Domain\Docker\Actions;
+
+use App\Enums\HostConnectionType;
+use App\Enums\HostStatus;
+use App\Models\Host;
+use App\Models\Project;
+use Illuminate\Support\Str;
+
+class CreateHostAction
+{
+    /**
+     * @param  array{
+     *     name: string,
+     *     provider?: ?string,
+     *     endpoint_url?: ?string,
+     *     connection_type?: HostConnectionType|string|null,
+     *     os?: ?string,
+     *     docker_version?: ?string,
+     *     cpu_count?: ?int,
+     *     memory_total_mb?: ?int,
+     *     disk_total_gb?: ?int,
+     * }  $attributes
+     */
+    public function execute(Project $project, array $attributes): Host
+    {
+        $name = $attributes['name'];
+        $connectionType = $attributes['connection_type'] ?? HostConnectionType::Agent;
+
+        return Host::query()->create([
+            'project_id' => $project->id,
+            'name' => $name,
+            'slug' => $this->uniqueSlugForProject($project, $name),
+            'provider' => $attributes['provider'] ?? null,
+            'endpoint_url' => $attributes['endpoint_url'] ?? null,
+            'connection_type' => $connectionType instanceof HostConnectionType
+                ? $connectionType->value
+                : (string) $connectionType,
+            'status' => HostStatus::Pending->value,
+            'os' => $attributes['os'] ?? null,
+            'docker_version' => $attributes['docker_version'] ?? null,
+            'cpu_count' => $attributes['cpu_count'] ?? null,
+            'memory_total_mb' => $attributes['memory_total_mb'] ?? null,
+            'disk_total_gb' => $attributes['disk_total_gb'] ?? null,
+        ]);
+    }
+
+    /**
+     * Slugs are unique per project. The DB unique index is the final
+     * gate; this loop just keeps the user-visible URL reasonable when
+     * two hosts share a name.
+     */
+    private function uniqueSlugForProject(Project $project, string $name): string
+    {
+        $base = Str::slug($name) ?: 'host';
+        $candidate = $base;
+        $i = 2;
+
+        while (Host::query()->where('project_id', $project->id)->where('slug', $candidate)->exists()) {
+            $candidate = $base.'-'.$i++;
+        }
+
+        return $candidate;
+    }
+}

--- a/app/Domain/Docker/Actions/IssueAgentTokenAction.php
+++ b/app/Domain/Docker/Actions/IssueAgentTokenAction.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Domain\Docker\Actions;
+
+use App\Models\AgentToken;
+use App\Models\Host;
+use App\Models\User;
+use Illuminate\Support\Str;
+
+/**
+ * Mint a new agent bearer token. The plaintext is returned **once** in
+ * the result tuple and then never persisted; the database stores only
+ * the sha256 hash. Callers (controllers) flash the plaintext to the
+ * session so the Vue layer can show it once and then drop it.
+ */
+class IssueAgentTokenAction
+{
+    public function execute(Host $host, ?string $name = null, ?User $createdBy = null): AgentTokenIssueResult
+    {
+        $plaintext = Str::random(40);
+
+        $token = AgentToken::query()->create([
+            'host_id' => $host->id,
+            'name' => $name,
+            'hashed_token' => AgentToken::hash($plaintext),
+            'created_by_user_id' => $createdBy?->id,
+        ]);
+
+        return new AgentTokenIssueResult($token, $plaintext);
+    }
+}

--- a/app/Domain/Docker/Actions/RevokeAgentTokenAction.php
+++ b/app/Domain/Docker/Actions/RevokeAgentTokenAction.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Domain\Docker\Actions;
+
+use App\Models\AgentToken;
+
+class RevokeAgentTokenAction
+{
+    public function execute(AgentToken $token): AgentToken
+    {
+        if ($token->revoked_at === null) {
+            $token->forceFill(['revoked_at' => now()])->save();
+        }
+
+        return $token;
+    }
+}

--- a/app/Domain/Docker/Actions/RotateAgentTokenAction.php
+++ b/app/Domain/Docker/Actions/RotateAgentTokenAction.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Domain\Docker\Actions;
+
+use App\Models\Host;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Revoke every currently-active token on a host and mint a fresh one.
+ * Wrapped in a transaction so the gap between "old token revoked" and
+ * "new token live" is invisible to the agent.
+ */
+class RotateAgentTokenAction
+{
+    public function __construct(
+        private IssueAgentTokenAction $issue,
+    ) {}
+
+    public function execute(Host $host, ?string $name = null, ?User $rotatedBy = null): AgentTokenIssueResult
+    {
+        return DB::transaction(function () use ($host, $name, $rotatedBy): AgentTokenIssueResult {
+            $host->agentTokens()
+                ->whereNull('revoked_at')
+                ->update(['revoked_at' => now()]);
+
+            return $this->issue->execute($host, $name, $rotatedBy);
+        });
+    }
+}

--- a/app/Domain/Docker/Actions/UpdateHostAction.php
+++ b/app/Domain/Docker/Actions/UpdateHostAction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Domain\Docker\Actions;
+
+use App\Models\Host;
+
+class UpdateHostAction
+{
+    /**
+     * Updates only the user-editable fields. Telemetry-derived columns
+     * (status, last_seen_at, cpu_count, memory_total_mb, etc.) are
+     * deliberately excluded — they're owned by the ingestion path
+     * (spec 027).
+     *
+     * @param  array{
+     *     name?: string,
+     *     provider?: ?string,
+     *     endpoint_url?: ?string,
+     * }  $attributes
+     */
+    public function execute(Host $host, array $attributes): Host
+    {
+        $host->fill(array_intersect_key($attributes, array_flip([
+            'name',
+            'provider',
+            'endpoint_url',
+        ])));
+
+        $host->save();
+
+        return $host;
+    }
+}

--- a/app/Enums/HostConnectionType.php
+++ b/app/Enums/HostConnectionType.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * How Nexus reaches (or is reached by) a host.
+ *
+ * Phase 6 only ships the `agent` strategy — a small process running on
+ * the host pushes telemetry to `/agent/telemetry` (spec 027). The other
+ * cases exist as data so a host can be migrated to a different strategy
+ * without a column rename later (roadmap §6.5).
+ *
+ * - `agent`      — push from a Nexus agent on the host (Phase 6 MVP).
+ * - `ssh`        — pull over SSH (future).
+ * - `docker_api` — pull from Docker Engine API (future).
+ * - `manual`     — no automatic telemetry; the host is tracked for
+ *                  inventory only.
+ */
+enum HostConnectionType: string
+{
+    case Agent = 'agent';
+    case Ssh = 'ssh';
+    case DockerApi = 'docker_api';
+    case Manual = 'manual';
+}

--- a/app/Enums/HostStatus.php
+++ b/app/Enums/HostStatus.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Lifecycle of a Docker host (spec 026).
+ *
+ * - `pending`   — created, no telemetry received yet.
+ * - `online`    — last telemetry was within the host's silence
+ *                 threshold.
+ * - `offline`   — last telemetry exceeded the threshold (set by
+ *                 spec 029's offline watcher).
+ * - `degraded`  — host is online but reporting unhealthy containers
+ *                 or resource pressure (spec 029).
+ * - `archived`  — soft-archived; hidden from active lists. Pairs
+ *                 with `archived_at`.
+ *
+ * Tones map to `StatusBadge`:
+ *   pending    → muted (no signal yet)
+ *   online     → success
+ *   offline    → danger
+ *   degraded   → warning
+ *   archived   → muted
+ */
+enum HostStatus: string
+{
+    case Pending = 'pending';
+    case Online = 'online';
+    case Offline = 'offline';
+    case Degraded = 'degraded';
+    case Archived = 'archived';
+
+    public function badgeTone(): string
+    {
+        return match ($this) {
+            self::Pending, self::Archived => 'muted',
+            self::Online => 'success',
+            self::Offline => 'danger',
+            self::Degraded => 'warning',
+        };
+    }
+}

--- a/app/Http/Controllers/Monitoring/AgentTokenController.php
+++ b/app/Http/Controllers/Monitoring/AgentTokenController.php
@@ -6,10 +6,10 @@ use App\Domain\Docker\Actions\IssueAgentTokenAction;
 use App\Domain\Docker\Actions\RevokeAgentTokenAction;
 use App\Domain\Docker\Actions\RotateAgentTokenAction;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Monitoring\StoreAgentTokenRequest;
 use App\Models\AgentToken;
 use App\Models\Host;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 
 /**
  * Lifecycle endpoints for a host's agent token. Plaintext travels via
@@ -19,18 +19,11 @@ use Illuminate\Http\Request;
  */
 class AgentTokenController extends Controller
 {
-    public function store(Request $request, Host $host, IssueAgentTokenAction $issue): RedirectResponse
+    public function store(StoreAgentTokenRequest $request, Host $host, IssueAgentTokenAction $issue): RedirectResponse
     {
-        $this->authorize('manageTokens', $host);
-
-        $name = $request->input('name');
-        if ($name !== null && ! is_string($name)) {
-            $name = null;
-        }
-
         $result = $issue->execute(
             $host,
-            $name !== null ? mb_substr($name, 0, 80) : null,
+            $request->validated()['name'] ?? null,
             $request->user(),
         );
 
@@ -40,19 +33,13 @@ class AgentTokenController extends Controller
             ->with('agentTokenPlaintext', $result->plaintext);
     }
 
-    public function rotate(Request $request, Host $host, AgentToken $token, RotateAgentTokenAction $rotate): RedirectResponse
+    public function rotate(StoreAgentTokenRequest $request, Host $host, AgentToken $token, RotateAgentTokenAction $rotate): RedirectResponse
     {
-        $this->authorize('manageTokens', $host);
         $this->ensureBelongs($host, $token);
-
-        $name = $request->input('name');
-        if ($name !== null && ! is_string($name)) {
-            $name = null;
-        }
 
         $result = $rotate->execute(
             $host,
-            $name !== null ? mb_substr($name, 0, 80) : null,
+            $request->validated()['name'] ?? null,
             $request->user(),
         );
 

--- a/app/Http/Controllers/Monitoring/AgentTokenController.php
+++ b/app/Http/Controllers/Monitoring/AgentTokenController.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Controllers\Monitoring;
+
+use App\Domain\Docker\Actions\IssueAgentTokenAction;
+use App\Domain\Docker\Actions\RevokeAgentTokenAction;
+use App\Domain\Docker\Actions\RotateAgentTokenAction;
+use App\Http\Controllers\Controller;
+use App\Models\AgentToken;
+use App\Models\Host;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Lifecycle endpoints for a host's agent token. Plaintext travels via
+ * the session flash so the Vue layer can show it once on redirect and
+ * then drop it. We never write the plaintext to logs, JSON, or
+ * Inertia props.
+ */
+class AgentTokenController extends Controller
+{
+    public function store(Request $request, Host $host, IssueAgentTokenAction $issue): RedirectResponse
+    {
+        $this->authorize('manageTokens', $host);
+
+        $name = $request->input('name');
+        if ($name !== null && ! is_string($name)) {
+            $name = null;
+        }
+
+        $result = $issue->execute(
+            $host,
+            $name !== null ? mb_substr($name, 0, 80) : null,
+            $request->user(),
+        );
+
+        return redirect()
+            ->route('monitoring.hosts.show', $host)
+            ->with('status', 'Agent token issued. Copy it now — it will not be shown again.')
+            ->with('agentTokenPlaintext', $result->plaintext);
+    }
+
+    public function rotate(Request $request, Host $host, AgentToken $token, RotateAgentTokenAction $rotate): RedirectResponse
+    {
+        $this->authorize('manageTokens', $host);
+        $this->ensureBelongs($host, $token);
+
+        $name = $request->input('name');
+        if ($name !== null && ! is_string($name)) {
+            $name = null;
+        }
+
+        $result = $rotate->execute(
+            $host,
+            $name !== null ? mb_substr($name, 0, 80) : null,
+            $request->user(),
+        );
+
+        return redirect()
+            ->route('monitoring.hosts.show', $host)
+            ->with('status', 'Agent token rotated. Copy the new token now — it will not be shown again.')
+            ->with('agentTokenPlaintext', $result->plaintext);
+    }
+
+    public function destroy(Host $host, AgentToken $token, RevokeAgentTokenAction $revoke): RedirectResponse
+    {
+        $this->authorize('manageTokens', $host);
+        $this->ensureBelongs($host, $token);
+
+        $revoke->execute($token);
+
+        return redirect()
+            ->route('monitoring.hosts.show', $host)
+            ->with('status', 'Agent token revoked.');
+    }
+
+    /**
+     * Defence in depth — the route already binds {host} and {token}
+     * separately, so a mismatched pair would otherwise just 404 on the
+     * agent's next request. Surface the mismatch as a 404 here.
+     */
+    private function ensureBelongs(Host $host, AgentToken $token): void
+    {
+        abort_if($token->host_id !== $host->id, 404);
+    }
+}

--- a/app/Http/Controllers/Monitoring/HostController.php
+++ b/app/Http/Controllers/Monitoring/HostController.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace App\Http\Controllers\Monitoring;
+
+use App\Domain\Docker\Actions\ArchiveHostAction;
+use App\Domain\Docker\Actions\CreateHostAction;
+use App\Domain\Docker\Actions\UpdateHostAction;
+use App\Enums\HostConnectionType;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Monitoring\StoreHostRequest;
+use App\Http\Requests\Monitoring\UpdateHostRequest;
+use App\Models\Host;
+use App\Models\Project;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Resourceful CRUD for Docker hosts (spec 026). Lives at
+ * `/monitoring/hosts/*` — sibling to `/monitoring/websites/*` so a
+ * future "Monitoring" landing page can wrap both.
+ *
+ * `destroy` doesn't actually delete: it routes through
+ * `ArchiveHostAction` so the host's telemetry history is preserved
+ * and any agent token is revoked in the same transaction.
+ */
+class HostController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $this->authorize('viewAny', Host::class);
+
+        $user = $request->user();
+
+        $hosts = Host::query()
+            ->with(['project:id,slug,name,color,icon,owner_user_id', 'activeAgentToken'])
+            ->whereHas('project', fn ($q) => $q->where('owner_user_id', $user->id))
+            ->orderBy('name')
+            ->get()
+            ->map(fn (Host $host) => $this->transform($host));
+
+        return Inertia::render('Monitoring/Hosts/Index', [
+            'hosts' => $hosts,
+        ]);
+    }
+
+    public function create(Request $request): Response
+    {
+        $this->authorize('viewAny', Host::class);
+
+        $user = $request->user();
+
+        $preselectId = $request->integer('project_id') ?: null;
+        $preselect = $preselectId !== null
+            ? Project::query()->where('owner_user_id', $user->id)->find($preselectId)
+            : null;
+
+        return Inertia::render('Monitoring/Hosts/Create', [
+            'projects' => $this->ownedProjects($user->id),
+            'preselectedProjectId' => $preselect?->id,
+            'options' => $this->formOptions(),
+        ]);
+    }
+
+    public function store(StoreHostRequest $request, CreateHostAction $createHost): RedirectResponse
+    {
+        $this->authorize('create', [Host::class, $request->resolvedProject()]);
+
+        $host = $createHost->execute(
+            $request->resolvedProject(),
+            $request->validated(),
+        );
+
+        return redirect()
+            ->route('monitoring.hosts.show', $host)
+            ->with('status', "Host “{$host->name}” created. Mint an agent token to bring it online.");
+    }
+
+    public function show(Request $request, Host $host): Response
+    {
+        $this->authorize('view', $host);
+
+        $host->loadMissing([
+            'project:id,slug,name,color,icon,owner_user_id',
+            'activeAgentToken',
+        ]);
+
+        return Inertia::render('Monitoring/Hosts/Show', [
+            'host' => $this->transform($host),
+            'canUpdate' => $request->user()?->can('update', $host) ?? false,
+            'canDelete' => $request->user()?->can('delete', $host) ?? false,
+            'canManageTokens' => $request->user()?->can('manageTokens', $host) ?? false,
+        ]);
+    }
+
+    public function edit(Request $request, Host $host): Response
+    {
+        $this->authorize('update', $host);
+
+        $host->loadMissing('project:id,slug,name,color,icon,owner_user_id');
+
+        return Inertia::render('Monitoring/Hosts/Edit', [
+            'host' => $this->transform($host),
+            'options' => $this->formOptions(),
+        ]);
+    }
+
+    public function update(UpdateHostRequest $request, Host $host, UpdateHostAction $updateHost): RedirectResponse
+    {
+        $updateHost->execute($host, $request->validated());
+
+        return redirect()
+            ->route('monitoring.hosts.show', $host)
+            ->with('status', 'Host updated.');
+    }
+
+    public function destroy(Host $host, ArchiveHostAction $archive): RedirectResponse
+    {
+        $this->authorize('delete', $host);
+
+        $archive->execute($host);
+
+        return redirect()
+            ->route('monitoring.hosts.index')
+            ->with('status', "Host “{$host->name}” archived. Existing agent tokens have been revoked.");
+    }
+
+    /**
+     * Single source of truth for the host JSON shape. Centralised so
+     * Index/Show/Edit don't drift on field set.
+     */
+    private function transform(Host $host): array
+    {
+        $activeToken = $host->activeAgentToken;
+
+        return [
+            'id' => $host->id,
+            'name' => $host->name,
+            'slug' => $host->slug,
+            'provider' => $host->provider,
+            'endpoint_url' => $host->endpoint_url,
+            'connection_type' => $host->connection_type?->value,
+            'status' => $host->status?->value,
+            'last_seen_at' => $host->last_seen_at?->diffForHumans(),
+            'last_seen_at_iso' => $host->last_seen_at?->toIso8601String(),
+            'cpu_count' => $host->cpu_count,
+            'memory_total_mb' => $host->memory_total_mb,
+            'disk_total_gb' => $host->disk_total_gb,
+            'os' => $host->os,
+            'docker_version' => $host->docker_version,
+            'archived_at' => $host->archived_at?->toIso8601String(),
+            'project' => $host->project ? [
+                'id' => $host->project->id,
+                'slug' => $host->project->slug,
+                'name' => $host->project->name,
+                'color' => $host->project->color,
+                'icon' => $host->project->icon,
+            ] : null,
+            // The plaintext token never travels through `transform()` —
+            // it only exists in the session flash. We surface only
+            // metadata about the active token so the UI can label
+            // "active token: agent v0.2 — last seen 2h ago".
+            'active_agent_token' => $activeToken ? [
+                'id' => $activeToken->id,
+                'name' => $activeToken->name,
+                'last_used_at' => $activeToken->last_used_at?->diffForHumans(),
+                'created_at' => $activeToken->created_at?->toIso8601String(),
+            ] : null,
+        ];
+    }
+
+    /**
+     * Project dropdown payload — only projects the user owns.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function ownedProjects(int $userId): array
+    {
+        return Project::query()
+            ->where('owner_user_id', $userId)
+            ->orderBy('name')
+            ->get(['id', 'name', 'color'])
+            ->map(fn (Project $project) => [
+                'id' => $project->id,
+                'name' => $project->name,
+                'color' => $project->color,
+            ])
+            ->all();
+    }
+
+    private function formOptions(): array
+    {
+        return [
+            'connection_types' => collect(HostConnectionType::cases())->map(fn (HostConnectionType $case) => [
+                'value' => $case->value,
+                'label' => match ($case) {
+                    HostConnectionType::Agent => 'Agent (push)',
+                    HostConnectionType::Ssh => 'SSH (coming soon)',
+                    HostConnectionType::DockerApi => 'Docker API (coming soon)',
+                    HostConnectionType::Manual => 'Manual / inventory only',
+                },
+                'enabled' => $case === HostConnectionType::Agent || $case === HostConnectionType::Manual,
+            ])->all(),
+        ];
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -42,6 +42,11 @@ class HandleInertiaRequests extends Middleware
             'flash' => [
                 'status' => fn () => $request->session()->get('status'),
                 'error' => fn () => $request->session()->get('error'),
+                // Spec 026 — plaintext agent token shown once after
+                // issue/rotate. Flashed by AgentTokenController; read
+                // by AgentTokenPanel.vue via `usePage().props.flash`.
+                // Never persisted, never logged.
+                'agentTokenPlaintext' => fn () => $request->session()->get('agentTokenPlaintext'),
             ],
             // Right-rail activity feed (spec 018). Inertia evaluates this
             // closure on every render (it's not a `LazyProp`); the

--- a/app/Http/Requests/Monitoring/StoreAgentTokenRequest.php
+++ b/app/Http/Requests/Monitoring/StoreAgentTokenRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Monitoring;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates the create-token form. The DB column caps `name` at 80
+ * chars; this request surfaces that as a validation error rather than
+ * silently truncating in the controller.
+ *
+ * Authorisation is delegated to the host's `manageTokens` gate.
+ */
+class StoreAgentTokenRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $host = $this->route('host');
+
+        return $host !== null
+            && $this->user()?->can('manageTokens', $host) === true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['nullable', 'string', 'max:80'],
+        ];
+    }
+}

--- a/app/Http/Requests/Monitoring/StoreHostRequest.php
+++ b/app/Http/Requests/Monitoring/StoreHostRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\Monitoring;
+
+use App\Enums\HostConnectionType;
+use App\Models\Host;
+use App\Models\Project;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates the create-host form. Project ownership is gated via the
+ * `HostPolicy::create` policy.
+ */
+class StoreHostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $project = $this->resolvedProject();
+
+        return $this->user()?->can('create', [Host::class, $project]) === true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'project_id' => ['required', Rule::exists('projects', 'id')],
+            'name' => ['required', 'string', 'max:120'],
+            'provider' => ['nullable', 'string', 'max:32'],
+            'endpoint_url' => ['nullable', 'url', 'max:2048'],
+            'connection_type' => ['required', Rule::enum(HostConnectionType::class)],
+        ];
+    }
+
+    public function resolvedProject(): ?Project
+    {
+        $id = $this->input('project_id');
+
+        return $id !== null ? Project::query()->find($id) : null;
+    }
+}

--- a/app/Http/Requests/Monitoring/UpdateHostRequest.php
+++ b/app/Http/Requests/Monitoring/UpdateHostRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests\Monitoring;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates the edit-host form. `project_id` is intentionally NOT
+ * editable post-create — moving a host between projects would orphan
+ * its telemetry. Re-create if needed.
+ *
+ * `connection_type` is also frozen post-create: changing it mid-flight
+ * would invalidate the existing agent's contract.
+ */
+class UpdateHostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $host = $this->route('host');
+
+        return $host !== null
+            && $this->user()?->can('update', $host) === true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:120'],
+            'provider' => ['nullable', 'string', 'max:32'],
+            'endpoint_url' => ['nullable', 'url', 'max:2048'],
+        ];
+    }
+}

--- a/app/Models/AgentToken.php
+++ b/app/Models/AgentToken.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\AgentTokenFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Bearer credential a Nexus agent presents on `/agent/telemetry`
+ * (spec 027). The plaintext is shown to the user once at issuance or
+ * rotation; only the sha256 hash is persisted.
+ */
+class AgentToken extends Model
+{
+    /** @use HasFactory<AgentTokenFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'host_id',
+        'name',
+        'hashed_token',
+        'last_used_at',
+        'revoked_at',
+        'created_by_user_id',
+    ];
+
+    /**
+     * The hash is the secret — keep it out of every default
+     * serialisation (Inertia props, JSON, logs).
+     */
+    protected $hidden = [
+        'hashed_token',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'last_used_at' => 'datetime',
+            'revoked_at' => 'datetime',
+        ];
+    }
+
+    public function host(): BelongsTo
+    {
+        return $this->belongsTo(Host::class);
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
+    }
+
+    public function isActive(): bool
+    {
+        return $this->revoked_at === null;
+    }
+
+    /**
+     * Hash a plaintext token the same way `IssueAgentTokenAction` does
+     * so `/agent/telemetry` middleware can do `where('hashed_token',
+     * static::hash($plaintext))` without leaking the plaintext into
+     * other layers.
+     */
+    public static function hash(string $plaintext): string
+    {
+        return hash('sha256', $plaintext);
+    }
+}

--- a/app/Models/Container.php
+++ b/app/Models/Container.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\ContainerFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Container extends Model
+{
+    /** @use HasFactory<ContainerFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'host_id',
+        'project_id',
+        'container_id',
+        'name',
+        'image',
+        'image_tag',
+        'status',
+        'state',
+        'health_status',
+        'ports',
+        'labels',
+        'cpu_percent',
+        'memory_usage_mb',
+        'memory_limit_mb',
+        'memory_percent',
+        'network_rx_bytes',
+        'network_tx_bytes',
+        'block_read_bytes',
+        'block_write_bytes',
+        'started_at',
+        'finished_at',
+        'last_seen_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'ports' => 'array',
+            'labels' => 'array',
+            'cpu_percent' => 'float',
+            'memory_percent' => 'float',
+            'memory_usage_mb' => 'integer',
+            'memory_limit_mb' => 'integer',
+            'network_rx_bytes' => 'integer',
+            'network_tx_bytes' => 'integer',
+            'block_read_bytes' => 'integer',
+            'block_write_bytes' => 'integer',
+            'started_at' => 'datetime',
+            'finished_at' => 'datetime',
+            'last_seen_at' => 'datetime',
+        ];
+    }
+
+    public function host(): BelongsTo
+    {
+        return $this->belongsTo(Host::class);
+    }
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function metricSnapshots(): HasMany
+    {
+        return $this->hasMany(ContainerMetricSnapshot::class);
+    }
+}

--- a/app/Models/ContainerMetricSnapshot.php
+++ b/app/Models/ContainerMetricSnapshot.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\ContainerMetricSnapshotFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ContainerMetricSnapshot extends Model
+{
+    /** @use HasFactory<ContainerMetricSnapshotFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'container_id',
+        'cpu_percent',
+        'memory_usage_mb',
+        'memory_limit_mb',
+        'memory_percent',
+        'network_rx_bytes',
+        'network_tx_bytes',
+        'block_read_bytes',
+        'block_write_bytes',
+        'recorded_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'cpu_percent' => 'float',
+            'memory_percent' => 'float',
+            'memory_usage_mb' => 'integer',
+            'memory_limit_mb' => 'integer',
+            'network_rx_bytes' => 'integer',
+            'network_tx_bytes' => 'integer',
+            'block_read_bytes' => 'integer',
+            'block_write_bytes' => 'integer',
+            'recorded_at' => 'datetime',
+        ];
+    }
+
+    public function container(): BelongsTo
+    {
+        return $this->belongsTo(Container::class);
+    }
+}

--- a/app/Models/Host.php
+++ b/app/Models/Host.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\HostConnectionType;
+use App\Enums\HostStatus;
+use Database\Factories\HostFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class Host extends Model
+{
+    /** @use HasFactory<HostFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'project_id',
+        'name',
+        'slug',
+        'provider',
+        'endpoint_url',
+        'connection_type',
+        'status',
+        'last_seen_at',
+        'cpu_count',
+        'memory_total_mb',
+        'disk_total_gb',
+        'os',
+        'docker_version',
+        'metadata',
+        'archived_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'connection_type' => HostConnectionType::class,
+            'status' => HostStatus::class,
+            'last_seen_at' => 'datetime',
+            'archived_at' => 'datetime',
+            'cpu_count' => 'integer',
+            'memory_total_mb' => 'integer',
+            'disk_total_gb' => 'integer',
+            'metadata' => 'array',
+        ];
+    }
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function agentTokens(): HasMany
+    {
+        return $this->hasMany(AgentToken::class);
+    }
+
+    /**
+     * The currently-active agent token for this host. Null when none
+     * exists or all have been revoked. Only one is expected to be
+     * active at a time — `RotateAgentTokenAction` revokes the previous
+     * before issuing the next.
+     */
+    public function activeAgentToken(): HasOne
+    {
+        return $this->hasOne(AgentToken::class)->whereNull('revoked_at')->latestOfMany();
+    }
+
+    public function containers(): HasMany
+    {
+        return $this->hasMany(Container::class);
+    }
+
+    public function metricSnapshots(): HasMany
+    {
+        return $this->hasMany(HostMetricSnapshot::class);
+    }
+}

--- a/app/Models/HostMetricSnapshot.php
+++ b/app/Models/HostMetricSnapshot.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\HostMetricSnapshotFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class HostMetricSnapshot extends Model
+{
+    /** @use HasFactory<HostMetricSnapshotFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'host_id',
+        'cpu_percent',
+        'memory_used_mb',
+        'memory_total_mb',
+        'disk_used_gb',
+        'disk_total_gb',
+        'load_average',
+        'network_rx_bytes',
+        'network_tx_bytes',
+        'recorded_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'cpu_percent' => 'float',
+            'load_average' => 'float',
+            'memory_used_mb' => 'integer',
+            'memory_total_mb' => 'integer',
+            'disk_used_gb' => 'integer',
+            'disk_total_gb' => 'integer',
+            'network_rx_bytes' => 'integer',
+            'network_tx_bytes' => 'integer',
+            'recorded_at' => 'datetime',
+        ];
+    }
+
+    public function host(): BelongsTo
+    {
+        return $this->belongsTo(Host::class);
+    }
+}

--- a/app/Policies/AgentTokenPolicy.php
+++ b/app/Policies/AgentTokenPolicy.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\AgentToken;
+use App\Models\User;
+
+/**
+ * Token authorization defers to the parent host. We never expose a
+ * "list all my tokens" view, so `viewAny` is intentionally absent.
+ */
+class AgentTokenPolicy
+{
+    public function view(User $user, AgentToken $token): bool
+    {
+        return $token->host !== null
+            && $user->can('view', $token->host);
+    }
+
+    public function delete(User $user, AgentToken $token): bool
+    {
+        return $token->host !== null
+            && $user->can('manageTokens', $token->host);
+    }
+}

--- a/app/Policies/HostPolicy.php
+++ b/app/Policies/HostPolicy.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Host;
+use App\Models\Project;
+use App\Models\User;
+
+/**
+ * Mirrors `WebsitePolicy`: create/update/delete are gated to the
+ * project owner; viewing is open to any verified user
+ * (single-tenant phase-1).
+ */
+class HostPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->hasVerifiedEmail();
+    }
+
+    public function view(User $user, Host $host): bool
+    {
+        return $user->hasVerifiedEmail();
+    }
+
+    /**
+     * `create` is project-scoped — invoked via
+     * `Gate::authorize('create', [Host::class, $project])`.
+     */
+    public function create(User $user, ?Project $project): bool
+    {
+        return $project !== null
+            && $user->hasVerifiedEmail()
+            && $user->can('update', $project);
+    }
+
+    public function update(User $user, Host $host): bool
+    {
+        $project = $host->project;
+
+        return $project !== null
+            && $user->hasVerifiedEmail()
+            && $user->can('update', $project);
+    }
+
+    public function delete(User $user, Host $host): bool
+    {
+        return $this->update($user, $host);
+    }
+
+    /** Token issue/rotate/revoke share the host's update gate. */
+    public function manageTokens(User $user, Host $host): bool
+    {
+        return $this->update($user, $host);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,9 +2,13 @@
 
 namespace App\Providers;
 
+use App\Models\AgentToken;
+use App\Models\Host;
 use App\Models\Project;
 use App\Models\Repository;
 use App\Models\Website;
+use App\Policies\AgentTokenPolicy;
+use App\Policies\HostPolicy;
 use App\Policies\ProjectPolicy;
 use App\Policies\RepositoryPolicy;
 use App\Policies\WebsitePolicy;
@@ -33,6 +37,8 @@ class AppServiceProvider extends ServiceProvider
         Gate::policy(Project::class, ProjectPolicy::class);
         Gate::policy(Repository::class, RepositoryPolicy::class);
         Gate::policy(Website::class, WebsitePolicy::class);
+        Gate::policy(Host::class, HostPolicy::class);
+        Gate::policy(AgentToken::class, AgentTokenPolicy::class);
 
         // Force https URL generation when APP_URL is https. Required for
         // Cloudflare/ngrok tunnels: TLS terminates at the tunnel and

--- a/database/factories/AgentTokenFactory.php
+++ b/database/factories/AgentTokenFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AgentToken;
+use App\Models\Host;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<AgentToken> */
+class AgentTokenFactory extends Factory
+{
+    protected $model = AgentToken::class;
+
+    public function definition(): array
+    {
+        // Tests almost never need the plaintext — they assert against
+        // the hash directly. When they do need the plaintext, they go
+        // through `IssueAgentTokenAction` which is the production path.
+        $plaintext = Str::random(40);
+
+        return [
+            'host_id' => Host::factory(),
+            'name' => 'agent token',
+            'hashed_token' => AgentToken::hash($plaintext),
+            'last_used_at' => null,
+            'revoked_at' => null,
+            'created_by_user_id' => null,
+        ];
+    }
+
+    public function revoked(): static
+    {
+        return $this->state(fn () => [
+            'revoked_at' => now(),
+        ]);
+    }
+}

--- a/database/factories/ContainerFactory.php
+++ b/database/factories/ContainerFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Container;
+use App\Models\Host;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<Container> */
+class ContainerFactory extends Factory
+{
+    protected $model = Container::class;
+
+    public function definition(): array
+    {
+        return [
+            'host_id' => Host::factory(),
+            'project_id' => null,
+            'container_id' => Str::random(12),
+            'name' => 'svc-'.fake()->word(),
+            'image' => 'nginx',
+            'image_tag' => 'latest',
+            'status' => 'running',
+            'state' => 'running',
+            'health_status' => null,
+            'ports' => [],
+            'labels' => [],
+            'cpu_percent' => null,
+            'memory_usage_mb' => null,
+            'memory_limit_mb' => null,
+            'memory_percent' => null,
+            'network_rx_bytes' => null,
+            'network_tx_bytes' => null,
+            'block_read_bytes' => null,
+            'block_write_bytes' => null,
+            'started_at' => now()->subHours(2),
+            'finished_at' => null,
+            'last_seen_at' => now(),
+        ];
+    }
+}

--- a/database/factories/ContainerMetricSnapshotFactory.php
+++ b/database/factories/ContainerMetricSnapshotFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Container;
+use App\Models\ContainerMetricSnapshot;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<ContainerMetricSnapshot> */
+class ContainerMetricSnapshotFactory extends Factory
+{
+    protected $model = ContainerMetricSnapshot::class;
+
+    public function definition(): array
+    {
+        return [
+            'container_id' => Container::factory(),
+            'cpu_percent' => fake()->randomFloat(1, 0, 100),
+            'memory_usage_mb' => fake()->numberBetween(64, 4096),
+            'memory_limit_mb' => 4096,
+            'memory_percent' => fake()->randomFloat(1, 0, 100),
+            'network_rx_bytes' => fake()->numberBetween(0, 1_000_000_000),
+            'network_tx_bytes' => fake()->numberBetween(0, 1_000_000_000),
+            'block_read_bytes' => fake()->numberBetween(0, 1_000_000_000),
+            'block_write_bytes' => fake()->numberBetween(0, 1_000_000_000),
+            'recorded_at' => now(),
+        ];
+    }
+}

--- a/database/factories/HostFactory.php
+++ b/database/factories/HostFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\HostConnectionType;
+use App\Enums\HostStatus;
+use App\Models\Host;
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<Host> */
+class HostFactory extends Factory
+{
+    protected $model = Host::class;
+
+    public function definition(): array
+    {
+        $name = fake()->unique()->domainWord().'-'.fake()->randomNumber(2, true);
+
+        return [
+            'project_id' => Project::factory(),
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'provider' => 'self-hosted',
+            'endpoint_url' => null,
+            'connection_type' => HostConnectionType::Agent->value,
+            'status' => HostStatus::Pending->value,
+            'last_seen_at' => null,
+            'cpu_count' => null,
+            'memory_total_mb' => null,
+            'disk_total_gb' => null,
+            'os' => null,
+            'docker_version' => null,
+            'metadata' => null,
+            'archived_at' => null,
+        ];
+    }
+
+    public function online(): static
+    {
+        return $this->state(fn () => [
+            'status' => HostStatus::Online->value,
+            'last_seen_at' => now(),
+            'cpu_count' => 4,
+            'memory_total_mb' => 8192,
+            'disk_total_gb' => 100,
+            'os' => 'Ubuntu 24.04',
+            'docker_version' => '26.1.0',
+        ]);
+    }
+
+    public function archived(): static
+    {
+        return $this->state(fn () => [
+            'status' => HostStatus::Archived->value,
+            'archived_at' => now(),
+        ]);
+    }
+}

--- a/database/factories/HostMetricSnapshotFactory.php
+++ b/database/factories/HostMetricSnapshotFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Host;
+use App\Models\HostMetricSnapshot;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<HostMetricSnapshot> */
+class HostMetricSnapshotFactory extends Factory
+{
+    protected $model = HostMetricSnapshot::class;
+
+    public function definition(): array
+    {
+        return [
+            'host_id' => Host::factory(),
+            'cpu_percent' => fake()->randomFloat(1, 5, 95),
+            'memory_used_mb' => fake()->numberBetween(1024, 16384),
+            'memory_total_mb' => 16384,
+            'disk_used_gb' => fake()->numberBetween(20, 200),
+            'disk_total_gb' => 256,
+            'load_average' => fake()->randomFloat(2, 0, 4),
+            'network_rx_bytes' => fake()->numberBetween(1_000_000, 10_000_000_000),
+            'network_tx_bytes' => fake()->numberBetween(1_000_000, 10_000_000_000),
+            'recorded_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/2026_05_01_080000_create_hosts_table.php
+++ b/database/migrations/2026_05_01_080000_create_hosts_table.php
@@ -1,0 +1,79 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('hosts', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('project_id')
+                ->constrained('projects')
+                ->cascadeOnDelete();
+
+            $table->string('name');
+            // Slug is unique within a project so URLs (28+) and agent
+            // self-identification can rely on it. Per-project rather
+            // than global so two projects can both have a `prod-01`.
+            $table->string('slug', 80);
+
+            // Free-text label of where the host runs (e.g. "DigitalOcean
+            // FRA1", "self-hosted"). Pure metadata for now — the agent
+            // strategy split (§6.5 of the roadmap) will bind it later.
+            $table->string('provider', 32)->nullable();
+
+            // Informational only for `connection_type=agent` (the agent
+            // pushes to us). Reserved for ssh/docker_api strategies in
+            // a later phase.
+            $table->string('endpoint_url', 2048)->nullable();
+
+            // agent | ssh | docker_api | manual (per HostConnectionType
+            // enum). Phase 6 only ships the `agent` path; the others
+            // exist as data so a host can be migrated without a column
+            // rename later.
+            $table->string('connection_type', 16)->default('agent');
+
+            // pending | online | offline | degraded | archived (per
+            // HostStatus enum). `pending` is the initial state — a host
+            // that has never reported telemetry. Transitions to other
+            // states arrive in 027 (online on first telemetry) and 029
+            // (offline / degraded via the watcher).
+            $table->string('status', 16)->default('pending');
+
+            $table->timestamp('last_seen_at')->nullable();
+
+            // Static facts captured from telemetry once the host is
+            // online (or filled in by the user at create time). Stored
+            // as columns rather than JSON because they're surfaced on
+            // the host card and queried in aggregate.
+            $table->unsignedSmallInteger('cpu_count')->nullable();
+            $table->unsignedInteger('memory_total_mb')->nullable();
+            $table->unsignedInteger('disk_total_gb')->nullable();
+            $table->string('os', 80)->nullable();
+            $table->string('docker_version', 32)->nullable();
+
+            // Free-form bag for fields we don't yet promote to columns
+            // (kernel version, agent build, region tags). Bounded by
+            // payload validation in 027.
+            $table->json('metadata')->nullable();
+
+            // Soft-archive: keep the row for historical reports but hide
+            // it from the active list. Pairs with `status=archived`.
+            $table->timestamp('archived_at')->nullable();
+
+            $table->timestamps();
+
+            $table->unique(['project_id', 'slug']);
+            $table->index(['project_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('hosts');
+    }
+};

--- a/database/migrations/2026_05_01_080001_create_agent_tokens_table.php
+++ b/database/migrations/2026_05_01_080001_create_agent_tokens_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('agent_tokens', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('host_id')
+                ->constrained('hosts')
+                ->cascadeOnDelete();
+
+            // Optional human label so a user can rotate tokens without
+            // losing context ("rotated 2026-05-01", "agent v0.2"). The
+            // active token also doubles as the install-command label.
+            $table->string('name', 80)->nullable();
+
+            // sha256 of the plaintext bearer token. Plaintext is shown
+            // to the user once at issuance/rotation and then discarded.
+            // Unique so middleware can `where(hashed_token = ?)` and
+            // hit the index.
+            $table->string('hashed_token', 64)->unique();
+
+            $table->timestamp('last_used_at')->nullable();
+
+            // Set when the token is rotated or explicitly revoked. The
+            // hash stays in the row so a stolen plaintext can be traced
+            // post-incident; middleware ignores rows where this is set.
+            $table->timestamp('revoked_at')->nullable();
+
+            $table->foreignId('created_by_user_id')
+                ->nullable()
+                ->constrained('users')
+                ->nullOnDelete();
+
+            $table->timestamps();
+
+            // Active-token lookup pattern: by host, scoped to non-revoked
+            // rows. Index covers the host_id half; the revoked filter is
+            // small enough to satisfy at scan time.
+            $table->index(['host_id', 'revoked_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('agent_tokens');
+    }
+};

--- a/database/migrations/2026_05_01_080002_create_containers_table.php
+++ b/database/migrations/2026_05_01_080002_create_containers_table.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('containers', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('host_id')
+                ->constrained('hosts')
+                ->cascadeOnDelete();
+
+            // Optional project pin — set when the container's labels
+            // identify it as belonging to a specific project. Defaults
+            // null; the agent reconciliation in 027 fills it where it
+            // can.
+            $table->foreignId('project_id')
+                ->nullable()
+                ->constrained('projects')
+                ->nullOnDelete();
+
+            // Docker's own container ID (12 or 64 char hex). Unique per
+            // host because Docker recycles short IDs across hosts.
+            $table->string('container_id', 80);
+
+            $table->string('name');
+            $table->string('image');
+            $table->string('image_tag', 128)->nullable();
+
+            // running | exited | created | paused | restarting | dead.
+            // Stored as string so Docker's evolving status set doesn't
+            // require migrations.
+            $table->string('status', 32)->nullable();
+
+            // Same string as `status` historically — kept distinct
+            // because Docker's `State` object is richer (boolean
+            // running, paused, etc.). MVP just mirrors `status`; future
+            // probes can populate fine-grained fields.
+            $table->string('state', 32)->nullable();
+
+            // healthy | unhealthy | starting | none. Sourced from
+            // Docker healthcheck output when present.
+            $table->string('health_status', 16)->nullable();
+
+            $table->json('ports')->nullable();
+            $table->json('labels')->nullable();
+
+            // Latest stat sample. The full time series goes into
+            // container_metric_snapshots; these columns power the
+            // current-state UI without a join.
+            $table->float('cpu_percent')->nullable();
+            $table->unsignedBigInteger('memory_usage_mb')->nullable();
+            $table->unsignedBigInteger('memory_limit_mb')->nullable();
+            $table->float('memory_percent')->nullable();
+            $table->unsignedBigInteger('network_rx_bytes')->nullable();
+            $table->unsignedBigInteger('network_tx_bytes')->nullable();
+            $table->unsignedBigInteger('block_read_bytes')->nullable();
+            $table->unsignedBigInteger('block_write_bytes')->nullable();
+
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('finished_at')->nullable();
+            $table->timestamp('last_seen_at')->nullable();
+
+            $table->timestamps();
+
+            $table->unique(['host_id', 'container_id']);
+            $table->index(['host_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('containers');
+    }
+};

--- a/database/migrations/2026_05_01_080003_create_host_metric_snapshots_table.php
+++ b/database/migrations/2026_05_01_080003_create_host_metric_snapshots_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('host_metric_snapshots', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('host_id')
+                ->constrained('hosts')
+                ->cascadeOnDelete();
+
+            // Percentage utilisation at the snapshot moment. Stored as
+            // float — Docker reports up to 1 decimal place.
+            $table->float('cpu_percent')->nullable();
+
+            $table->unsignedBigInteger('memory_used_mb')->nullable();
+            $table->unsignedBigInteger('memory_total_mb')->nullable();
+            $table->unsignedBigInteger('disk_used_gb')->nullable();
+            $table->unsignedBigInteger('disk_total_gb')->nullable();
+
+            // Unix `uptime` 1-min load average. Not normalised against
+            // CPU count — that's done at render time.
+            $table->float('load_average')->nullable();
+
+            $table->unsignedBigInteger('network_rx_bytes')->nullable();
+            $table->unsignedBigInteger('network_tx_bytes')->nullable();
+
+            // The agent's clock for when these stats were observed. The
+            // `created_at` column captures when the row landed, which is
+            // useful for ingestion-lag monitoring.
+            $table->timestamp('recorded_at');
+
+            $table->timestamps();
+
+            // Time-series query pattern.
+            $table->index(['host_id', 'recorded_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('host_metric_snapshots');
+    }
+};

--- a/database/migrations/2026_05_01_080004_create_container_metric_snapshots_table.php
+++ b/database/migrations/2026_05_01_080004_create_container_metric_snapshots_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('container_metric_snapshots', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('container_id')
+                ->constrained('containers')
+                ->cascadeOnDelete();
+
+            $table->float('cpu_percent')->nullable();
+            $table->unsignedBigInteger('memory_usage_mb')->nullable();
+            $table->unsignedBigInteger('memory_limit_mb')->nullable();
+            $table->float('memory_percent')->nullable();
+            $table->unsignedBigInteger('network_rx_bytes')->nullable();
+            $table->unsignedBigInteger('network_tx_bytes')->nullable();
+            $table->unsignedBigInteger('block_read_bytes')->nullable();
+            $table->unsignedBigInteger('block_write_bytes')->nullable();
+
+            $table->timestamp('recorded_at');
+
+            $table->timestamps();
+
+            $table->index(['container_id', 'recorded_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('container_metric_snapshots');
+    }
+};

--- a/resources/js/Components/Hosts/AgentTokenPanel.vue
+++ b/resources/js/Components/Hosts/AgentTokenPanel.vue
@@ -1,0 +1,212 @@
+<script setup lang="ts">
+import DangerButton from '@/Components/DangerButton.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+import { router, usePage } from '@inertiajs/vue3';
+import {
+    AlertTriangle,
+    Check,
+    Copy,
+    KeyRound,
+    RefreshCcw,
+    ShieldAlert,
+    ShieldCheck,
+} from 'lucide-vue-next';
+import { computed, ref } from 'vue';
+
+interface ActiveAgentToken {
+    id: number;
+    name: string | null;
+    last_used_at: string | null;
+    created_at: string | null;
+}
+
+const props = defineProps<{
+    hostId: number;
+    activeToken: ActiveAgentToken | null;
+    canManageTokens: boolean;
+}>();
+
+// Plaintext flashed by the controller after issue/rotate. Read-only —
+// once the user navigates away the page reload drops it. We never echo
+// it into anything but the copy-to-clipboard / display affordance below.
+const page = usePage();
+const flashedPlaintext = computed<string | null>(
+    () => page.props.flash?.agentTokenPlaintext ?? null,
+);
+
+const copied = ref(false);
+const copyToClipboard = async () => {
+    if (!flashedPlaintext.value) return;
+    try {
+        await navigator.clipboard.writeText(flashedPlaintext.value);
+        copied.value = true;
+        setTimeout(() => (copied.value = false), 2000);
+    } catch {
+        // Clipboard unavailable (insecure context, denied permission).
+        // The user can still select-and-copy the visible string.
+    }
+};
+
+const issueToken = () => {
+    if (!props.canManageTokens) return;
+    router.post(
+        route('monitoring.hosts.tokens.store', props.hostId),
+        {},
+        { preserveScroll: true },
+    );
+};
+
+const rotateToken = () => {
+    if (!props.canManageTokens || !props.activeToken) return;
+    if (
+        !window.confirm(
+            'Rotate this agent token? The current token will stop working immediately.',
+        )
+    ) {
+        return;
+    }
+    router.post(
+        route('monitoring.hosts.tokens.rotate', [
+            props.hostId,
+            props.activeToken.id,
+        ]),
+        {},
+        { preserveScroll: true },
+    );
+};
+
+const revokeToken = () => {
+    if (!props.canManageTokens || !props.activeToken) return;
+    if (
+        !window.confirm(
+            'Revoke this agent token? The host will stop ingesting telemetry until a new token is minted.',
+        )
+    ) {
+        return;
+    }
+    router.delete(
+        route('monitoring.hosts.tokens.destroy', [
+            props.hostId,
+            props.activeToken.id,
+        ]),
+        { preserveScroll: true },
+    );
+};
+</script>
+
+<template>
+    <section
+        class="glass-card flex flex-col gap-4 p-6"
+        aria-labelledby="agent-token-heading"
+    >
+        <header class="flex items-center gap-2">
+            <KeyRound
+                class="h-4 w-4 text-accent-cyan"
+                aria-hidden="true"
+            />
+            <h2
+                id="agent-token-heading"
+                class="text-sm font-semibold uppercase tracking-[0.32em] text-text-secondary"
+            >
+                Agent token
+            </h2>
+        </header>
+
+        <div
+            v-if="flashedPlaintext"
+            class="flex flex-col gap-2 rounded-lg border border-status-warning/40 bg-status-warning/10 p-3"
+            role="status"
+        >
+            <div
+                class="flex items-start gap-2 text-xs text-status-warning"
+            >
+                <AlertTriangle
+                    class="mt-0.5 h-4 w-4 shrink-0"
+                    aria-hidden="true"
+                />
+                <p class="leading-relaxed">
+                    Copy this token now — Nexus stores only a hash and
+                    cannot show it again. Anyone with this token can
+                    submit telemetry as this host.
+                </p>
+            </div>
+            <div
+                class="flex items-center gap-2 rounded-md border border-border-subtle bg-slate-950/80 px-3 py-2"
+            >
+                <code
+                    class="flex-1 truncate font-mono text-xs text-text-primary"
+                    aria-label="Agent token plaintext"
+                >
+                    {{ flashedPlaintext }}
+                </code>
+                <button
+                    type="button"
+                    class="inline-flex items-center gap-1 rounded-md border border-accent-cyan/40 bg-accent-cyan/10 px-2 py-1 text-[11px] font-semibold text-accent-cyan transition hover:border-accent-cyan/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                    @click="copyToClipboard"
+                >
+                    <component
+                        :is="copied ? Check : Copy"
+                        class="h-3 w-3"
+                        aria-hidden="true"
+                    />
+                    {{ copied ? 'Copied' : 'Copy' }}
+                </button>
+            </div>
+        </div>
+
+        <div
+            v-if="activeToken"
+            class="flex flex-col gap-1 rounded-md border border-border-subtle bg-background-panel-hover px-3 py-2 text-xs text-text-secondary"
+        >
+            <div class="flex items-center gap-2 text-status-success">
+                <ShieldCheck class="h-4 w-4" aria-hidden="true" />
+                <span class="font-semibold uppercase tracking-[0.2em]">
+                    Active token
+                </span>
+            </div>
+            <p>
+                <span v-if="activeToken.last_used_at">
+                    Last seen {{ activeToken.last_used_at }}
+                </span>
+                <span v-else>Never used yet — awaiting first telemetry.</span>
+            </p>
+        </div>
+
+        <div
+            v-else
+            class="flex items-start gap-2 rounded-md border border-border-subtle bg-background-panel-hover px-3 py-2 text-xs text-text-muted"
+        >
+            <ShieldAlert
+                class="mt-0.5 h-4 w-4 shrink-0"
+                aria-hidden="true"
+            />
+            <p>
+                No active token. Mint one to authorise the agent that
+                runs on this host.
+            </p>
+        </div>
+
+        <div
+            v-if="canManageTokens"
+            class="flex flex-wrap items-center justify-end gap-2"
+        >
+            <PrimaryButton
+                v-if="!activeToken"
+                type="button"
+                @click="issueToken"
+            >
+                Mint agent token
+            </PrimaryButton>
+            <template v-else>
+                <SecondaryButton type="button" @click="rotateToken">
+                    <RefreshCcw class="mr-1 h-3 w-3" aria-hidden="true" />
+                    Rotate
+                </SecondaryButton>
+                <DangerButton type="button" @click="revokeToken">
+                    Revoke
+                </DangerButton>
+            </template>
+        </div>
+    </section>
+</template>

--- a/resources/js/Pages/Monitoring/Hosts/Create.vue
+++ b/resources/js/Pages/Monitoring/Hosts/Create.vue
@@ -1,0 +1,173 @@
+<script setup lang="ts">
+import InputError from '@/Components/InputError.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import { ChevronLeft } from 'lucide-vue-next';
+
+interface ProjectOption {
+    id: number;
+    name: string;
+    color: string | null;
+}
+
+interface ConnectionTypeOption {
+    value: string;
+    label: string;
+    enabled: boolean;
+}
+
+const props = defineProps<{
+    projects: ProjectOption[];
+    preselectedProjectId: number | null;
+    options: {
+        connection_types: ConnectionTypeOption[];
+    };
+}>();
+
+const form = useForm({
+    project_id: props.preselectedProjectId ?? props.projects[0]?.id ?? null,
+    name: '',
+    provider: '',
+    endpoint_url: '',
+    connection_type: 'agent',
+});
+
+const submit = () => {
+    form.post(route('monitoring.hosts.store'));
+};
+</script>
+
+<template>
+    <Head title="New host" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <Link
+                    :href="route('monitoring.hosts.index')"
+                    class="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan transition hover:text-accent-cyan/80"
+                >
+                    <ChevronLeft class="h-3 w-3" aria-hidden="true" />
+                    Hosts
+                </Link>
+                <h1 class="text-lg font-semibold text-text-primary">
+                    New host
+                </h1>
+            </div>
+        </template>
+
+        <div class="mx-auto max-w-2xl px-4 py-6 sm:px-6 lg:px-8">
+            <form
+                class="glass-card flex flex-col gap-5 p-6"
+                @submit.prevent="submit"
+            >
+                <div class="flex flex-col gap-2">
+                    <InputLabel for="project_id" value="Project" />
+                    <select
+                        id="project_id"
+                        v-model.number="form.project_id"
+                        class="rounded-md border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:border-accent-cyan/60 focus:outline-none"
+                    >
+                        <option
+                            v-for="project in projects"
+                            :key="project.id"
+                            :value="project.id"
+                        >
+                            {{ project.name }}
+                        </option>
+                    </select>
+                    <InputError :message="form.errors.project_id" />
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <InputLabel for="name" value="Name" />
+                    <TextInput
+                        id="name"
+                        v-model="form.name"
+                        type="text"
+                        placeholder="prod-frankfurt-01"
+                        autofocus
+                    />
+                    <p class="text-xs text-text-muted">
+                        A short label that uniquely identifies this host
+                        within the project.
+                    </p>
+                    <InputError :message="form.errors.name" />
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <InputLabel
+                        for="provider"
+                        value="Provider (optional)"
+                    />
+                    <TextInput
+                        id="provider"
+                        v-model="form.provider"
+                        type="text"
+                        placeholder="DigitalOcean FRA1"
+                    />
+                    <InputError :message="form.errors.provider" />
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <InputLabel
+                        for="connection_type"
+                        value="Connection"
+                    />
+                    <select
+                        id="connection_type"
+                        v-model="form.connection_type"
+                        class="rounded-md border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:border-accent-cyan/60 focus:outline-none"
+                    >
+                        <option
+                            v-for="opt in options.connection_types"
+                            :key="opt.value"
+                            :value="opt.value"
+                            :disabled="!opt.enabled"
+                        >
+                            {{ opt.label }}
+                        </option>
+                    </select>
+                    <p class="text-xs text-text-muted">
+                        Phase 6 ships the agent (push) path. SSH and
+                        Docker API will be wired up in a later phase.
+                    </p>
+                    <InputError :message="form.errors.connection_type" />
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <InputLabel
+                        for="endpoint_url"
+                        value="Endpoint URL (optional)"
+                    />
+                    <TextInput
+                        id="endpoint_url"
+                        v-model="form.endpoint_url"
+                        type="url"
+                        placeholder="https://prod-01.example.com"
+                    />
+                    <p class="text-xs text-text-muted">
+                        Informational only for the agent path — the
+                        agent pushes to Nexus.
+                    </p>
+                    <InputError :message="form.errors.endpoint_url" />
+                </div>
+
+                <div class="flex items-center justify-end gap-3">
+                    <Link
+                        :href="route('monitoring.hosts.index')"
+                        class="text-sm font-semibold text-text-secondary hover:text-text-primary"
+                    >
+                        Cancel
+                    </Link>
+                    <PrimaryButton :disabled="form.processing">
+                        Create host
+                    </PrimaryButton>
+                </div>
+            </form>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Monitoring/Hosts/Edit.vue
+++ b/resources/js/Pages/Monitoring/Hosts/Edit.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import InputError from '@/Components/InputError.vue';
+import InputLabel from '@/Components/InputLabel.vue';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import TextInput from '@/Components/TextInput.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import { ChevronLeft } from 'lucide-vue-next';
+
+interface HostPayload {
+    id: number;
+    name: string;
+    provider: string | null;
+    endpoint_url: string | null;
+    connection_type: string | null;
+    project: { id: number; name: string } | null;
+}
+
+const props = defineProps<{
+    host: HostPayload;
+    options: {
+        connection_types: { value: string; label: string; enabled: boolean }[];
+    };
+}>();
+
+const form = useForm({
+    name: props.host.name,
+    provider: props.host.provider ?? '',
+    endpoint_url: props.host.endpoint_url ?? '',
+});
+
+const submit = () => {
+    form.patch(route('monitoring.hosts.update', props.host.id));
+};
+</script>
+
+<template>
+    <Head :title="`Edit ${host.name}`" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <Link
+                    :href="route('monitoring.hosts.show', host.id)"
+                    class="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan transition hover:text-accent-cyan/80"
+                >
+                    <ChevronLeft class="h-3 w-3" aria-hidden="true" />
+                    {{ host.name }}
+                </Link>
+                <h1 class="text-lg font-semibold text-text-primary">
+                    Edit host
+                </h1>
+            </div>
+        </template>
+
+        <div class="mx-auto max-w-2xl px-4 py-6 sm:px-6 lg:px-8">
+            <form
+                class="glass-card flex flex-col gap-5 p-6"
+                @submit.prevent="submit"
+            >
+                <div class="flex flex-col gap-2">
+                    <InputLabel for="name" value="Name" />
+                    <TextInput id="name" v-model="form.name" type="text" />
+                    <InputError :message="form.errors.name" />
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <InputLabel for="provider" value="Provider" />
+                    <TextInput
+                        id="provider"
+                        v-model="form.provider"
+                        type="text"
+                    />
+                    <InputError :message="form.errors.provider" />
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <InputLabel for="endpoint_url" value="Endpoint URL" />
+                    <TextInput
+                        id="endpoint_url"
+                        v-model="form.endpoint_url"
+                        type="url"
+                    />
+                    <InputError :message="form.errors.endpoint_url" />
+                </div>
+
+                <p class="text-xs text-text-muted">
+                    Project and connection type are fixed after
+                    creation. Archive and re-create the host if you need
+                    to change those.
+                </p>
+
+                <div class="flex items-center justify-end gap-3">
+                    <Link
+                        :href="route('monitoring.hosts.show', host.id)"
+                        class="text-sm font-semibold text-text-secondary hover:text-text-primary"
+                    >
+                        Cancel
+                    </Link>
+                    <PrimaryButton :disabled="form.processing">
+                        Save changes
+                    </PrimaryButton>
+                </div>
+            </form>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Monitoring/Hosts/Index.vue
+++ b/resources/js/Pages/Monitoring/Hosts/Index.vue
@@ -1,0 +1,198 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import { hostStatusTone as statusTone } from '@/lib/hostStyles';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link } from '@inertiajs/vue3';
+import { Plus, Server, ShieldAlert, ShieldCheck } from 'lucide-vue-next';
+
+interface ProjectChip {
+    id: number;
+    slug: string;
+    name: string;
+    color: string | null;
+    icon: string | null;
+}
+
+interface ActiveAgentToken {
+    id: number;
+    name: string | null;
+    last_used_at: string | null;
+    created_at: string | null;
+}
+
+interface HostRow {
+    id: number;
+    name: string;
+    slug: string;
+    provider: string | null;
+    connection_type: string | null;
+    status:
+        | 'pending'
+        | 'online'
+        | 'offline'
+        | 'degraded'
+        | 'archived'
+        | string
+        | null;
+    last_seen_at: string | null;
+    project: ProjectChip | null;
+    active_agent_token: ActiveAgentToken | null;
+}
+
+defineProps<{
+    hosts: HostRow[];
+}>();
+
+const projectAccentClass = (color: string | null) =>
+    (
+        ({
+            cyan: 'text-accent-cyan',
+            blue: 'text-accent-blue',
+            purple: 'text-accent-purple',
+            magenta: 'text-accent-magenta',
+            success: 'text-status-success',
+            warning: 'text-status-warning',
+        }) as const
+    )[color ?? ''] ?? 'text-text-muted';
+</script>
+
+<template>
+    <Head title="Monitoring · Hosts" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <span
+                    class="text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan"
+                >
+                    Phase 6
+                </span>
+                <h1 class="text-lg font-semibold text-text-primary">
+                    Hosts
+                </h1>
+            </div>
+        </template>
+
+        <div class="mx-auto max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
+            <header class="mb-6 flex flex-wrap items-end justify-between gap-3">
+                <div class="flex flex-col gap-2">
+                    <h2 class="text-xl font-semibold text-text-primary">
+                        Docker hosts
+                    </h2>
+                    <p class="text-sm text-text-secondary">
+                        Hosts running the Nexus agent. Mint a token,
+                        install the agent, and the host's CPU, memory,
+                        and containers stream into Nexus. Telemetry
+                        ingestion lands in spec 027.
+                    </p>
+                </div>
+                <Link
+                    :href="route('monitoring.hosts.create')"
+                    class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/15 px-3 py-2 text-sm font-semibold text-accent-cyan transition hover:border-accent-cyan/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                >
+                    <Plus class="h-4 w-4" aria-hidden="true" />
+                    Add host
+                </Link>
+            </header>
+
+            <div
+                v-if="hosts.length === 0"
+                class="glass-card flex flex-col items-center justify-center gap-3 px-6 py-16 text-center"
+            >
+                <span
+                    class="flex h-12 w-12 items-center justify-center rounded-full border border-border-subtle bg-slate-950/60"
+                >
+                    <Server
+                        class="h-5 w-5 text-text-muted"
+                        aria-hidden="true"
+                    />
+                </span>
+                <p class="text-sm font-medium text-text-secondary">
+                    No hosts yet
+                </p>
+                <p class="max-w-sm text-xs text-text-muted">
+                    Add your first host to start tracking Docker
+                    container health, CPU, and memory across your
+                    infrastructure.
+                </p>
+            </div>
+
+            <ul v-else class="flex flex-col gap-2">
+                <li v-for="host in hosts" :key="host.id">
+                    <Link
+                        :href="route('monitoring.hosts.show', host.id)"
+                        class="glass-card flex items-center gap-4 px-4 py-3 transition hover:border-accent-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                    >
+                        <Server
+                            class="h-4 w-4 shrink-0 text-text-muted"
+                            aria-hidden="true"
+                        />
+                        <div class="flex min-w-0 flex-1 flex-col gap-1">
+                            <div class="flex items-center gap-2">
+                                <span
+                                    class="truncate text-sm font-semibold text-text-primary"
+                                >
+                                    {{ host.name }}
+                                </span>
+                                <span
+                                    v-if="host.project"
+                                    class="inline-flex items-center gap-1 rounded-full border border-current/30 px-1.5 py-0.5 text-[10px] font-mono uppercase tracking-[0.18em]"
+                                    :class="projectAccentClass(host.project.color)"
+                                >
+                                    {{ host.project.name }}
+                                </span>
+                            </div>
+                            <p
+                                class="flex flex-wrap items-center gap-x-2 gap-y-1 truncate text-xs text-text-muted"
+                            >
+                                <span
+                                    v-if="host.provider"
+                                    class="font-mono text-text-secondary"
+                                >
+                                    {{ host.provider }}
+                                </span>
+                                <span
+                                    v-if="host.connection_type"
+                                    class="font-mono uppercase"
+                                >
+                                    {{ host.connection_type }}
+                                </span>
+                                <span v-if="host.last_seen_at">
+                                    · Last seen {{ host.last_seen_at }}
+                                </span>
+                                <span v-else class="text-text-muted/70">
+                                    · Awaiting first telemetry
+                                </span>
+                            </p>
+                        </div>
+                        <div class="flex shrink-0 items-center gap-2">
+                            <span
+                                v-if="host.active_agent_token"
+                                class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-status-success"
+                            >
+                                <ShieldCheck
+                                    class="h-3 w-3"
+                                    aria-hidden="true"
+                                />
+                                Token
+                            </span>
+                            <span
+                                v-else
+                                class="inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-text-muted"
+                            >
+                                <ShieldAlert
+                                    class="h-3 w-3"
+                                    aria-hidden="true"
+                                />
+                                No token
+                            </span>
+                            <StatusBadge :tone="statusTone(host.status)">
+                                {{ host.status }}
+                            </StatusBadge>
+                        </div>
+                    </Link>
+                </li>
+            </ul>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Monitoring/Hosts/Show.vue
+++ b/resources/js/Pages/Monitoring/Hosts/Show.vue
@@ -1,0 +1,250 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import AgentTokenPanel from '@/Components/Hosts/AgentTokenPanel.vue';
+import { hostStatusTone as statusTone } from '@/lib/hostStyles';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import {
+    ChevronLeft,
+    ExternalLink,
+    PencilLine,
+    Trash2,
+} from 'lucide-vue-next';
+
+interface ActiveAgentToken {
+    id: number;
+    name: string | null;
+    last_used_at: string | null;
+    created_at: string | null;
+}
+
+interface ProjectChip {
+    id: number;
+    slug: string;
+    name: string;
+    color: string | null;
+    icon: string | null;
+}
+
+interface HostPayload {
+    id: number;
+    name: string;
+    slug: string;
+    provider: string | null;
+    endpoint_url: string | null;
+    connection_type: string | null;
+    status:
+        | 'pending'
+        | 'online'
+        | 'offline'
+        | 'degraded'
+        | 'archived'
+        | string
+        | null;
+    last_seen_at: string | null;
+    cpu_count: number | null;
+    memory_total_mb: number | null;
+    disk_total_gb: number | null;
+    os: string | null;
+    docker_version: string | null;
+    project: ProjectChip | null;
+    active_agent_token: ActiveAgentToken | null;
+}
+
+const props = defineProps<{
+    host: HostPayload;
+    canUpdate: boolean;
+    canDelete: boolean;
+    canManageTokens: boolean;
+}>();
+
+const archive = () => {
+    if (
+        !window.confirm(
+            'Archive this host? Existing agent tokens will be revoked. Telemetry history is kept.',
+        )
+    ) {
+        return;
+    }
+    router.delete(route('monitoring.hosts.destroy', props.host.id));
+};
+</script>
+
+<template>
+    <Head :title="`Host · ${host.name}`" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <Link
+                    :href="route('monitoring.hosts.index')"
+                    class="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan transition hover:text-accent-cyan/80"
+                >
+                    <ChevronLeft class="h-3 w-3" aria-hidden="true" />
+                    Hosts
+                </Link>
+                <h1 class="text-lg font-semibold text-text-primary">
+                    {{ host.name }}
+                </h1>
+            </div>
+        </template>
+
+        <div
+            class="mx-auto flex max-w-4xl flex-col gap-4 px-4 py-6 sm:px-6 lg:px-8"
+        >
+            <section class="glass-card flex flex-col gap-4 p-6">
+                <header
+                    class="flex flex-wrap items-start justify-between gap-3"
+                >
+                    <div class="flex flex-col gap-2">
+                        <div class="flex items-center gap-2">
+                            <h2
+                                class="text-xl font-semibold text-text-primary"
+                            >
+                                {{ host.name }}
+                            </h2>
+                            <StatusBadge :tone="statusTone(host.status)">
+                                {{ host.status }}
+                            </StatusBadge>
+                        </div>
+                        <p
+                            class="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-text-muted"
+                        >
+                            <span
+                                v-if="host.project"
+                                class="font-mono uppercase tracking-[0.18em] text-text-secondary"
+                            >
+                                {{ host.project.name }}
+                            </span>
+                            <span v-if="host.provider">
+                                · {{ host.provider }}
+                            </span>
+                            <span v-if="host.connection_type">
+                                · {{ host.connection_type }} push
+                            </span>
+                            <span v-if="host.last_seen_at">
+                                · Last seen {{ host.last_seen_at }}
+                            </span>
+                            <span v-else class="text-text-muted/70">
+                                · Awaiting first telemetry
+                            </span>
+                        </p>
+                    </div>
+                    <div class="flex shrink-0 items-center gap-2">
+                        <Link
+                            v-if="canUpdate"
+                            :href="route('monitoring.hosts.edit', host.id)"
+                            class="inline-flex items-center gap-1 rounded-md border border-border-subtle bg-background-panel-hover px-2 py-1 text-xs font-semibold text-text-secondary transition hover:border-accent-cyan/60 hover:text-text-primary"
+                        >
+                            <PencilLine
+                                class="h-3 w-3"
+                                aria-hidden="true"
+                            />
+                            Edit
+                        </Link>
+                        <button
+                            v-if="canDelete"
+                            type="button"
+                            class="inline-flex items-center gap-1 rounded-md border border-status-danger/40 bg-status-danger/10 px-2 py-1 text-xs font-semibold text-status-danger transition hover:border-status-danger/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-status-danger/60"
+                            @click="archive"
+                        >
+                            <Trash2 class="h-3 w-3" aria-hidden="true" />
+                            Archive
+                        </button>
+                    </div>
+                </header>
+
+                <dl
+                    class="grid grid-cols-2 gap-4 border-t border-border-subtle pt-4 text-xs sm:grid-cols-4"
+                >
+                    <div class="flex flex-col gap-1">
+                        <dt class="uppercase tracking-[0.18em] text-text-muted">
+                            CPU cores
+                        </dt>
+                        <dd
+                            class="font-mono text-sm text-text-primary"
+                        >
+                            {{ host.cpu_count ?? '—' }}
+                        </dd>
+                    </div>
+                    <div class="flex flex-col gap-1">
+                        <dt class="uppercase tracking-[0.18em] text-text-muted">
+                            Memory
+                        </dt>
+                        <dd
+                            class="font-mono text-sm text-text-primary"
+                        >
+                            {{
+                                host.memory_total_mb !== null
+                                    ? `${Math.round(host.memory_total_mb / 1024)} GB`
+                                    : '—'
+                            }}
+                        </dd>
+                    </div>
+                    <div class="flex flex-col gap-1">
+                        <dt class="uppercase tracking-[0.18em] text-text-muted">
+                            Disk
+                        </dt>
+                        <dd
+                            class="font-mono text-sm text-text-primary"
+                        >
+                            {{
+                                host.disk_total_gb !== null
+                                    ? `${host.disk_total_gb} GB`
+                                    : '—'
+                            }}
+                        </dd>
+                    </div>
+                    <div class="flex flex-col gap-1">
+                        <dt class="uppercase tracking-[0.18em] text-text-muted">
+                            Docker
+                        </dt>
+                        <dd
+                            class="font-mono text-sm text-text-primary"
+                        >
+                            {{ host.docker_version ?? '—' }}
+                        </dd>
+                    </div>
+                </dl>
+
+                <p
+                    v-if="host.endpoint_url"
+                    class="flex items-center gap-1 text-xs text-text-muted"
+                >
+                    Endpoint
+                    <a
+                        :href="host.endpoint_url"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="font-mono text-text-secondary transition hover:text-accent-cyan"
+                    >
+                        {{ host.endpoint_url }}
+                        <ExternalLink
+                            class="ml-1 inline h-3 w-3"
+                            aria-hidden="true"
+                        />
+                    </a>
+                </p>
+            </section>
+
+            <AgentTokenPanel
+                :host-id="host.id"
+                :active-token="host.active_agent_token"
+                :can-manage-tokens="canManageTokens"
+            />
+
+            <section
+                class="glass-card flex flex-col gap-2 border-dashed p-6 text-xs text-text-muted"
+            >
+                <p class="font-semibold uppercase tracking-[0.2em] text-text-secondary">
+                    Coming in spec 027 / 028
+                </p>
+                <p>
+                    Telemetry ingestion (CPU, memory, container stats)
+                    and the host's container table arrive in the next
+                    two specs of phase 6.
+                </p>
+            </section>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/lib/hostStyles.ts
+++ b/resources/js/lib/hostStyles.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared style helpers for Docker hosts (spec 026).
+ *
+ * Mirrors `websiteStyles.ts`: keep this map in sync with
+ * `HostStatus::badgeTone()` so server- and client-rendered badges
+ * agree.
+ */
+
+export type HostStatusValue =
+    | 'pending'
+    | 'online'
+    | 'offline'
+    | 'degraded'
+    | 'archived'
+    | string
+    | null;
+
+export const hostStatusTone = (
+    status: HostStatusValue,
+): 'muted' | 'success' | 'warning' | 'danger' =>
+    (
+        ({
+            pending: 'muted',
+            online: 'success',
+            offline: 'danger',
+            degraded: 'warning',
+            archived: 'muted',
+        }) as const
+    )[status ?? ''] ?? 'muted';

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -14,6 +14,12 @@ export type PageProps<
     flash?: {
         status?: string | null;
         error?: string | null;
+        /**
+         * Spec 026 — plaintext agent token surfaced once after issue or
+         * rotate. Read by `Components/Hosts/AgentTokenPanel.vue`. Never
+         * persisted on the client; the next page load drops it.
+         */
+        agentTokenPlaintext?: string | null;
     };
     /**
      * Right-rail activity feed shared by `HandleInertiaRequests::share()`

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,8 @@ use App\Http\Controllers\ActivityController;
 use App\Http\Controllers\DeploymentController;
 use App\Http\Controllers\GithubConnectionController;
 use App\Http\Controllers\GithubRepositoryImportController;
+use App\Http\Controllers\Monitoring\AgentTokenController;
+use App\Http\Controllers\Monitoring\HostController;
 use App\Http\Controllers\Monitoring\WebsiteController;
 use App\Http\Controllers\Monitoring\WebsiteProbeController;
 use App\Http\Controllers\OverviewController;
@@ -98,6 +100,18 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->names('monitoring.websites');
     Route::post('/monitoring/websites/{website}/probe', WebsiteProbeController::class)
         ->name('monitoring.websites.probe');
+
+    // Spec 026 — Docker hosts CRUD + agent token lifecycle. Telemetry
+    // ingestion arrives in spec 027; the UI metric rendering in 028.
+    Route::resource('monitoring/hosts', HostController::class)
+        ->parameters(['hosts' => 'host'])
+        ->names('monitoring.hosts');
+    Route::post('/monitoring/hosts/{host}/tokens', [AgentTokenController::class, 'store'])
+        ->name('monitoring.hosts.tokens.store');
+    Route::post('/monitoring/hosts/{host}/tokens/{token}/rotate', [AgentTokenController::class, 'rotate'])
+        ->name('monitoring.hosts.tokens.rotate');
+    Route::delete('/monitoring/hosts/{host}/tokens/{token}', [AgentTokenController::class, 'destroy'])
+        ->name('monitoring.hosts.tokens.destroy');
 });
 
 // Spec 017 — GitHub webhooks (no auth/CSRF; signature-verified inside).

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,7 +41,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 3 | GitHub Webhooks & Activity Feed | 🟢 | 3/3 specs done (017–019). Phase complete. |
 | 4 | Deployments & CI/CD | 🟢 | 3/3 specs done (020–022). Phase complete. |
 | 5 | Website Monitoring | 🟢 | 3/3 specs done (023–025). Phase complete. |
-| 6 | Docker Host Agent MVP | 🟡 | 0/4 specs done (026–029). Folder + spec 026 drafted. |
+| 6 | Docker Host Agent MVP | 🟡 | 1/4 specs done (026–029). 026 shipped. |
 | 7 | Alerts Engine | ⬜ | — |
 | 8 | Analytics & Health Scores | ⬜ | — |
 | 9 | Polish & Production Readiness | ⬜ | — |

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,7 +41,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 3 | GitHub Webhooks & Activity Feed | 🟢 | 3/3 specs done (017–019). Phase complete. |
 | 4 | Deployments & CI/CD | 🟢 | 3/3 specs done (020–022). Phase complete. |
 | 5 | Website Monitoring | 🟢 | 3/3 specs done (023–025). Phase complete. |
-| 6 | Docker Host Agent MVP | ⬜ | — |
+| 6 | Docker Host Agent MVP | 🟡 | 0/4 specs done (026–029). Folder + spec 026 drafted. |
 | 7 | Alerts Engine | ⬜ | — |
 | 8 | Analytics & Health Scores | ⬜ | — |
 | 9 | Polish & Production Readiness | ⬜ | — |

--- a/specs/phase-6-docker-hosts/026-hosts-and-agent-tokens.md
+++ b/specs/phase-6-docker-hosts/026-hosts-and-agent-tokens.md
@@ -87,7 +87,7 @@ Roadmap refs: §8.7 Docker Hosts, §9.1 Core Tables, §16.5 Agent Security.
    - `resources/js/Pages/Monitoring/Hosts/Index.vue` — table with name, project, status badge, last seen, agent token state.
    - `resources/js/Pages/Monitoring/Hosts/Create.vue` + `Edit.vue` — forms (mirrors `Monitoring/Websites/{Create,Edit}.vue`).
    - `resources/js/Pages/Monitoring/Hosts/Show.vue` — detail page for the host card + token panel. Metric rendering is intentionally deferred to 028; this page exists so the post-create redirect target is real.
-   - `resources/js/Components/Hosts/HostStatusBadge.vue`.
+   - `resources/js/lib/hostStyles.ts` — `hostStatusTone()` helper consumed by the existing shared `Components/Dashboard/StatusBadge.vue`. Mirrors `websiteStyles.ts`; avoids spinning up a host-specific badge wrapper for one tone map.
    - `resources/js/Components/Hosts/AgentTokenPanel.vue` — handles "show once" plaintext reveal (driven by `flash('agentTokenPlaintext')`) + copy-to-clipboard + rotate confirmation.
    - The project detail page already has a Hosts tab placeholder (verified in `resources/js/Pages/Projects/Show.vue:170`). No change needed here in 026 — the placeholder already shows "Phase 6" pending state.
    - Sidebar: `Hosts` link **stays disabled** until 028 wires it to `monitoring.hosts.index`.
@@ -125,10 +125,14 @@ Fill in as work progresses.
 - `app/Policies/AgentTokenPolicy.php` — new
 - `app/Http/Controllers/Monitoring/HostController.php` — new
 - `app/Http/Controllers/Monitoring/AgentTokenController.php` — new
-- `app/Http/Requests/Monitoring/{StoreHostRequest,UpdateHostRequest}.php` — new
+- `app/Http/Requests/Monitoring/{StoreHostRequest,UpdateHostRequest,StoreAgentTokenRequest}.php` — new
+- `app/Http/Middleware/HandleInertiaRequests.php` — share `flash.agentTokenPlaintext`
+- `app/Providers/AppServiceProvider.php` — register HostPolicy + AgentTokenPolicy
 - `routes/web.php` — register new routes
 - `resources/js/Pages/Monitoring/Hosts/{Index,Create,Edit,Show}.vue` — new
-- `resources/js/Components/Hosts/{HostStatusBadge,AgentTokenPanel}.vue` — new
+- `resources/js/Components/Hosts/AgentTokenPanel.vue` — new
+- `resources/js/lib/hostStyles.ts` — new (replaces planned HostStatusBadge.vue)
+- `resources/js/types/index.d.ts` — extend `flash` with `agentTokenPlaintext`
 - `tests/Feature/Monitoring/HostControllerTest.php` — new
 - `tests/Feature/Monitoring/HostPolicyTest.php` — new
 - `tests/Feature/Monitoring/AgentTokenLifecycleTest.php` — new
@@ -138,6 +142,9 @@ Fill in as work progresses.
 ### 2026-05-01
 - Spec drafted.
 - Issue [#78](https://github.com/Copxer/nexus/issues/78) opened, branch `spec/026-hosts-and-agent-tokens` cut off `main`.
+- Implementation landed in one commit: 5 migrations, 5 models, 2 enums, 7 actions (incl. DTO), 2 policies, 2 controllers, 3 form requests, 4 Vue pages + 1 component + 1 style helper, route registrations, Inertia flash plumbing.
+- Self-review pass via `superpowers:code-reviewer` surfaced 4 should-fix items: (1) rotate mismatched-pair test missing, (2) sibling-isolation feature tests missing for show/edit/update/destroy, (3) token name length silently truncated instead of validated, (4) `ArchiveHostAction` not idempotent on `archived_at`. All four addressed in a follow-up commit.
+- Tests grew 20 → 27 (added rotate-mismatch, store-overlong-name, archive-idempotent, sibling-blocked × 4). Full suite 434 passing, Pint clean, build green.
 
 ## Open questions / blockers
 - Are agent tokens scoped per-host (current plan) or per-team? Per-host is more secure and matches §16.5; sticking with per-host unless we change our minds.

--- a/specs/phase-6-docker-hosts/026-hosts-and-agent-tokens.md
+++ b/specs/phase-6-docker-hosts/026-hosts-and-agent-tokens.md
@@ -1,0 +1,144 @@
+---
+spec: hosts-and-agent-tokens
+phase: 6
+status: in-progress
+owner: Yoany
+created: 2026-05-01
+updated: 2026-05-01
+---
+
+# 026 — Hosts + Agent Tokens Scaffolding
+
+## Goal
+Lay the data + auth foundation for Phase 6. Add the `hosts`, `agent_tokens`, `containers`, `host_metric_snapshots`, and `container_metric_snapshots` tables; build the host CRUD UX inside Settings; and let the user mint an agent token (shown once, hashed at rest) and rotate it. No telemetry ingestion in this spec — that lands in 027.
+
+Roadmap refs: §8.7 Docker Hosts, §9.1 Core Tables, §16.5 Agent Security.
+
+## Scope
+
+**In scope:**
+- Migrations + models for `hosts`, `agent_tokens`, `containers`, `host_metric_snapshots`, `container_metric_snapshots`.
+- `Host` policy + factory; `AgentToken` policy + factory.
+- Host CRUD action classes (`CreateHostAction`, `UpdateHostAction`, `ArchiveHostAction`).
+- Token issuance (`IssueAgentTokenAction`) — generates a random 40-char token, stores `hashed_token`, returns plaintext **once** in the response payload only.
+- Token rotation (`RotateAgentTokenAction`) — invalidates the previous token by replacing the hash; previous plaintext is unrecoverable.
+- Settings UI under `/settings/integrations/hosts` (or analogous route consistent with how other integrations live):
+  - Hosts table.
+  - Create / edit form.
+  - "Show install command" panel that displays the agent token **once** after creation/rotation.
+- Project detail page gets a "Hosts" tab placeholder (real wiring lands in 028).
+- Tests for: action classes, policy gating, token issuance flow (token shown once, hash persisted), rotation flow.
+
+**Out of scope:**
+- The `/agent/telemetry` endpoint and `agent.auth` middleware (027).
+- Reference agent script (027).
+- Hosts index/show pages and metric rendering (028).
+- Offline detection job + activity events (029).
+- Alert table integration (Phase 7).
+
+## Plan
+
+1. **Migrations.** New files under `database/migrations/` in this order:
+   - `create_hosts_table` — fields per roadmap §8.7 (`id`, `project_id`, `name`, `slug`, `provider`, `endpoint_url` *nullable*, `connection_type`, `status` enum (`pending|online|offline|degraded|archived`), `last_seen_at` *nullable*, `cpu_count`, `memory_total_mb`, `disk_total_gb`, `os`, `docker_version`, `metadata` json, `archived_at` *nullable*, timestamps). Slug unique per project.
+   - `create_agent_tokens_table` — `id`, `host_id`, `name` (label), `hashed_token` (string, indexed unique), `last_used_at` *nullable*, `revoked_at` *nullable*, `created_by_user_id`, timestamps.
+   - `create_containers_table` — fields per roadmap §8.7 (`id`, `host_id`, `project_id` *nullable*, `container_id`, `name`, `image`, `image_tag`, `status`, `state`, `health_status`, `ports` json, `labels` json, plus stats fields). Index on `(host_id, container_id)`.
+   - `create_host_metric_snapshots_table` — `id`, `host_id`, `cpu_percent`, `memory_used_mb`, `memory_total_mb`, `disk_used_gb`, `disk_total_gb`, `load_average` (float), `network_rx_bytes` bigint, `network_tx_bytes` bigint, `recorded_at`, timestamps. Index `(host_id, recorded_at)`.
+   - `create_container_metric_snapshots_table` — same shape but per-container plus `cpu_percent`, `memory_usage_mb`, `memory_limit_mb`, `block_read_bytes`, `block_write_bytes`. Index `(container_id, recorded_at)`.
+
+2. **Models.**
+   - `app/Models/Host.php` — belongsTo Project, hasMany AgentToken, hasMany Container, hasMany HostMetricSnapshot. Casts: `metadata` array, `last_seen_at` datetime, `archived_at` datetime, `status` to enum. `slug()` accessor.
+   - `app/Models/AgentToken.php` — belongsTo Host, belongsTo User (creator). Hidden: `hashed_token`. Static helper `findActiveByPlaintext(string $plaintext): ?self` that hashes + lookups; used later by middleware.
+   - `app/Models/Container.php`, `app/Models/HostMetricSnapshot.php`, `app/Models/ContainerMetricSnapshot.php`.
+
+3. **Enums.** (Repo convention: top-level `app/Enums/`, not nested under domain folders.)
+   - `app/Enums/HostStatus.php` — string enum (`pending|online|offline|degraded|archived`). Includes `badgeTone()` matching `WebsiteStatus::badgeTone()`.
+   - `app/Enums/HostConnectionType.php` — `agent | ssh | docker_api | manual`.
+
+4. **Actions.**
+   - `app/Domain/Docker/Actions/CreateHostAction.php` — input DTO, persists `Host` with `status: pending`, returns model.
+   - `app/Domain/Docker/Actions/UpdateHostAction.php`.
+   - `app/Domain/Docker/Actions/ArchiveHostAction.php` — soft-archive (sets `archived_at`, status `archived`, revokes any active tokens).
+   - `app/Domain/Docker/Actions/IssueAgentTokenAction.php` — generates `Str::random(40)`, computes `hash('sha256', ...)`, persists `AgentToken`, returns object containing `{token: AgentToken, plaintext: string}`. Plaintext is never logged.
+   - `app/Domain/Docker/Actions/RotateAgentTokenAction.php` — marks previous token revoked, issues a new one.
+   - `app/Domain/Docker/Actions/RevokeAgentTokenAction.php` — sets `revoked_at`.
+
+5. **Policies.**
+   - `app/Policies/HostPolicy.php` — view/update/delete tied to project membership (mirrors how `WebsitePolicy` was wired in Phase 5).
+   - `app/Policies/AgentTokenPolicy.php` — same.
+
+6. **Controllers + routes.** (Repo convention: hosts sit under `/monitoring/*` next to websites, per the comment in `WebsiteController.php`. Tests + Form Requests follow the same `Monitoring/` namespace.)
+   - `app/Http/Controllers/Monitoring/HostController.php` — index/create/store/show/edit/update/destroy. Uses Inertia. Mirrors `WebsiteController` (private `transform()` for response shape, `ownedProjects()` helper, `?project_id=N` preselect on `create`).
+   - `app/Http/Controllers/Monitoring/AgentTokenController.php` — `store`, `rotate`, `destroy`. Plaintext is returned via session flash on `store`/`rotate` so the Vue layer can show it once.
+   - `app/Http/Requests/Monitoring/StoreHostRequest.php` + `UpdateHostRequest.php`.
+   - Routes append to `routes/web.php` next to the websites routes:
+     ```php
+     Route::resource('monitoring/hosts', HostController::class)
+         ->parameters(['hosts' => 'host'])
+         ->names('monitoring.hosts');
+     Route::post('/monitoring/hosts/{host}/tokens', [AgentTokenController::class, 'store'])
+         ->name('monitoring.hosts.tokens.store');
+     Route::post('/monitoring/hosts/{host}/tokens/{token}/rotate', [AgentTokenController::class, 'rotate'])
+         ->name('monitoring.hosts.tokens.rotate');
+     Route::delete('/monitoring/hosts/{host}/tokens/{token}', [AgentTokenController::class, 'destroy'])
+         ->name('monitoring.hosts.tokens.destroy');
+     ```
+
+7. **Frontend (Monitoring/Hosts pages + components).**
+   - `resources/js/Pages/Monitoring/Hosts/Index.vue` — table with name, project, status badge, last seen, agent token state.
+   - `resources/js/Pages/Monitoring/Hosts/Create.vue` + `Edit.vue` — forms (mirrors `Monitoring/Websites/{Create,Edit}.vue`).
+   - `resources/js/Pages/Monitoring/Hosts/Show.vue` — detail page for the host card + token panel. Metric rendering is intentionally deferred to 028; this page exists so the post-create redirect target is real.
+   - `resources/js/Components/Hosts/HostStatusBadge.vue`.
+   - `resources/js/Components/Hosts/AgentTokenPanel.vue` — handles "show once" plaintext reveal (driven by `flash('agentTokenPlaintext')`) + copy-to-clipboard + rotate confirmation.
+   - The project detail page already has a Hosts tab placeholder (verified in `resources/js/Pages/Projects/Show.vue:170`). No change needed here in 026 — the placeholder already shows "Phase 6" pending state.
+   - Sidebar: `Hosts` link **stays disabled** until 028 wires it to `monitoring.hosts.index`.
+
+8. **Tests.**
+   - Feature: Settings hosts CRUD (index, store, update, archive). Auth required, policy enforced.
+   - Feature: token issue — plaintext returned in response, `hashed_token` matches `hash('sha256', plaintext)`.
+   - Feature: token rotate — old hash gone, new hash present, `last_used_at` cleared.
+   - Unit: `IssueAgentTokenAction` does not log plaintext (assert via Pail/log channel mock or simply by not depending on the logger).
+   - Existing test suites still green (`php artisan test`, `npm run build`, Pint).
+
+## Acceptance criteria
+- [ ] All five migrations apply cleanly on a fresh DB and roll back cleanly.
+- [ ] Models + factories exist; `php artisan tinker` can create a Host + AgentToken via factory.
+- [ ] Settings → Hosts page lists hosts under the current team's projects.
+- [ ] Creating a host then minting a token displays the plaintext **once**, then only ever shows the hash state.
+- [ ] Rotating a token replaces the active token; old plaintext no longer validates against any hash in DB.
+- [ ] Project detail page shows a `Hosts` tab with an empty state.
+- [ ] Sidebar still shows `Hosts` as disabled or marked "coming soon" — routing to a real index lands in 028.
+- [ ] Pint clean, tests green, `npm run build` succeeds.
+
+## Files touched
+Fill in as work progresses.
+
+- `database/migrations/...` — new migrations (5)
+- `app/Models/Host.php` — new
+- `app/Models/AgentToken.php` — new
+- `app/Models/Container.php` — new
+- `app/Models/HostMetricSnapshot.php` — new
+- `app/Models/ContainerMetricSnapshot.php` — new
+- `app/Enums/HostStatus.php` — new
+- `app/Enums/HostConnectionType.php` — new
+- `app/Domain/Docker/Actions/*.php` — new (5 actions)
+- `app/Policies/HostPolicy.php` — new
+- `app/Policies/AgentTokenPolicy.php` — new
+- `app/Http/Controllers/Monitoring/HostController.php` — new
+- `app/Http/Controllers/Monitoring/AgentTokenController.php` — new
+- `app/Http/Requests/Monitoring/{StoreHostRequest,UpdateHostRequest}.php` — new
+- `routes/web.php` — register new routes
+- `resources/js/Pages/Monitoring/Hosts/{Index,Create,Edit,Show}.vue` — new
+- `resources/js/Components/Hosts/{HostStatusBadge,AgentTokenPanel}.vue` — new
+- `tests/Feature/Monitoring/HostControllerTest.php` — new
+- `tests/Feature/Monitoring/HostPolicyTest.php` — new
+- `tests/Feature/Monitoring/AgentTokenLifecycleTest.php` — new
+
+## Work log
+
+### 2026-05-01
+- Spec drafted.
+- Issue [#78](https://github.com/Copxer/nexus/issues/78) opened, branch `spec/026-hosts-and-agent-tokens` cut off `main`.
+
+## Open questions / blockers
+- Are agent tokens scoped per-host (current plan) or per-team? Per-host is more secure and matches §16.5; sticking with per-host unless we change our minds.
+- Should `endpoint_url` be required for `connection_type=agent`? Plan: no — agent pushes to us, so the field is informational only and stays nullable.

--- a/specs/phase-6-docker-hosts/026-hosts-and-agent-tokens.md
+++ b/specs/phase-6-docker-hosts/026-hosts-and-agent-tokens.md
@@ -1,7 +1,7 @@
 ---
 spec: hosts-and-agent-tokens
 phase: 6
-status: in-progress
+status: done
 owner: Yoany
 created: 2026-05-01
 updated: 2026-05-01

--- a/specs/phase-6-docker-hosts/README.md
+++ b/specs/phase-6-docker-hosts/README.md
@@ -1,0 +1,31 @@
+# Phase 6 — Docker Host Agent MVP
+
+Source: [roadmap §19 Phase 6](../../nexus_control_center_roadmap.md), §8.7 Docker Hosts.
+
+## Phase goal
+Stand up Docker host + container monitoring end-to-end via a pull-from-agent model. By the end of phase 6, a user can register a host under a project, mint an agent token, run a small reference script on the host that posts telemetry to `/agent/telemetry`, and see the host + its containers with live CPU/memory on the Hosts page. Hosts that go silent past their timeout flip to offline and emit an activity event; a recovery does the same. The Overview Hosts KPI is fed by real data.
+
+## Tasks
+
+| # | Task | Status |
+|---|------|--------|
+| 026 | Hosts + agent tokens scaffolding (CRUD + token rotation) | ⬜ |
+| 027 | Telemetry ingestion endpoint + reference agent script | ⬜ |
+| 028 | Hosts UI (index + show + project Hosts tab) | ⬜ |
+| 029 | Host offline detection + activity events + Overview KPI wiring | ⬜ |
+
+## Acceptance criteria (phase-level)
+- [ ] User can create / edit / archive a host under a project.
+- [ ] User can mint an agent token (shown once) and rotate it.
+- [ ] Agent endpoint accepts signed telemetry, rejects invalid tokens, and is rate-limited.
+- [ ] Host + container snapshots persist with CPU / memory / disk / network fields.
+- [ ] Hosts index + detail pages render real data with empty/loading/error states.
+- [ ] Host that hasn't reported within its timeout flips to `offline` and emits a `host.offline` activity event; recovery emits `host.recovered`.
+- [ ] Overview Hosts KPI reflects real online/offline counts (no mocks).
+- [ ] Sidebar `Hosts` entry is enabled and routes to the hosts listing.
+- [ ] Pint + tests + build clean. CI green for every spec PR.
+
+## Scope notes
+- Alerts (the dedicated `alerts` table + acknowledge/resolve flow) are Phase 7. Phase 6 surfaces host issues as activity events only.
+- Container ↔ deployment correlation, Kubernetes, and cloud-provider integrations are out of scope.
+- The reference agent in 027 is a small Node script documenting the contract, not a production-ready Go binary.

--- a/specs/phase-6-docker-hosts/README.md
+++ b/specs/phase-6-docker-hosts/README.md
@@ -9,7 +9,7 @@ Stand up Docker host + container monitoring end-to-end via a pull-from-agent mod
 
 | # | Task | Status |
 |---|------|--------|
-| 026 | Hosts + agent tokens scaffolding (CRUD + token rotation) | ⬜ |
+| 026 | Hosts + agent tokens scaffolding (CRUD + token rotation) | 🟢 |
 | 027 | Telemetry ingestion endpoint + reference agent script | ⬜ |
 | 028 | Hosts UI (index + show + project Hosts tab) | ⬜ |
 | 029 | Host offline detection + activity events + Overview KPI wiring | ⬜ |

--- a/tests/Feature/Monitoring/AgentTokenLifecycleTest.php
+++ b/tests/Feature/Monitoring/AgentTokenLifecycleTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Tests\Feature\Monitoring;
+
+use App\Domain\Docker\Actions\IssueAgentTokenAction;
+use App\Domain\Docker\Actions\RotateAgentTokenAction;
+use App\Models\AgentToken;
+use App\Models\Host;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class AgentTokenLifecycleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_issue_returns_plaintext_once_and_persists_only_the_hash(): void
+    {
+        $action = app(IssueAgentTokenAction::class);
+        $host = Host::factory()->create();
+
+        $result = $action->execute($host, 'agent v0.1');
+
+        $this->assertSame(40, mb_strlen($result->plaintext));
+        $this->assertNotSame($result->plaintext, $result->token->hashed_token);
+        $this->assertSame(
+            AgentToken::hash($result->plaintext),
+            $result->token->fresh()->hashed_token,
+        );
+
+        // The DB never sees the plaintext.
+        $this->assertSame(
+            0,
+            AgentToken::query()->where('hashed_token', $result->plaintext)->count(),
+        );
+    }
+
+    public function test_issue_does_not_log_plaintext(): void
+    {
+        $host = Host::factory()->create();
+
+        $logSpy = Log::spy();
+
+        app(IssueAgentTokenAction::class)->execute($host);
+
+        // No log call at all is the strongest assertion. If we ever add
+        // an audit log call here, narrow the assertion to "the plaintext
+        // string isn't a substring of any logged message."
+        $logSpy->shouldNotHaveReceived('info');
+        $logSpy->shouldNotHaveReceived('debug');
+        $logSpy->shouldNotHaveReceived('warning');
+        $logSpy->shouldNotHaveReceived('error');
+    }
+
+    public function test_rotate_revokes_previous_active_tokens_and_issues_a_fresh_one(): void
+    {
+        $rotate = app(RotateAgentTokenAction::class);
+        $host = Host::factory()->create();
+        $existing = AgentToken::factory()->create(['host_id' => $host->id]);
+
+        $result = $rotate->execute($host, 'rotated');
+
+        $existing->refresh();
+        $this->assertNotNull($existing->revoked_at);
+
+        $this->assertNull($result->token->revoked_at);
+        $this->assertSame('rotated', $result->token->name);
+        $this->assertNotSame($existing->id, $result->token->id);
+    }
+
+    public function test_store_endpoint_flashes_plaintext_for_one_request(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+
+        $response = $this->actingAs($user)
+            ->post(route('monitoring.hosts.tokens.store', $host), ['name' => 'agent v0.1']);
+
+        $response->assertRedirect(route('monitoring.hosts.show', $host));
+        $response->assertSessionHas('agentTokenPlaintext');
+
+        $plaintext = session('agentTokenPlaintext');
+        $this->assertIsString($plaintext);
+        $this->assertSame(40, mb_strlen($plaintext));
+
+        $token = AgentToken::query()->where('host_id', $host->id)->latest('id')->firstOrFail();
+        $this->assertSame(AgentToken::hash($plaintext), $token->hashed_token);
+    }
+
+    public function test_rotate_endpoint_invalidates_old_plaintext(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+
+        // Mint the first token via the controller so we capture the
+        // real plaintext exactly once.
+        $this->actingAs($user)
+            ->post(route('monitoring.hosts.tokens.store', $host));
+        $oldPlaintext = session('agentTokenPlaintext');
+        $oldToken = AgentToken::query()->where('host_id', $host->id)->latest('id')->firstOrFail();
+
+        // Now rotate and capture the new plaintext.
+        $this->actingAs($user)
+            ->post(route('monitoring.hosts.tokens.rotate', [$host, $oldToken]))
+            ->assertRedirect(route('monitoring.hosts.show', $host));
+        $newPlaintext = session('agentTokenPlaintext');
+
+        $this->assertNotSame($oldPlaintext, $newPlaintext);
+
+        // The old plaintext's hash now belongs only to a revoked row.
+        $oldHashRow = AgentToken::query()
+            ->where('hashed_token', AgentToken::hash($oldPlaintext))
+            ->firstOrFail();
+        $this->assertNotNull($oldHashRow->revoked_at);
+
+        // The new plaintext's hash maps to an active row.
+        $newHashRow = AgentToken::query()
+            ->where('hashed_token', AgentToken::hash($newPlaintext))
+            ->firstOrFail();
+        $this->assertNull($newHashRow->revoked_at);
+    }
+
+    public function test_destroy_endpoint_revokes_a_token(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+        $token = AgentToken::factory()->create(['host_id' => $host->id]);
+
+        $this->actingAs($user)
+            ->delete(route('monitoring.hosts.tokens.destroy', [$host, $token]))
+            ->assertRedirect(route('monitoring.hosts.show', $host));
+
+        $token->refresh();
+        $this->assertNotNull($token->revoked_at);
+    }
+
+    public function test_token_endpoints_404_on_mismatched_pair(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $hostA = Host::factory()->create(['project_id' => $project->id]);
+        $hostB = Host::factory()->create(['project_id' => $project->id]);
+        $tokenForB = AgentToken::factory()->create(['host_id' => $hostB->id]);
+
+        $this->actingAs($user)
+            ->delete(route('monitoring.hosts.tokens.destroy', [$hostA, $tokenForB]))
+            ->assertNotFound();
+    }
+
+    public function test_token_endpoints_blocked_for_non_owner(): void
+    {
+        $owner = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+
+        $this->actingAs($other)
+            ->post(route('monitoring.hosts.tokens.store', $host))
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Monitoring/AgentTokenLifecycleTest.php
+++ b/tests/Feature/Monitoring/AgentTokenLifecycleTest.php
@@ -144,7 +144,7 @@ class AgentTokenLifecycleTest extends TestCase
         $this->assertNotNull($token->revoked_at);
     }
 
-    public function test_token_endpoints_404_on_mismatched_pair(): void
+    public function test_destroy_endpoint_404s_on_mismatched_pair(): void
     {
         $user = $this->verifiedUser();
         $project = Project::factory()->create(['owner_user_id' => $user->id]);
@@ -155,6 +155,43 @@ class AgentTokenLifecycleTest extends TestCase
         $this->actingAs($user)
             ->delete(route('monitoring.hosts.tokens.destroy', [$hostA, $tokenForB]))
             ->assertNotFound();
+
+        // The mismatched token must not have been touched.
+        $tokenForB->refresh();
+        $this->assertNull($tokenForB->revoked_at);
+    }
+
+    public function test_rotate_endpoint_404s_on_mismatched_pair(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $hostA = Host::factory()->create(['project_id' => $project->id]);
+        $hostB = Host::factory()->create(['project_id' => $project->id]);
+        $tokenForB = AgentToken::factory()->create(['host_id' => $hostB->id]);
+
+        $this->actingAs($user)
+            ->post(route('monitoring.hosts.tokens.rotate', [$hostA, $tokenForB]))
+            ->assertNotFound();
+
+        $tokenForB->refresh();
+        $this->assertNull($tokenForB->revoked_at);
+        // No new token should have been minted on either host.
+        $this->assertSame(1, AgentToken::query()->count());
+    }
+
+    public function test_store_endpoint_rejects_overlong_name(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+
+        $this->actingAs($user)
+            ->post(route('monitoring.hosts.tokens.store', $host), [
+                'name' => str_repeat('a', 81),
+            ])
+            ->assertSessionHasErrors('name');
+
+        $this->assertSame(0, AgentToken::query()->count());
     }
 
     public function test_token_endpoints_blocked_for_non_owner(): void

--- a/tests/Feature/Monitoring/HostControllerTest.php
+++ b/tests/Feature/Monitoring/HostControllerTest.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace Tests\Feature\Monitoring;
+
+use App\Enums\HostStatus;
+use App\Models\AgentToken;
+use App\Models\Host;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class HostControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_index_lists_hosts_under_users_projects(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Host::factory()->create([
+            'project_id' => $project->id,
+            'name' => 'prod-frankfurt-01',
+        ]);
+
+        // Sibling user's host must not leak.
+        $other = $this->verifiedUser();
+        $otherProject = Project::factory()->create(['owner_user_id' => $other->id]);
+        Host::factory()->create(['project_id' => $otherProject->id]);
+
+        $this->actingAs($user)
+            ->get(route('monitoring.hosts.index'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Monitoring/Hosts/Index')
+                    ->has('hosts', 1)
+                    ->where('hosts.0.name', 'prod-frankfurt-01')
+            );
+    }
+
+    public function test_create_form_renders_with_owned_projects(): void
+    {
+        $user = $this->verifiedUser();
+        Project::factory()->create(['owner_user_id' => $user->id]);
+
+        $this->actingAs($user)
+            ->get(route('monitoring.hosts.create'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Monitoring/Hosts/Create')
+                    ->has('projects', 1)
+                    ->has('options.connection_types')
+            );
+    }
+
+    public function test_store_creates_a_host_for_project_owner(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        $response = $this->actingAs($user)->post(route('monitoring.hosts.store'), [
+            'project_id' => $project->id,
+            'name' => 'prod-frankfurt-01',
+            'provider' => 'DigitalOcean',
+            'endpoint_url' => null,
+            'connection_type' => 'agent',
+        ]);
+
+        $host = Host::query()->firstWhere('name', 'prod-frankfurt-01');
+        $this->assertNotNull($host);
+        $this->assertSame(HostStatus::Pending, $host->status);
+        $this->assertSame('prod-frankfurt-01', $host->slug);
+        $response->assertRedirect(route('monitoring.hosts.show', $host));
+    }
+
+    public function test_store_assigns_a_unique_slug_per_project(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        Host::factory()->create([
+            'project_id' => $project->id,
+            'name' => 'prod-frankfurt-01',
+            'slug' => 'prod-frankfurt-01',
+        ]);
+
+        $this->actingAs($user)->post(route('monitoring.hosts.store'), [
+            'project_id' => $project->id,
+            'name' => 'prod-frankfurt-01',
+            'connection_type' => 'agent',
+        ])->assertRedirect();
+
+        $second = Host::query()->latest('id')->first();
+        $this->assertNotNull($second);
+        $this->assertSame('prod-frankfurt-01-2', $second->slug);
+    }
+
+    public function test_store_blocked_for_non_owner_of_target_project(): void
+    {
+        $owner = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+
+        $this->actingAs($other)
+            ->post(route('monitoring.hosts.store'), [
+                'project_id' => $project->id,
+                'name' => 'sneaky',
+                'connection_type' => 'agent',
+            ])
+            ->assertForbidden();
+
+        $this->assertSame(0, Host::query()->count());
+    }
+
+    public function test_store_rejects_invalid_connection_type(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        $this->actingAs($user)
+            ->post(route('monitoring.hosts.store'), [
+                'project_id' => $project->id,
+                'name' => 'host',
+                'connection_type' => 'wireless-pigeon',
+            ])
+            ->assertSessionHasErrors('connection_type');
+    }
+
+    public function test_show_returns_host_with_active_token_metadata(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+        AgentToken::factory()->create(['host_id' => $host->id, 'name' => 'agent v0.1']);
+
+        $this->actingAs($user)
+            ->get(route('monitoring.hosts.show', $host))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Monitoring/Hosts/Show')
+                    ->where('host.name', $host->name)
+                    ->where('host.active_agent_token.name', 'agent v0.1')
+                    ->where('canUpdate', true)
+                    ->where('canDelete', true)
+                    ->where('canManageTokens', true)
+            );
+    }
+
+    public function test_update_changes_the_host_for_owner(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $host = Host::factory()->create([
+            'project_id' => $project->id,
+            'name' => 'old',
+        ]);
+
+        $response = $this->actingAs($user)->patch(
+            route('monitoring.hosts.update', $host),
+            [
+                'name' => 'new-name',
+                'provider' => 'Hetzner',
+                'endpoint_url' => null,
+            ],
+        );
+
+        $host->refresh();
+        $this->assertSame('new-name', $host->name);
+        $this->assertSame('Hetzner', $host->provider);
+        $response->assertRedirect(route('monitoring.hosts.show', $host));
+    }
+
+    public function test_destroy_archives_the_host_and_revokes_active_tokens(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+        $token = AgentToken::factory()->create(['host_id' => $host->id]);
+
+        $this->actingAs($user)
+            ->delete(route('monitoring.hosts.destroy', $host))
+            ->assertRedirect(route('monitoring.hosts.index'));
+
+        $host->refresh();
+        $token->refresh();
+
+        $this->assertSame(HostStatus::Archived, $host->status);
+        $this->assertNotNull($host->archived_at);
+        $this->assertNotNull($token->revoked_at);
+    }
+}

--- a/tests/Feature/Monitoring/HostControllerTest.php
+++ b/tests/Feature/Monitoring/HostControllerTest.php
@@ -197,4 +197,91 @@ class HostControllerTest extends TestCase
         $this->assertNotNull($host->archived_at);
         $this->assertNotNull($token->revoked_at);
     }
+
+    public function test_destroy_is_idempotent_and_does_not_overwrite_archived_at(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+
+        $this->actingAs($user)->delete(route('monitoring.hosts.destroy', $host));
+        $host->refresh();
+        $firstArchivedAt = $host->archived_at;
+        $this->assertNotNull($firstArchivedAt);
+
+        $this->travel(5)->minutes();
+
+        $this->actingAs($user)->delete(route('monitoring.hosts.destroy', $host));
+        $host->refresh();
+
+        // archived_at should be pinned to the first archive, not the
+        // second call's `now()`.
+        $this->assertTrue($host->archived_at->equalTo($firstArchivedAt));
+    }
+
+    public function test_show_blocked_for_unrelated_user(): void
+    {
+        $owner = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+
+        // `view` policy is open in phase-1 (mirrors WebsitePolicy), but
+        // `canUpdate` / `canDelete` / `canManageTokens` must be false
+        // for a non-owner — that's what gates the buttons.
+        $this->actingAs($other)
+            ->get(route('monitoring.hosts.show', $host))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Monitoring/Hosts/Show')
+                    ->where('canUpdate', false)
+                    ->where('canDelete', false)
+                    ->where('canManageTokens', false)
+            );
+    }
+
+    public function test_edit_blocked_for_unrelated_user(): void
+    {
+        $owner = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+
+        $this->actingAs($other)
+            ->get(route('monitoring.hosts.edit', $host))
+            ->assertForbidden();
+    }
+
+    public function test_update_blocked_for_unrelated_user(): void
+    {
+        $owner = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $host = Host::factory()->create(['project_id' => $project->id, 'name' => 'kept']);
+
+        $this->actingAs($other)
+            ->patch(route('monitoring.hosts.update', $host), [
+                'name' => 'hijacked',
+                'provider' => null,
+                'endpoint_url' => null,
+            ])
+            ->assertForbidden();
+
+        $this->assertSame('kept', $host->fresh()->name);
+    }
+
+    public function test_destroy_blocked_for_unrelated_user(): void
+    {
+        $owner = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+
+        $this->actingAs($other)
+            ->delete(route('monitoring.hosts.destroy', $host))
+            ->assertForbidden();
+
+        $this->assertNull($host->fresh()->archived_at);
+    }
 }

--- a/tests/Feature/Monitoring/HostPolicyTest.php
+++ b/tests/Feature/Monitoring/HostPolicyTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Monitoring;
+
+use App\Models\Host;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class HostPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_create_requires_a_project_the_user_owns(): void
+    {
+        $owner = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+
+        $this->assertTrue($owner->can('create', [Host::class, $project]));
+        $this->assertFalse($other->can('create', [Host::class, $project]));
+        $this->assertFalse($owner->can('create', [Host::class, null]));
+    }
+
+    public function test_update_and_delete_follow_host_project_owner(): void
+    {
+        $owner = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+
+        $this->assertTrue($owner->can('update', $host));
+        $this->assertTrue($owner->can('delete', $host));
+        $this->assertTrue($owner->can('manageTokens', $host));
+
+        $this->assertFalse($other->can('update', $host));
+        $this->assertFalse($other->can('delete', $host));
+        $this->assertFalse($other->can('manageTokens', $host));
+    }
+
+    public function test_view_open_to_any_verified_user_in_phase_1(): void
+    {
+        $user = $this->verifiedUser();
+        $owner = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+
+        // Mirrors WebsitePolicy — single-tenant phase-1 keeps view open
+        // so the team-pivot lands without changing every callsite.
+        $this->assertTrue($user->can('view', $host));
+        $this->assertTrue($user->can('viewAny', Host::class));
+    }
+}


### PR DESCRIPTION
Closes #78

Spec: `specs/phase-6-docker-hosts/026-hosts-and-agent-tokens.md`

## Summary
- Lays the data + auth foundation for Phase 6 (Docker Host Agent MVP): five new tables (`hosts`, `agent_tokens`, `containers`, `host_metric_snapshots`, `container_metric_snapshots`), models, factories, and `HostStatus` / `HostConnectionType` enums.
- Adds the Docker domain actions (`Create/Update/Archive Host`, `Issue/Rotate/Revoke AgentToken`) plus a small `AgentTokenIssueResult` DTO. Plaintext bearer tokens are generated by `IssueAgentTokenAction`, returned exactly once via the DTO, flashed to the session for one-shot reveal in the UI, and never persisted, never logged. The DB only ever sees `sha256(plaintext)`.
- Wires `HostPolicy` + `AgentTokenPolicy` (project-owner gates mirroring `WebsitePolicy`), Inertia controllers + routes under `/monitoring/hosts/*`, and the matching Vue pages (Index / Create / Edit / Show) plus an `AgentTokenPanel` component that handles the one-shot plaintext reveal + copy + rotate / revoke confirmations.

## Test plan
- [x] All five migrations apply cleanly on a fresh DB and roll back cleanly (`migrate:fresh` + `migrate:rollback --step=5`).
- [x] Models + factories work end-to-end via `php artisan tinker`.
- [x] Settings → Monitoring → Hosts page lists hosts under the current user's projects (sibling-user data does not leak).
- [x] Creating a host then minting a token displays the plaintext **once** (via `flash.agentTokenPlaintext`); subsequent navigation drops it.
- [x] Rotating a token replaces the active row; the old plaintext's hash now belongs to a revoked row.
- [x] Project detail page shows a `Hosts` tab with an empty state (existing phase-pending placeholder; spec 028 wires the real list).
- [x] `vendor/bin/pint --dirty` clean.
- [x] `php artisan test` — 434 passing (+30 vs main).
- [x] `npm run build` succeeds.

## Self-review notes
Self-review pass via `superpowers:code-reviewer` flagged four should-fix items, all addressed in commit f4ee30a:
- `ArchiveHostAction` is now idempotent on `archived_at` — re-archive leaves the original timestamp pinned (with a feature test).
- Token name length validates via a new `StoreAgentTokenRequest` form request (`max:80`) instead of being silently `mb_substr`'d in the controller.
- Added the `rotate` mismatched-pair 404 test to mirror the existing `destroy` case (both endpoints share `ensureBelongs`).
- Added 4 sibling-isolation feature tests covering `show` / `edit` / `update` / `destroy`. The policy is unit-tested, but a controller-level regression (e.g., dropping `$this->authorize(...)`) would have slipped past those — these lock the contract end-to-end.

Spec deviation: `resources/js/lib/hostStyles.ts` (mirrors `websiteStyles.ts`) replaced the planned `HostStatusBadge.vue`. The spec's "Files touched" list was updated to reflect the actual approach.

Two nice-to-haves deferred (in scope for a future hardening pass, not blocking):
- Plaintext briefly lives in `sessions.payload` (encrypted with `APP_KEY`) for the redirect target's read. Known characteristic of any Laravel `redirect()->with(...)`. A future polish could return the plaintext via `useForm`'s `onSuccess` callback to skip the session round-trip.
- Inertia caches page props in `window.history.state`, so a back-nav after issuing a token will re-render the plaintext from history cache. Not a cross-user leak (same browser session, same authenticated user), but a tighter UX could `router.replace({ preserveState: false })` after the first paint.