### PR TITLE
feat(command-palette): wire up stale Cmd+K entries

### DIFF
--- a/app/Http/Controllers/Monitoring/WebsiteController.php
+++ b/app/Http/Controllers/Monitoring/WebsiteController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Monitoring;
 
 use App\Domain\Monitoring\Queries\GetWebsitePerformanceSummaryQuery;
+use App\Enums\WebsiteStatus;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Monitoring\StoreWebsiteRequest;
 use App\Http\Requests\Monitoring\UpdateWebsiteRequest;
@@ -30,15 +31,30 @@ class WebsiteController extends Controller
 
         $user = $request->user();
 
+        // Status lives in the query string so a filtered view is
+        // shareable and survives reload — same shape as the Deployments
+        // timeline filters. Validated against the enum so a new
+        // WebsiteStatus case is the only edit a future filter needs.
+        $statusValues = array_map(fn (WebsiteStatus $status) => $status->value, WebsiteStatus::cases());
+
+        $validated = $request->validate([
+            'status' => 'sometimes|nullable|in:'.implode(',', $statusValues),
+        ]);
+
+        $status = $validated['status'] ?? null;
+
         $websites = Website::query()
             ->with('project:id,slug,name,color,icon,owner_user_id')
             ->whereHas('project', fn ($q) => $q->where('owner_user_id', $user->id))
+            ->when($status, fn ($q) => $q->where('status', $status))
             ->orderBy('name')
             ->get()
             ->map(fn (Website $website) => $this->transform($website));
 
         return Inertia::render('Monitoring/Websites/Index', [
             'websites' => $websites,
+            'filters' => ['status' => $status],
+            'filterOptions' => ['statuses' => $statusValues],
         ]);
     }
 

--- a/app/Http/Controllers/RepositorySyncAllController.php
+++ b/app/Http/Controllers/RepositorySyncAllController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\GitHub\Jobs\SyncGitHubRepositoryJob;
+use App\Enums\RepositorySyncStatus;
+use App\Models\Repository;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+/**
+ * Global "Run sync" — the Cmd+K command-palette action. Re-dispatches
+ * `SyncGitHubRepositoryJob` for every repository under the current
+ * user's projects; the bulk sibling of the per-repo
+ * `RepositorySyncController`.
+ *
+ * The repo set is scoped to the user's own projects, so ownership is
+ * enforced by the query itself — there is no foreign repository a
+ * request could reach, hence no per-row policy check. Sync fields are
+ * flipped to `syncing` in one bulk update before the jobs queue, so the
+ * next render paints every affected row mid-sync.
+ */
+class RepositorySyncAllController extends Controller
+{
+    public function __invoke(Request $request): RedirectResponse
+    {
+        $repositories = Repository::query()
+            ->whereHas('project', fn ($query) => $query->where('owner_user_id', $request->user()->id))
+            ->get();
+
+        if ($repositories->isEmpty()) {
+            return back()->with('status', 'No repositories to sync.');
+        }
+
+        // Clear the metadata and child-sync errors alongside the status
+        // flip — the metadata job cascades into issues + PRs + workflow
+        // runs, so the user's mental model is "Run sync re-runs all four".
+        Repository::query()
+            ->whereKey($repositories->modelKeys())
+            ->update([
+                'sync_status' => RepositorySyncStatus::Syncing->value,
+                'sync_error' => null,
+                'sync_failed_at' => null,
+                'issues_sync_error' => null,
+                'issues_sync_failed_at' => null,
+                'prs_sync_error' => null,
+                'prs_sync_failed_at' => null,
+                'workflow_runs_sync_error' => null,
+                'workflow_runs_sync_failed_at' => null,
+            ]);
+
+        foreach ($repositories as $repository) {
+            SyncGitHubRepositoryJob::dispatch($repository->id);
+        }
+
+        $count = $repositories->count();
+
+        return back()->with('status', "Queued sync for {$count} ".Str::plural('repository', $count).'.');
+    }
+}

