### PR TITLE
chore: add scripts/dev-tunnels.sh for one-command tunneled dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Spec 017's webhook ingestion needs GitHub to be able to reach your dev server. P
 
 ### Browsing the dev UI through a Cloudflare tunnel
 
+> **Shortcut:** `./scripts/dev-tunnels.sh` does all of the steps below in one
+> command — boots 3 cloudflared tunnels, rewrites `.env` (incl. `SESSION_DOMAIN`
+> and `SANCTUM_STATEFUL_DOMAINS`), runs `php artisan optimize`, then hands off to
+> `composer run dev`. Tunnels are killed on Ctrl+C; `.env` keeps the tunnel URLs.
+> Read on if you want to understand what it does, or you need named tunnels.
+
 Sometimes you want to browse the running app from a public URL — to demo the dashboard, hit it from another device, or run an OAuth callback that GitHub can reach. `composer run dev` boots two long-running HTTP servers — Laravel on `:8000` and Vite on `:5173` — and the browser needs to talk to **both**. Tunneling only port 8000 will load the HTML but every Vite asset (`@vite/client`, `app.ts`, …) will 404 / CORS-fail because the page tries to fetch them from `localhost:5173`.
 
 Set up two cloudflared tunnels and point Vite at its public URL:

--- a/docs/superpowers/plans/2026-05-20-dev-tunnels-script.md
+++ b/docs/superpowers/plans/2026-05-20-dev-tunnels-script.md
@@ -1,0 +1,352 @@
+# `scripts/dev-tunnels.sh` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a single bash script that spawns 3 cloudflared quick tunnels, rewrites the matching `.env` keys, runs `php artisan optimize`, and execs `composer run dev` — replacing the documented 3-terminal-plus-manual-`.env`-edit ritual.
+
+**Architecture:** One bash script under `scripts/`, ~100 lines. Strict mode (`set -euo pipefail`). Preflight → parallel tunnel boot → log polling for URL capture → idempotent per-key sed rewrite of `.env` → cleanup trap on `INT TERM EXIT` → `composer run dev` in the foreground so the trap fires on Ctrl+C.
+
+**Tech Stack:** Bash 3.2+ (macOS default), BSD sed, `cloudflared`, the existing Laravel + composer tooling.
+
+**Reference spec:** [`docs/superpowers/specs/2026-05-20-dev-tunnels-script-design.md`](../specs/2026-05-20-dev-tunnels-script-design.md).
+
+**Verification strategy:** This codebase has no bash test framework (it's a Laravel + Vue app — PHPUnit and vue-tsc). Verification is per-task observed behavior, plus a final end-to-end smoke test. `shellcheck` is optional but recommended (`brew install shellcheck`) — if available, run it as a static check.
+
+---
+
+## File Structure
+
+| Path | Status | Responsibility |
+|---|---|---|
+| `scripts/dev-tunnels.sh` | new, executable | The entire script. Single file, top-to-bottom procedural. |
+
+Nothing else changes. No new composer scripts, no new env keys, no edits to existing dotfiles.
+
+---
+
+## Task 1: Scaffolding + preflight checks
+
+**Files:**
+- Create: `scripts/dev-tunnels.sh` (chmod +x)
+
+- [ ] **Step 1: Create the script with shebang, strict mode, and preflight**
+
+```bash
+mkdir -p scripts
+cat > scripts/dev-tunnels.sh <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."   # always run from repo root
+
+die() { printf '\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+info() { printf '\033[36m▸ %s\033[0m\n' "$*"; }
+ok() { printf '\033[32m✓ %s\033[0m\n' "$*"; }
+warn() { printf '\033[33m⚠ %s\033[0m\n' "$*"; }
+
+preflight() {
+  command -v cloudflared >/dev/null \
+    || die "cloudflared not on PATH — install with: brew install cloudflared"
+  [[ -f .env ]] \
+    || die ".env not found — run: cp .env.example .env && php artisan key:generate"
+  for port in 8000 5173 8080; do
+    if lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+      die "port $port already in use — find it with: lsof -nP -iTCP:$port -sTCP:LISTEN"
+    fi
+  done
+  ok "preflight passed"
+}
+
+preflight
+SCRIPT
+chmod +x scripts/dev-tunnels.sh
+```
+
+- [ ] **Step 2: Verify preflight runs cleanly (all 3 ports free, .env exists)**
+
+Run: `./scripts/dev-tunnels.sh`
+Expected: `▸ ... ✓ preflight passed` and exit 0. **Nothing else** — no tunnels yet.
+
+- [ ] **Step 3: Verify preflight fails clearly when port 8000 is taken**
+
+Run in two terminals:
+```bash
+# Terminal A — occupy 8000
+python3 -m http.server 8000
+
+# Terminal B
+./scripts/dev-tunnels.sh
+```
+Expected (Terminal B): `✗ port 8000 already in use — find it with: lsof -nP -iTCP:8000 -sTCP:LISTEN`, exit 1.
+Cleanup: Ctrl+C in Terminal A.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/dev-tunnels.sh
+git commit -m "feat(scripts): scaffold dev-tunnels.sh with preflight checks"
+```
+
+---
+
+## Task 2: Boot 3 tunnels in parallel + capture URLs
+
+**Files:**
+- Modify: `scripts/dev-tunnels.sh` (append after `preflight` call)
+
+- [ ] **Step 1: Add tunnel boot + URL capture + cleanup trap**
+
+Append to `scripts/dev-tunnels.sh` (before the final newline if any). The new code goes after the `preflight` call from Task 1:
+
+```bash
+TUNNEL_PIDS=()
+LOG_DIR=$(mktemp -d -t nexus-tunnels.XXXXXX)
+info "tunnel logs: $LOG_DIR"
+
+cleanup() {
+  if ((${#TUNNEL_PIDS[@]})); then
+    kill "${TUNNEL_PIDS[@]}" 2>/dev/null || true
+    wait 2>/dev/null || true
+  fi
+}
+trap cleanup INT TERM EXIT
+
+boot_tunnel() {
+  local port=$1 log="$LOG_DIR/tunnel-$1.log"
+  cloudflared tunnel --url "http://localhost:$port" >"$log" 2>&1 &
+  TUNNEL_PIDS+=("$!")
+  printf '%s' "$log"
+}
+
+wait_for_url() {
+  local log=$1 url=""
+  for _ in $(seq 1 60); do
+    url=$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' "$log" 2>/dev/null | head -1 || true)
+    if [[ -n "$url" ]]; then
+      printf '%s' "$url"
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
+info "booting 3 cloudflared tunnels in parallel…"
+LARAVEL_LOG=$(boot_tunnel 8000)
+VITE_LOG=$(boot_tunnel 5173)
+REVERB_LOG=$(boot_tunnel 8080)
+
+LARAVEL_URL=$(wait_for_url "$LARAVEL_LOG") || die "Laravel tunnel timed out — see $LARAVEL_LOG"
+ok "Laravel  → $LARAVEL_URL"
+VITE_URL=$(wait_for_url "$VITE_LOG") || die "Vite tunnel timed out — see $VITE_LOG"
+ok "Vite     → $VITE_URL"
+REVERB_URL=$(wait_for_url "$REVERB_LOG") || die "Reverb tunnel timed out — see $REVERB_LOG"
+ok "Reverb   → $REVERB_URL"
+```
+
+- [ ] **Step 2: Run the script and confirm all 3 URLs are captured**
+
+Run: `./scripts/dev-tunnels.sh`
+Expected output (URLs will vary):
+```
+▸ tunnel logs: /tmp/nexus-tunnels.XXXXXX
+▸ booting 3 cloudflared tunnels in parallel…
+✓ Laravel  → https://<random>.trycloudflare.com
+✓ Vite     → https://<random>.trycloudflare.com
+✓ Reverb   → https://<random>.trycloudflare.com
+```
+The script will then exit (we haven't added the `.env` rewrite yet), and the `EXIT` trap will kill the 3 cloudflared processes.
+
+- [ ] **Step 3: Verify tunnels were cleaned up on exit**
+
+Run: `pgrep -lf cloudflared || echo "no cloudflared processes"`
+Expected: `no cloudflared processes`
+
+- [ ] **Step 4: Verify timeout behavior by pointing one tunnel at a non-existent port**
+
+Edit `scripts/dev-tunnels.sh` temporarily:
+```bash
+# Change the line:
+LARAVEL_LOG=$(boot_tunnel 8000)
+# To:
+LARAVEL_LOG=$(boot_tunnel 9999)   # nothing listens here
+```
+Run: `./scripts/dev-tunnels.sh`
+Expected: still captures a tunnel URL (cloudflared assigns a URL even when nothing's behind it). This is fine — the timeout safety net is for cases where cloudflared itself fails (no network, auth issue, etc). Revert the edit before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/dev-tunnels.sh
+git commit -m "feat(scripts): boot 3 cloudflared tunnels and capture URLs"
+```
+
+---
+
+## Task 3: Rewrite `.env` with the 7 keys
+
+**Files:**
+- Modify: `scripts/dev-tunnels.sh` (append after the URL captures)
+
+- [ ] **Step 1: Add `write_env` and apply to the 7 keys**
+
+Append to `scripts/dev-tunnels.sh`:
+
+```bash
+write_env() {
+  local key=$1 val=$2
+  if grep -qE "^${key}=" .env; then
+    # Use | as sed delimiter since URLs contain /
+    sed -i '' "s|^${key}=.*|${key}=${val}|" .env
+  else
+    printf '%s=%s\n' "$key" "$val" >> .env
+  fi
+}
+
+LARAVEL_HOST="${LARAVEL_URL#https://}"
+REVERB_HOST="${REVERB_URL#https://}"
+
+info "rewriting .env…"
+write_env APP_URL                  "$LARAVEL_URL"
+write_env VITE_DEV_SERVER_URL      "$VITE_URL"
+write_env VITE_REVERB_HOST         "$REVERB_HOST"
+write_env VITE_REVERB_SCHEME       "https"
+write_env VITE_REVERB_PORT         "443"
+write_env SESSION_DOMAIN           ""
+write_env SANCTUM_STATEFUL_DOMAINS "${LARAVEL_HOST},localhost,127.0.0.1"
+ok ".env updated"
+```
+
+- [ ] **Step 2: Run the script and inspect `.env` to confirm rewrite**
+
+Run: `./scripts/dev-tunnels.sh`
+Then in another terminal (or after the script exits):
+```bash
+grep -E '^(APP_URL|VITE_DEV_SERVER_URL|VITE_REVERB_HOST|VITE_REVERB_SCHEME|VITE_REVERB_PORT|SESSION_DOMAIN|SANCTUM_STATEFUL_DOMAINS)=' .env
+```
+Expected: 7 lines, all reflecting the freshly-captured tunnel URLs. `APP_URL` and `VITE_DEV_SERVER_URL` are full `https://…trycloudflare.com` URLs; `VITE_REVERB_HOST` is just the bare hostname; `SESSION_DOMAIN=` is blank.
+
+- [ ] **Step 3: Re-run to confirm idempotency (no duplicate keys, just overwrites)**
+
+Run: `./scripts/dev-tunnels.sh`
+Then check there are no duplicate lines:
+```bash
+grep -cE '^APP_URL=' .env                  # should be 1
+grep -cE '^SANCTUM_STATEFUL_DOMAINS=' .env # should be 1
+```
+Expected: both print `1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/dev-tunnels.sh
+git commit -m "feat(scripts): rewrite .env with tunnel URLs + Sanctum/session config"
+```
+
+---
+
+## Task 4: Optimize, OAuth reminder, hand off to `composer run dev`
+
+**Files:**
+- Modify: `scripts/dev-tunnels.sh` (append the final section)
+
+- [ ] **Step 1: Add the optimize call, OAuth reminder, and composer dev**
+
+Append to `scripts/dev-tunnels.sh`:
+
+```bash
+clear
+info "running php artisan optimize…"
+php artisan optimize
+
+cat <<EOF
+
+$(printf '\033[33m⚠ Reminder:\033[0m update your GitHub App OAuth callback URL to:')
+    ${LARAVEL_URL}/integrations/github/callback
+
+GitHub App settings: https://github.com/settings/developers (or your GitHub App
+settings page if you registered as a GitHub App rather than an OAuth App).
+
+EOF
+
+info "handing off to composer run dev — Ctrl+C to stop everything"
+composer run dev
+```
+
+Note: **no `exec`**. We want the bash process to stay alive so the cleanup trap fires when composer exits or the user Ctrl+Cs.
+
+- [ ] **Step 2: End-to-end smoke run**
+
+Run: `./scripts/dev-tunnels.sh`
+Expected:
+1. Preflight passes.
+2. 3 tunnel URLs print.
+3. `.env` rewritten (no duplicates).
+4. `clear` wipes the terminal.
+5. `php artisan optimize` runs (you'll see config/route/event/view caching lines).
+6. The OAuth reminder prints with the new `APP_URL`.
+7. `composer run dev` boots — you'll see colored `server`, `queue`, `reverb`, `scheduler`, `logs`, `vite` rows from `concurrently`.
+8. Look for the `[vite] tunnel mode active — origin=…` line in the `vite:` rows. If it's missing, the script didn't successfully wire `VITE_DEV_SERVER_URL` — debug `.env`.
+9. Open the printed `APP_URL` in a browser. Sign-in/Overview should load with no CORS / 419 / Mixed Content errors.
+
+- [ ] **Step 3: Verify Ctrl+C cleanup**
+
+In the running script: press Ctrl+C.
+Expected:
+1. `concurrently` tears down server / queue / reverb / scheduler / logs / vite.
+2. The script exits (the `EXIT` trap fires after composer exits).
+3. Run `pgrep -lf cloudflared || echo "all clean"` — expected `all clean`.
+4. `.env` still has the tunnel URLs (per the design decision: leave `.env` tunneled).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/dev-tunnels.sh
+git commit -m "feat(scripts): optimize, OAuth reminder, hand off to composer dev"
+```
+
+---
+
+## Task 5: Optional static analysis + final polish
+
+- [ ] **Step 1: Run shellcheck if available**
+
+```bash
+command -v shellcheck && shellcheck scripts/dev-tunnels.sh || echo "shellcheck not installed — skipping (brew install shellcheck)"
+```
+Expected: either no output (clean) or a list of warnings to address. Fix any genuine issues; suppressions are okay if they're false positives (e.g. `# shellcheck disable=SC2155` is common for `local x=$(…)`).
+
+- [ ] **Step 2: README touch-up (optional but recommended)**
+
+The README's "Browsing the dev UI through a Cloudflare tunnel" section walks through the manual 3-tunnel ritual. Add a one-paragraph "Shortcut" callout pointing at the new script.
+
+Modify the section's intro paragraph in `README.md` near line 130:
+
+```markdown
+> **Shortcut:** `./scripts/dev-tunnels.sh` does all of the steps below in one
+> command — boots 3 cloudflared tunnels, rewrites `.env`, runs
+> `php artisan optimize`, and hands off to `composer run dev`. Read on if you
+> want to understand what it's doing or you need named tunnels instead.
+```
+
+- [ ] **Step 3: Commit (one commit for both, if you did step 2)**
+
+```bash
+git add scripts/dev-tunnels.sh README.md
+git commit -m "chore(scripts): shellcheck pass + README shortcut callout"
+```
+
+---
+
+## End-to-end acceptance criteria
+
+Before declaring done, all of these should be true on a fresh terminal session:
+
+- [ ] `./scripts/dev-tunnels.sh` boots from a clean repo state and ends with a working `composer run dev` running through 3 tunnels.
+- [ ] Browser can load the Overview page at the printed `APP_URL` with no console errors (no CORS from Vite, no 419 from sessions, no Mixed Content from forced HTTPS).
+- [ ] Ctrl+C in the running script kills all 3 cloudflared processes (`pgrep -lf cloudflared` returns nothing).
+- [ ] Running the script twice in a row does not duplicate any `.env` key (`grep -cE '^APP_URL=' .env` returns `1`).
+- [ ] If any port (8000 / 5173 / 8080) is already taken, the script exits with a clear remedy *before* booting any tunnel.
+- [ ] If `cloudflared` is missing or `.env` is missing, the script exits with a clear install/setup remedy.
+
+If any of the above fails, fix the script — don't paper over with documentation.

--- a/docs/superpowers/specs/2026-05-20-dev-tunnels-script-design.md
+++ b/docs/superpowers/specs/2026-05-20-dev-tunnels-script-design.md
@@ -1,0 +1,200 @@
+# Dev Tunnels Script — Design
+
+**Date:** 2026-05-20
+**Owner:** Yoany Vaillant
+**Status:** Design approved, ready for implementation plan
+
+## Goal
+
+Replace the manual 3-terminal-plus-edit-`.env` ritual described in
+[`README.md`](../../../README.md) (the "Browsing the dev UI through a Cloudflare
+tunnel" section) with a single command that brings up the full tunneled dev
+stack from scratch.
+
+One command, no copy-paste of trycloudflare URLs into `.env`.
+
+## Non-goals
+
+- **Named tunnels.** Only quick (`cloudflared tunnel --url ...`) tunnels. Named
+  tunnels need account/zone config that lives outside the repo.
+- **`.env` rollback.** When the script exits, `.env` keeps the tunnel URLs.
+  Restoring localhost defaults is manual (re-run with localhost or git-checkout
+  the file).
+- **GitHub App callback automation.** The script will *remind* the user to
+  update the OAuth callback URL after the Laravel tunnel URL changes; it does
+  not call the GitHub API to update it.
+- **Production / staging.** Dev-only utility. Never run against prod.
+
+## Inputs (decisions already locked in)
+
+| Question | Decision |
+|---|---|
+| On exit (Ctrl+C / crash) | Kill the 3 cloudflared PIDs. Leave `.env` tunneled. |
+| Artisan command before `composer dev` | `php artisan optimize` (user's call, against the recommendation to use `optimize:clear`; see "Known footgun" below) |
+| Script location + form | `scripts/dev-tunnels.sh`, bash, invoked as `./scripts/dev-tunnels.sh` |
+| Session / Sanctum handling | Auto-blank `SESSION_DOMAIN`, auto-write `SANCTUM_STATEFUL_DOMAINS=<laravel-host>,localhost,127.0.0.1` |
+| OAuth callback drift | Print a yellow reminder at the end pointing at the GitHub App settings URL |
+
+## Architecture
+
+Single bash script with `set -euo pipefail`. Execution order:
+
+```
+preflight  →  boot 3 tunnels in parallel  →  capture URLs (30s timeout each)  →
+rewrite .env (7 keys)  →  clear + php artisan optimize  →
+print OAuth callback reminder  →  run composer run dev (foreground, no exec)
+```
+
+Trap on `INT TERM EXIT` kills the 3 backgrounded cloudflared PIDs. **Do not
+`exec` into composer** — `exec` replaces the bash process, which discards the
+trap, leaving the tunnels orphaned on Ctrl+C. Run composer in the foreground
+under bash so the trap fires when composer exits or the user Ctrl+Cs.
+
+### Preflight
+
+Fail fast with a single-line remedy:
+
+- `cloudflared` is on `PATH` (else: install hint — `brew install cloudflared`).
+- `.env` exists in the working directory (else: `cp .env.example .env`).
+- Ports 8000 / 5173 / 8080 are free (else: `lsof -i :PORT` to find the culprit).
+
+### Tunnel boot + URL capture
+
+Boot the 3 quick tunnels in parallel — they have no dependency on each other,
+so sequential boot would cost ~20–30s for nothing.
+
+```bash
+cloudflared tunnel --url http://localhost:8000 >/tmp/nexus-tunnel-8000.log 2>&1 &
+LARAVEL_PID=$!
+cloudflared tunnel --url http://localhost:5173 >/tmp/nexus-tunnel-5173.log 2>&1 &
+VITE_PID=$!
+cloudflared tunnel --url http://localhost:8080 >/tmp/nexus-tunnel-8080.log 2>&1 &
+REVERB_PID=$!
+TUNNEL_PIDS=("$LARAVEL_PID" "$VITE_PID" "$REVERB_PID")
+```
+
+Per-tunnel URL capture: 30s bounded poll on the log file for the
+`https://*.trycloudflare.com` line cloudflared emits once the tunnel is
+established.
+
+```bash
+wait_for_url() {
+  local log=$1 url=""
+  for _ in {1..60}; do
+    url=$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' "$log" | head -1)
+    [[ -n "$url" ]] && { printf '%s' "$url"; return 0; }
+    sleep 0.5
+  done
+  return 1
+}
+```
+
+If any of the 3 captures times out: kill the other two tunnels, print the
+failing log path, exit 1.
+
+### `.env` rewrite (idempotent, per-key)
+
+BSD sed (macOS) in-place edit. 6 of the 7 target keys already exist in the
+current `.env`; `SANCTUM_STATEFUL_DOMAINS` does not. So: replace-if-exists,
+else append.
+
+```bash
+write_env() {
+  local key=$1 val=$2
+  if grep -qE "^${key}=" .env; then
+    sed -i '' "s|^${key}=.*|${key}=${val}|" .env
+  else
+    printf '%s=%s\n' "$key" "$val" >> .env
+  fi
+}
+
+LARAVEL_HOST="${LARAVEL_URL#https://}"
+
+write_env APP_URL                  "$LARAVEL_URL"
+write_env VITE_DEV_SERVER_URL      "$VITE_URL"
+write_env VITE_REVERB_HOST         "${REVERB_URL#https://}"   # bare host
+write_env VITE_REVERB_SCHEME       "https"
+write_env VITE_REVERB_PORT         "443"
+write_env SESSION_DOMAIN           ""                          # blank
+write_env SANCTUM_STATEFUL_DOMAINS "${LARAVEL_HOST},localhost,127.0.0.1"
+```
+
+Re-running the script just overwrites — no backup file, no diff, idempotent.
+
+### Cleanup + final exec
+
+```bash
+cleanup() {
+  kill "${TUNNEL_PIDS[@]}" 2>/dev/null || true
+  wait 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+clear
+php artisan optimize
+
+cat <<EOF
+⚠ Reminder: update your GitHub App's OAuth callback URL to:
+    ${LARAVEL_URL}/integrations/github/callback
+    (https://github.com/settings/developers — or your GitHub App settings page)
+EOF
+
+composer run dev   # foreground; trap fires on its exit / Ctrl+C
+```
+
+## Known footgun (documented, not solved)
+
+The user explicitly chose `php artisan optimize` over `optimize:clear`.
+Implication: after this script runs, `bootstrap/cache/config.php` caches the
+new tunneled `.env`. **Any further `.env` edits during the dev session are
+silently ignored** until `php artisan optimize:clear` (or another full
+restart).
+
+In practice this is fine for the intended workflow — boot tunneled, work,
+Ctrl+C, done — but worth flagging if the script ever shows up in onboarding
+docs. If this turns into a problem in the future, the one-line fix is to swap
+`optimize` for `optimize:clear` in the script.
+
+## Error handling
+
+| Failure | Behavior |
+|---|---|
+| `cloudflared` not installed | Print install hint, exit 1, no tunnels started. |
+| `.env` missing | Print `cp .env.example .env` hint, exit 1. |
+| Port already in use | Print `lsof -i :PORT` hint, exit 1, no tunnels started. |
+| Tunnel times out (no URL in 30s) | Kill the other tunnels, print failing log path, exit 1. |
+| `php artisan optimize` fails | Tunnels die via trap, `.env` keeps the tunnel URLs (idempotent — re-run). |
+| `composer run dev` fails / Ctrl+C | Tunnels die via trap. `.env` unchanged. |
+
+## File layout
+
+```
+scripts/
+    dev-tunnels.sh        — new file, executable (chmod +x)
+```
+
+Nothing else in the repo changes. No new composer scripts, no new env keys,
+no edits to existing dotfiles.
+
+## Verification (manual, for after implementation)
+
+1. With nothing running: `./scripts/dev-tunnels.sh` — observe 3 tunnels boot,
+   `.env` get rewritten, composer dev start.
+2. Open the printed `APP_URL` in a browser — page loads, no CORS / 403
+   errors from Vite or Reverb. The Vite tunnel-mode banner appears in
+   composer dev output.
+3. Ctrl+C — tunnels die (`pgrep cloudflared` returns nothing), `.env` still
+   has the tunnel URLs.
+4. Re-run with a port already taken (e.g. `php artisan serve` already on 8000)
+   — script exits before booting any tunnel with a clear remedy.
+5. Simulate a tunnel timeout by killing one cloudflared mid-boot — other two
+   die, log path is printed.
+
+## Out of scope for this spec (future ideas)
+
+- A `--no-reverb` flag that boots only 2 tunnels for users who don't need
+  real-time features.
+- A `--restore` flag to revert `.env` to localhost defaults from
+  `.env.example` without re-running the full boot.
+- Wiring into `composer dev:tunneled` if the script becomes a daily-driver
+  workflow.

--- a/scripts/dev-tunnels.sh
+++ b/scripts/dev-tunnels.sh
@@ -71,9 +71,12 @@ ok "Reverb   → $REVERB_URL"
 write_env() {
   local key=$1 val=$2
   if grep -qE "^${key}=" .env; then
-    # Use | as sed delimiter since URLs contain /
+    # Delimiter is | (URLs contain /). Safe from sed-injection because val is
+    # regex-constrained by wait_for_url — no |, &, \ possible.
     sed -i '' "s|^${key}=.*|${key}=${val}|" .env
   else
+    # Guarantee a trailing newline so the append can't merge onto the last line.
+    [[ -s .env && -z $(tail -c1 .env) ]] || printf '\n' >> .env
     printf '%s=%s\n' "$key" "$val" >> .env
   fi
 }

--- a/scripts/dev-tunnels.sh
+++ b/scripts/dev-tunnels.sh
@@ -22,3 +22,47 @@ preflight() {
 }
 
 preflight
+
+TUNNEL_PIDS=()
+LOG_DIR=$(mktemp -d -t nexus-tunnels.XXXXXX)
+info "tunnel logs: $LOG_DIR"
+
+cleanup() {
+  if ((${#TUNNEL_PIDS[@]})); then
+    kill "${TUNNEL_PIDS[@]}" 2>/dev/null || true
+    wait 2>/dev/null || true
+  fi
+}
+trap cleanup INT TERM EXIT
+
+wait_for_url() {
+  local log=$1 url=""
+  for _ in $(seq 1 60); do
+    url=$(grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' "$log" 2>/dev/null | head -1 || true)
+    if [[ -n "$url" ]]; then
+      printf '%s' "$url"
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
+info "booting 3 cloudflared tunnels in parallel…"
+LARAVEL_LOG="$LOG_DIR/tunnel-8000.log"
+VITE_LOG="$LOG_DIR/tunnel-5173.log"
+REVERB_LOG="$LOG_DIR/tunnel-8080.log"
+
+cloudflared tunnel --url "http://localhost:8000" >"$LARAVEL_LOG" 2>&1 &
+TUNNEL_PIDS+=("$!")
+cloudflared tunnel --url "http://localhost:5173" >"$VITE_LOG" 2>&1 &
+TUNNEL_PIDS+=("$!")
+cloudflared tunnel --url "http://localhost:8080" >"$REVERB_LOG" 2>&1 &
+TUNNEL_PIDS+=("$!")
+
+LARAVEL_URL=$(wait_for_url "$LARAVEL_LOG") || die "Laravel tunnel timed out — see $LARAVEL_LOG"
+ok "Laravel  → $LARAVEL_URL"
+VITE_URL=$(wait_for_url "$VITE_LOG") || die "Vite tunnel timed out — see $VITE_LOG"
+ok "Vite     → $VITE_URL"
+REVERB_URL=$(wait_for_url "$REVERB_LOG") || die "Reverb tunnel timed out — see $REVERB_LOG"
+ok "Reverb   → $REVERB_URL"

--- a/scripts/dev-tunnels.sh
+++ b/scripts/dev-tunnels.sh
@@ -94,17 +94,21 @@ write_env SESSION_DOMAIN           ""
 write_env SANCTUM_STATEFUL_DOMAINS "${LARAVEL_HOST},localhost,127.0.0.1"
 ok ".env updated"
 
-clear
+clear || true
 info "running php artisan optimize…"
 php artisan optimize
 
+warn "Reminder: update your GitHub App OAuth callback URL to:"
 cat <<EOF
-
-$(printf '\033[33m⚠ Reminder:\033[0m update your GitHub App OAuth callback URL to:')
     ${LARAVEL_URL}/integrations/github/callback
 
 GitHub App settings: https://github.com/settings/developers (or your GitHub App
 settings page if you registered as a GitHub App rather than an OAuth App).
+
+Tunnels (also written to .env):
+    Laravel  ${LARAVEL_URL}
+    Vite     ${VITE_URL}
+    Reverb   ${REVERB_URL}
 
 EOF
 

--- a/scripts/dev-tunnels.sh
+++ b/scripts/dev-tunnels.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."   # always run from repo root
+
+die() { printf '\033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+info() { printf '\033[36m▸ %s\033[0m\n' "$*"; }
+ok() { printf '\033[32m✓ %s\033[0m\n' "$*"; }
+warn() { printf '\033[33m⚠ %s\033[0m\n' "$*"; }
+
+preflight() {
+  command -v cloudflared >/dev/null \
+    || die "cloudflared not on PATH — install with: brew install cloudflared"
+  [[ -f .env ]] \
+    || die ".env not found — run: cp .env.example .env && php artisan key:generate"
+  for port in 8000 5173 8080; do
+    if lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+      die "port $port already in use — find it with: lsof -nP -iTCP:$port -sTCP:LISTEN"
+    fi
+  done
+  ok "preflight passed"
+}
+
+preflight

--- a/scripts/dev-tunnels.sh
+++ b/scripts/dev-tunnels.sh
@@ -24,10 +24,11 @@ preflight() {
 preflight
 
 TUNNEL_PIDS=()
-LOG_DIR=$(mktemp -d -t nexus-tunnels.XXXXXX)
+LOG_DIR=$(mktemp -d -t nexus-tunnels)
 info "tunnel logs: $LOG_DIR"
 
 cleanup() {
+  # Tunnel logs in $LOG_DIR are intentionally left for postmortem on timeout.
   if ((${#TUNNEL_PIDS[@]})); then
     kill "${TUNNEL_PIDS[@]}" 2>/dev/null || true
     wait 2>/dev/null || true

--- a/scripts/dev-tunnels.sh
+++ b/scripts/dev-tunnels.sh
@@ -93,3 +93,20 @@ write_env VITE_REVERB_PORT         "443"
 write_env SESSION_DOMAIN           ""
 write_env SANCTUM_STATEFUL_DOMAINS "${LARAVEL_HOST},localhost,127.0.0.1"
 ok ".env updated"
+
+clear
+info "running php artisan optimize…"
+php artisan optimize
+
+cat <<EOF
+
+$(printf '\033[33m⚠ Reminder:\033[0m update your GitHub App OAuth callback URL to:')
+    ${LARAVEL_URL}/integrations/github/callback
+
+GitHub App settings: https://github.com/settings/developers (or your GitHub App
+settings page if you registered as a GitHub App rather than an OAuth App).
+
+EOF
+
+info "handing off to composer run dev — Ctrl+C to stop everything"
+composer run dev

--- a/scripts/dev-tunnels.sh
+++ b/scripts/dev-tunnels.sh
@@ -67,3 +67,26 @@ VITE_URL=$(wait_for_url "$VITE_LOG") || die "Vite tunnel timed out — see $VITE
 ok "Vite     → $VITE_URL"
 REVERB_URL=$(wait_for_url "$REVERB_LOG") || die "Reverb tunnel timed out — see $REVERB_LOG"
 ok "Reverb   → $REVERB_URL"
+
+write_env() {
+  local key=$1 val=$2
+  if grep -qE "^${key}=" .env; then
+    # Use | as sed delimiter since URLs contain /
+    sed -i '' "s|^${key}=.*|${key}=${val}|" .env
+  else
+    printf '%s=%s\n' "$key" "$val" >> .env
+  fi
+}
+
+LARAVEL_HOST="${LARAVEL_URL#https://}"
+REVERB_HOST="${REVERB_URL#https://}"
+
+info "rewriting .env…"
+write_env APP_URL                  "$LARAVEL_URL"
+write_env VITE_DEV_SERVER_URL      "$VITE_URL"
+write_env VITE_REVERB_HOST         "$REVERB_HOST"
+write_env VITE_REVERB_SCHEME       "https"
+write_env VITE_REVERB_PORT         "443"
+write_env SESSION_DOMAIN           ""
+write_env SANCTUM_STATEFUL_DOMAINS "${LARAVEL_HOST},localhost,127.0.0.1"
+ok ".env updated"

--- a/scripts/dev-tunnels.sh
+++ b/scripts/dev-tunnels.sh
@@ -28,10 +28,10 @@ LOG_DIR=$(mktemp -d -t nexus-tunnels)
 info "tunnel logs: $LOG_DIR"
 
 cleanup() {
-  # Tunnel logs in $LOG_DIR are intentionally left for postmortem on timeout.
+  # Tunnel logs in $LOG_DIR are intentionally left behind for postmortem.
   if ((${#TUNNEL_PIDS[@]})); then
     kill "${TUNNEL_PIDS[@]}" 2>/dev/null || true
-    wait 2>/dev/null || true
+    wait "${TUNNEL_PIDS[@]}" 2>/dev/null || true
   fi
 }
 trap cleanup INT TERM EXIT


### PR DESCRIPTION
## Summary

- New `scripts/dev-tunnels.sh` — one command to run the dev stack behind 3 cloudflared quick tunnels. Boots tunnels for Laravel (`:8000`), Vite (`:5173`) and Reverb (`:8080`) in parallel, captures their `*.trycloudflare.com` URLs, rewrites the matching `.env` keys (`APP_URL`, `VITE_DEV_SERVER_URL`, `VITE_REVERB_HOST/SCHEME/PORT`, plus `SESSION_DOMAIN` blank and `SANCTUM_STATEFUL_DOMAINS`), runs `php artisan optimize`, prints a GitHub OAuth-callback reminder, then hands off to `composer run dev`.
- Tunnels are killed on Ctrl+C via an `INT TERM EXIT` trap; `.env` keeps the tunnel URLs so re-runs are idempotent. No `exec`, so the trap survives to clean up.
- Replaces the manual 3-terminal-plus-hand-edit-`.env` ritual already documented in the README — a "Shortcut" callout was added to that section.
- Includes the design spec and implementation plan under `docs/superpowers/`.

## Test plan

- [ ] `./scripts/dev-tunnels.sh` boots from a clean repo state and ends with `composer run dev` running through 3 tunnels
- [ ] Open the printed `APP_URL` in a browser — Overview loads with no CORS / 419 / Mixed-Content errors; `[vite] tunnel mode active` appears in output
- [ ] Ctrl+C kills all 3 cloudflared processes (`pgrep -lf cloudflared` returns nothing)
- [ ] Running the script twice does not duplicate any `.env` key
- [ ] Preflight fails clearly when a port (8000/5173/8080) is taken or `cloudflared` / `.env` is missing

Note: the script + README are dev-only; no application code changed.