--- a/resources/js/Pages/Monitoring/Websites/Index.vue
+++ b/resources/js/Pages/Monitoring/Websites/Index.vue
@@ -48,7 +48,11 @@ const applyFilter = () => {
     router.get(
         route('monitoring.websites.index'),
         statusFilter.value ? { status: statusFilter.value } : {},
-        { preserveScroll: true, preserveState: true },
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['websites', 'filters', 'filterOptions'],
+        },
     );
 };
 

--- a/resources/js/Pages/Monitoring/Websites/Index.vue
+++ b/resources/js/Pages/Monitoring/Websites/Index.vue
@@ -2,8 +2,9 @@
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import { websiteStatusTone as statusTone } from '@/lib/websiteStyles';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import { Head, Link } from '@inertiajs/vue3';
+import { Head, Link, router } from '@inertiajs/vue3';
 import { ExternalLink, Globe, Plus } from 'lucide-vue-next';
+import { ref } from 'vue';
 
 interface ProjectChip {
     id: number;
@@ -30,12 +31,34 @@ interface WebsiteRow {
     project: ProjectChip | null;
 }
 
-defineProps<{
+const props = defineProps<{
     websites: WebsiteRow[];
+    filters: { status: string | null };
+    filterOptions: { statuses: string[] };
 }>();
 
 // `statusTone` re-exported from `@/lib/websiteStyles` above so the
 // four consumers stay in sync when the WebsiteStatus enum grows.
+
+const statusFilter = ref<string | null>(props.filters.status);
+
+// Status lives in the query string so a filtered view is shareable and
+// survives reload — same pattern as the Deployments timeline filters.
+const applyFilter = () => {
+    router.get(
+        route('monitoring.websites.index'),
+        statusFilter.value ? { status: statusFilter.value } : {},
+        { preserveScroll: true, preserveState: true },
+    );
+};
+
+const clearFilter = () => {
+    statusFilter.value = null;
+    applyFilter();
+};
+
+const statusLabel = (status: string) =>
+    status.charAt(0).toUpperCase() + status.slice(1);
 
 const projectAccentClass = (color: string | null) =>
     (
@@ -79,17 +102,43 @@ const projectAccentClass = (color: string | null) =>
                         every probe.
                     </p>
                 </div>
-                <Link
-                    :href="route('monitoring.websites.create')"
-                    class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/15 px-3 py-2 text-sm font-semibold text-accent-cyan transition hover:border-accent-cyan/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
-                >
-                    <Plus class="h-4 w-4" aria-hidden="true" />
-                    Add monitor
-                </Link>
+                <div class="flex items-end gap-3">
+                    <label
+                        v-if="websites.length > 0 || statusFilter"
+                        class="flex flex-col gap-1 text-xs"
+                    >
+                        <span
+                            class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                        >
+                            Status
+                        </span>
+                        <select
+                            v-model="statusFilter"
+                            class="min-w-[120px] rounded-md border border-border-subtle bg-background-panel-hover px-2 py-1.5 text-sm text-text-primary focus:border-accent-cyan/60 focus:outline-none"
+                            @change="applyFilter"
+                        >
+                            <option :value="null">Any status</option>
+                            <option
+                                v-for="status in filterOptions.statuses"
+                                :key="status"
+                                :value="status"
+                            >
+                                {{ statusLabel(status) }}
+                            </option>
+                        </select>
+                    </label>
+                    <Link
+                        :href="route('monitoring.websites.create')"
+                        class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/15 px-3 py-2 text-sm font-semibold text-accent-cyan transition hover:border-accent-cyan/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                    >
+                        <Plus class="h-4 w-4" aria-hidden="true" />
+                        Add monitor
+                    </Link>
+                </div>
             </header>
 
             <div
-                v-if="websites.length === 0"
+                v-if="websites.length === 0 && !statusFilter"
                 class="glass-card flex flex-col items-center justify-center gap-3 px-6 py-16 text-center"
             >
                 <span
@@ -109,6 +158,30 @@ const projectAccentClass = (color: string | null) =>
                     use the manual "Probe now" button on the detail
                     page.
                 </p>
+            </div>
+
+            <div
+                v-else-if="websites.length === 0"
+                class="glass-card flex flex-col items-center justify-center gap-3 px-6 py-16 text-center"
+            >
+                <span
+                    class="flex h-12 w-12 items-center justify-center rounded-full border border-border-subtle bg-slate-950/60"
+                >
+                    <Globe
+                        class="h-5 w-5 text-text-muted"
+                        aria-hidden="true"
+                    />
+                </span>
+                <p class="text-sm font-medium text-text-secondary">
+                    No monitors match this filter
+                </p>
+                <button
+                    type="button"
+                    class="text-xs font-semibold text-accent-cyan transition hover:text-accent-cyan/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                    @click="clearFilter"
+                >
+                    Clear filter
+                </button>
             </div>
 
             <ul v-else class="flex flex-col gap-2">

--- a/resources/js/lib/commands.ts
+++ b/resources/js/lib/commands.ts
@@ -110,8 +110,10 @@ export function getCommands(): Command[] {
             label: 'Go to Pipelines',
             group: 'navigation',
             icon: Activity,
+            // Pipelines is a planned nav view (roadmap §7.6/§8.6) with
+            // no assigned phase yet — stays inert like Analytics/Alerts.
             disabled: true,
-            soonLabel: 'Phase 4',
+            soonLabel: 'Planned',
         },
         {
             id: 'go-deployments',
@@ -126,8 +128,8 @@ export function getCommands(): Command[] {
             label: 'Go to Hosts',
             group: 'navigation',
             icon: Server,
-            disabled: true,
-            soonLabel: 'Phase 6',
+            keywords: ['docker', 'agents', 'servers', 'containers'],
+            run: () => router.visit(route('monitoring.hosts.index')),
         },
         {
             id: 'go-monitoring',
@@ -192,24 +194,26 @@ export function getCommands(): Command[] {
             label: 'Run sync',
             group: 'actions',
             icon: RefreshCw,
-            disabled: true,
-            soonLabel: 'Phase 2',
+            keywords: ['sync', 'refresh', 'github', 'repositories'],
+            run: () => router.post(route('repositories.sync-all')),
         },
         {
             id: 'view-failed-deployments',
             label: 'View failed deployments',
             group: 'actions',
             icon: Flame,
-            disabled: true,
-            soonLabel: 'Phase 4',
+            keywords: ['failed', 'deployments', 'broken', 'ci'],
+            run: () =>
+                router.visit(route('deployments.index', { conclusion: 'failure' })),
         },
         {
             id: 'view-slow-websites',
             label: 'View slow websites',
             group: 'actions',
             icon: Globe2,
-            disabled: true,
-            soonLabel: 'Phase 5',
+            keywords: ['slow', 'websites', 'monitoring', 'performance'],
+            run: () =>
+                router.visit(route('monitoring.websites.index', { status: 'slow' })),
         },
 
         // ────── System ────── //

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\ProjectController;
 use App\Http\Controllers\RepositoryController;
 use App\Http\Controllers\RepositoryIssuesSyncController;
 use App\Http\Controllers\RepositoryPullRequestsSyncController;
+use App\Http\Controllers\RepositorySyncAllController;
 use App\Http\Controllers\RepositorySyncController;
 use App\Http\Controllers\RepositoryWorkflowRunsSyncController;
 use App\Http\Controllers\SettingsController;
@@ -87,6 +88,13 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/repositories/{repository}/workflow-runs/sync', RepositoryWorkflowRunsSyncController::class)
         ->where('repository', '[\w.-]+/[\w.-]+')
         ->name('repositories.workflow-runs.sync');
+
+    // Global "Run sync" — the Cmd+K command-palette action. Bulk sibling
+    // of the per-repo sync above; re-syncs every repo under the user's
+    // projects. Literal path, so it never collides with the slash-keyed
+    // `{repository}` routes.
+    Route::post('/repositories/sync-all', RepositorySyncAllController::class)
+        ->name('repositories.sync-all');
 
     // Spec 016 — unified Work Items queue (issues + PRs).
     Route::get('/work-items', WorkItemController::class)->name('work-items.index');

--- a/tests/Feature/Monitoring/WebsiteControllerTest.php
+++ b/tests/Feature/Monitoring/WebsiteControllerTest.php
@@ -44,6 +44,59 @@ class WebsiteControllerTest extends TestCase
             );
     }
 
+    public function test_index_filters_by_status(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Website::factory()->create([
+            'project_id' => $project->id,
+            'name' => 'Slow site',
+            'status' => 'slow',
+        ]);
+        Website::factory()->create([
+            'project_id' => $project->id,
+            'name' => 'Healthy site',
+            'status' => 'up',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('monitoring.websites.index', ['status' => 'slow']))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Monitoring/Websites/Index')
+                    ->has('websites', 1)
+                    ->where('websites.0.name', 'Slow site')
+                    ->where('filters.status', 'slow')
+                    ->has('filterOptions.statuses', 5)
+            );
+    }
+
+    public function test_index_without_a_status_filter_lists_every_website(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Website::factory()->count(3)->create(['project_id' => $project->id]);
+
+        $this->actingAs($user)
+            ->get(route('monitoring.websites.index'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('websites', 3)
+                    ->where('filters.status', null)
+            );
+    }
+
+    public function test_index_rejects_an_unknown_status_filter(): void
+    {
+        $user = $this->verifiedUser();
+
+        $this->actingAs($user)
+            ->get(route('monitoring.websites.index', ['status' => 'bogus']))
+            ->assertSessionHasErrors('status');
+    }
+
     public function test_create_form_renders_with_owned_projects(): void
     {
         $user = $this->verifiedUser();

--- a/tests/Feature/Repositories/RepositorySyncAllControllerTest.php
+++ b/tests/Feature/Repositories/RepositorySyncAllControllerTest.php
@@ -44,11 +44,17 @@ class RepositorySyncAllControllerTest extends TestCase
         $user = $this->verifiedUser();
         $otherUser = $this->verifiedUser();
         $otherProject = Project::factory()->create(['owner_user_id' => $otherUser->id]);
-        Repository::factory()->create(['project_id' => $otherProject->id]);
+        $otherRepository = Repository::factory()->create([
+            'project_id' => $otherProject->id,
+            'sync_status' => 'pending',
+        ]);
 
         $this->actingAs($user)->post(route('repositories.sync-all'));
 
         Queue::assertNotPushed(SyncGitHubRepositoryJob::class);
+        // The bulk status update is keyed to the user's own repos —
+        // a sibling's row must be left exactly as it was.
+        $this->assertSame('pending', $otherRepository->fresh()->sync_status->value);
     }
 
     public function test_it_flips_sync_status_to_syncing_and_clears_errors(): void

--- a/tests/Feature/Repositories/RepositorySyncAllControllerTest.php
+++ b/tests/Feature/Repositories/RepositorySyncAllControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature\Repositories;
+
+use App\Domain\GitHub\Jobs\SyncGitHubRepositoryJob;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class RepositorySyncAllControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_it_queues_a_sync_job_for_each_of_the_users_repositories(): void
+    {
+        Queue::fake();
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repositories = Repository::factory()->count(3)->create(['project_id' => $project->id]);
+
+        $response = $this->actingAs($user)->post(route('repositories.sync-all'));
+
+        $response->assertRedirect();
+        foreach ($repositories as $repository) {
+            Queue::assertPushed(
+                SyncGitHubRepositoryJob::class,
+                fn (SyncGitHubRepositoryJob $job) => $job->repositoryId === $repository->id,
+            );
+        }
+        Queue::assertPushed(SyncGitHubRepositoryJob::class, 3);
+    }
+
+    public function test_it_does_not_sync_repositories_owned_by_other_users(): void
+    {
+        Queue::fake();
+        $user = $this->verifiedUser();
+        $otherUser = $this->verifiedUser();
+        $otherProject = Project::factory()->create(['owner_user_id' => $otherUser->id]);
+        Repository::factory()->create(['project_id' => $otherProject->id]);
+
+        $this->actingAs($user)->post(route('repositories.sync-all'));
+
+        Queue::assertNotPushed(SyncGitHubRepositoryJob::class);
+    }
+
+    public function test_it_flips_sync_status_to_syncing_and_clears_errors(): void
+    {
+        Queue::fake();
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'sync_status' => 'failed',
+            'sync_error' => 'GitHub request failed: HTTP 404 Not Found',
+            'sync_failed_at' => now()->subMinutes(3),
+        ]);
+
+        $this->actingAs($user)->post(route('repositories.sync-all'));
+
+        $repository->refresh();
+        $this->assertSame('syncing', $repository->sync_status->value);
+        $this->assertNull($repository->sync_error);
+        $this->assertNull($repository->sync_failed_at);
+    }
+
+    public function test_it_reports_when_there_is_nothing_to_sync(): void
+    {
+        Queue::fake();
+        $user = $this->verifiedUser();
+
+        $response = $this->actingAs($user)->post(route('repositories.sync-all'));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('status', 'No repositories to sync.');
+        Queue::assertNotPushed(SyncGitHubRepositoryJob::class);
+    }
+
+    public function test_guests_cannot_trigger_a_global_sync(): void
+    {
+        Queue::fake();
+
+        $this->post(route('repositories.sync-all'))->assertRedirect(route('login'));
+
+        Queue::assertNotPushed(SyncGitHubRepositoryJob::class);
+    }
+}


### PR DESCRIPTION
## Summary

The Cmd+K command palette carried entries left `disabled` with stale "Phase N" labels for phases that have already shipped. This wires them up:

- **Go to Hosts** → `monitoring.hosts.index` (Hosts shipped in spec 026)
- **View failed deployments** → `deployments.index?conclusion=failure` (the page already supports the `conclusion` URL filter)
- **View slow websites** → `monitoring.websites.index?status=slow` — required building a status filter on the websites index (it had none)
- **Run sync** → new global `RepositorySyncAllController` that dispatches `SyncGitHubRepositoryJob` for every repo under the user's projects
- **Go to Pipelines** stays disabled — it's a genuine future nav view (roadmap §7.6/§8.6), not a stale bug — just relabelled from the wrong `Phase 4` to `Planned`

Supporting changes:

- `RepositorySyncAllController` + `POST /repositories/sync-all` route. Literal path, so no collision with the slash-keyed `{repository}` routes.
- `WebsiteController@index` gains a `?status=` filter validated against the `WebsiteStatus` enum, passing `filters` / `filterOptions` props — mirrors `DeploymentController`.
- `Monitoring/Websites/Index.vue` gets a status dropdown and a distinct "no monitors match this filter" empty state.

## Test plan

- [ ] `php artisan test` — green (469 + 8 new = 477 tests; 17 in the touched files, 118 assertions)
- [ ] `./vendor/bin/pint` — clean
- [ ] `npm run build` — clean (vue-tsc type-check passes)
- [ ] Cmd+K → "Go to Hosts" / "View failed deployments" / "View slow websites" / "Run sync" each navigate or trigger correctly
- [ ] "Run sync" flashes "Queued sync for N repositories." (or "No repositories to sync.")
- [ ] Websites index status dropdown filters the list and survives reload

## Self-review notes

Reviewed via `superpowers:code-reviewer` — assessed ready to PR, no critical/blocking issues. Addressed in commit 2:
- websites filter `router.get` scoped with `only:[…]` for partial-reload consistency with the Deployments timeline
- hardened the sync-all test to assert a sibling user's `sync_status` is untouched by the bulk update

Deferred / conscious choices:
- `RepositorySyncAllController` authorizes by query-scoping (`whereHas` on `owner_user_id`) rather than a per-row policy call — same approach as `DeploymentController`, sound for the phase-1 single-owner model. A dedicated Gate would be defense-in-depth but is YAGNI here.
- The duplicated sync-field-clearing block (per-repo vs bulk controller) was left un-extracted — only 2 call sites, and they have genuinely different write shapes (single vs bulk `update()`).