### PR TITLE
Spec 028 — Hosts UI (telemetry display)

### DIFF
--- a/app/Domain/Docker/Actions/IngestHostTelemetryAction.php
+++ b/app/Domain/Docker/Actions/IngestHostTelemetryAction.php
@@ -3,6 +3,7 @@
 namespace App\Domain\Docker\Actions;
 
 use App\Enums\HostStatus;
+use App\Events\HostTelemetryRecorded;
 use App\Models\Host;
 use App\Models\HostMetricSnapshot;
 use Carbon\CarbonImmutable;
@@ -49,6 +50,12 @@ class IngestHostTelemetryAction
             $this->insertHostSnapshot($host, $recordedAt, $metrics);
             $this->syncContainers->execute($host, $recordedAt, $containers);
         });
+
+        // Dispatched after the transaction commits (not via DB::afterCommit
+        // — we're already past the transaction block) so the Host Show
+        // page never partial-reloads ahead of the write. `ShouldBroadcastNow`
+        // means the publish hits Reverb synchronously here. Spec 028.
+        HostTelemetryRecorded::dispatch($host->id, $host->project?->owner_user_id);
     }
 
     /**

--- a/app/Domain/Docker/Queries/GetHostTelemetryQuery.php
+++ b/app/Domain/Docker/Queries/GetHostTelemetryQuery.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Domain\Docker\Queries;
+
+use App\Models\Container;
+use App\Models\Host;
+use App\Models\HostMetricSnapshot;
+
+/**
+ * Read model for the Host detail page (spec 028). Bundles three things
+ * so `HostController@show` stays thin:
+ *
+ *   - `current`    — the latest host metric snapshot (or null).
+ *   - `series`     — the last 50 snapshots, oldest→newest, as
+ *                    {cpu_percent, memory_percent, recorded_at} for the
+ *                    Show-page sparkline.
+ *   - `containers` — the host's containers with current per-container
+ *                    stats, ordered by name.
+ */
+class GetHostTelemetryQuery
+{
+    /** Most recent snapshots fed to the Show-page sparkline. */
+    private const SERIES_LIMIT = 50;
+
+    /**
+     * @return array{
+     *     current: array<string, mixed>|null,
+     *     series: list<array<string, mixed>>,
+     *     containers: list<array<string, mixed>>,
+     * }
+     */
+    public function execute(Host $host): array
+    {
+        // Pull newest-first (so the LIMIT keeps the *recent* rows), then
+        // reverse for the chart series so it reads left→right oldest→newest.
+        $snapshots = HostMetricSnapshot::query()
+            ->where('host_id', $host->id)
+            ->orderByDesc('recorded_at')
+            ->limit(self::SERIES_LIMIT)
+            ->get();
+
+        $current = $snapshots->first();
+
+        $series = $snapshots
+            ->reverse()
+            ->values()
+            ->map(fn (HostMetricSnapshot $snapshot): array => [
+                'cpu_percent' => $snapshot->cpu_percent,
+                'memory_percent' => $snapshot->memoryPercent(),
+                'recorded_at' => $snapshot->recorded_at?->toIso8601String(),
+            ])
+            ->all();
+
+        $containers = Container::query()
+            ->where('host_id', $host->id)
+            ->orderBy('name')
+            ->get()
+            ->map(fn (Container $container): array => [
+                'id' => $container->id,
+                'container_id' => $container->container_id,
+                'name' => $container->name,
+                'image' => $container->image,
+                'image_tag' => $container->image_tag,
+                'status' => $container->status,
+                'state' => $container->state,
+                'health_status' => $container->health_status,
+                'cpu_percent' => $container->cpu_percent,
+                'memory_usage_mb' => $container->memory_usage_mb,
+                'memory_limit_mb' => $container->memory_limit_mb,
+                'memory_percent' => $container->memory_percent,
+                'last_seen_at' => $container->last_seen_at?->diffForHumans(),
+            ])
+            ->all();
+
+        return [
+            'current' => $current === null ? null : [
+                'cpu_percent' => $current->cpu_percent,
+                'memory_used_mb' => $current->memory_used_mb,
+                'memory_total_mb' => $current->memory_total_mb,
+                'memory_percent' => $current->memoryPercent(),
+                'disk_used_gb' => $current->disk_used_gb,
+                'disk_total_gb' => $current->disk_total_gb,
+                'load_average' => $current->load_average,
+                'network_rx_bytes' => $current->network_rx_bytes,
+                'network_tx_bytes' => $current->network_tx_bytes,
+                'recorded_at' => $current->recorded_at?->toIso8601String(),
+            ],
+            'series' => $series,
+            'containers' => $containers,
+        ];
+    }
+}

--- a/app/Events/HostTelemetryRecorded.php
+++ b/app/Events/HostTelemetryRecorded.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Real-time pulse emitted whenever a host's agent posts telemetry
+ * (spec 028). The Vue `Pages/Monitoring/Hosts/Show` page subscribes
+ * via Echo and triggers a partial Inertia reload of the host /
+ * telemetry props on receipt — server-side query logic re-applies
+ * naturally, so we never replicate aggregation logic in JS.
+ *
+ * Pre-resolved owner id in the constructor (mirrors spec 025's
+ * `WebsiteCheckRecorded`) — avoids the broadcaster lazy-loading the
+ * host / project relations during fan-out.
+ *
+ * `ShouldBroadcastNow` so the broadcast hits Reverb synchronously —
+ * matches the rest of the event family. `IngestHostTelemetryAction`
+ * dispatches it only after the telemetry transaction commits, so the
+ * browser never partial-reloads ahead of the write.
+ */
+class HostTelemetryRecorded implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $hostId,
+        public readonly ?int $ownerUserId,
+    ) {}
+
+    /**
+     * Broadcast on the host owner's private hosts channel.
+     * `users.{userId}.hosts` is authorized in `routes/channels.php`.
+     *
+     * Returns no channels when the owner can't be resolved (orphan
+     * project) — Laravel skips the publish.
+     *
+     * @return list<PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        if ($this->ownerUserId === null) {
+            return [];
+        }
+
+        return [
+            new PrivateChannel("users.{$this->ownerUserId}.hosts"),
+        ];
+    }
+
+    /**
+     * Light-weight pulse — the client uses this as a trigger, not as
+     * the source of truth. The Show page partial-reloads its host +
+     * telemetry props after receiving any pulse for its own host id.
+     *
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'host_id' => $this->hostId,
+        ];
+    }
+
+    /**
+     * Stable event name for Echo subscribers:
+     * `Echo.private('users.{id}.hosts').listen('.HostTelemetryRecorded', ...)`.
+     */
+    public function broadcastAs(): string
+    {
+        return 'HostTelemetryRecorded';
+    }
+}

--- a/app/Events/HostTelemetryRecorded.php
+++ b/app/Events/HostTelemetryRecorded.php
@@ -5,6 +5,7 @@ namespace App\Events;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
@@ -20,11 +21,13 @@ use Illuminate\Queue\SerializesModels;
  * host / project relations during fan-out.
  *
  * `ShouldBroadcastNow` so the broadcast hits Reverb synchronously —
- * matches the rest of the event family. `IngestHostTelemetryAction`
- * dispatches it only after the telemetry transaction commits, so the
- * browser never partial-reloads ahead of the write.
+ * matches the rest of the event family. `ShouldDispatchAfterCommit`
+ * defends against any future caller that wraps the ingest action in an
+ * outer transaction: the broadcast then still waits for the outermost
+ * commit before it fires, so the Show page never partial-reloads ahead
+ * of the write.
  */
-class HostTelemetryRecorded implements ShouldBroadcastNow
+class HostTelemetryRecorded implements ShouldBroadcastNow, ShouldDispatchAfterCommit
 {
     use Dispatchable;
     use InteractsWithSockets;

--- a/app/Http/Controllers/Monitoring/HostController.php
+++ b/app/Http/Controllers/Monitoring/HostController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Monitoring;
 use App\Domain\Docker\Actions\ArchiveHostAction;
 use App\Domain\Docker\Actions\CreateHostAction;
 use App\Domain\Docker\Actions\UpdateHostAction;
+use App\Domain\Docker\Queries\GetHostTelemetryQuery;
 use App\Enums\HostConnectionType;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Monitoring\StoreHostRequest;
@@ -34,7 +35,11 @@ class HostController extends Controller
         $user = $request->user();
 
         $hosts = Host::query()
-            ->with(['project:id,slug,name,color,icon,owner_user_id', 'activeAgentToken'])
+            ->with([
+                'project:id,slug,name,color,icon,owner_user_id',
+                'activeAgentToken',
+                'latestMetricSnapshot',
+            ])
             ->whereHas('project', fn ($q) => $q->where('owner_user_id', $user->id))
             ->orderBy('name')
             ->get()
@@ -77,17 +82,19 @@ class HostController extends Controller
             ->with('status', "Host “{$host->name}” created. Mint an agent token to bring it online.");
     }
 
-    public function show(Request $request, Host $host): Response
+    public function show(Request $request, Host $host, GetHostTelemetryQuery $telemetry): Response
     {
         $this->authorize('view', $host);
 
         $host->loadMissing([
             'project:id,slug,name,color,icon,owner_user_id',
             'activeAgentToken',
+            'latestMetricSnapshot',
         ]);
 
         return Inertia::render('Monitoring/Hosts/Show', [
             'host' => $this->transform($host),
+            'telemetry' => $telemetry->execute($host),
             'canUpdate' => $request->user()?->can('update', $host) ?? false,
             'canDelete' => $request->user()?->can('delete', $host) ?? false,
             'canManageTokens' => $request->user()?->can('manageTokens', $host) ?? false,
@@ -98,7 +105,10 @@ class HostController extends Controller
     {
         $this->authorize('update', $host);
 
-        $host->loadMissing('project:id,slug,name,color,icon,owner_user_id');
+        $host->loadMissing([
+            'project:id,slug,name,color,icon,owner_user_id',
+            'latestMetricSnapshot',
+        ]);
 
         return Inertia::render('Monitoring/Hosts/Edit', [
             'host' => $this->transform($host),
@@ -133,6 +143,7 @@ class HostController extends Controller
     private function transform(Host $host): array
     {
         $activeToken = $host->activeAgentToken;
+        $latestSnapshot = $host->latestMetricSnapshot;
 
         return [
             'id' => $host->id,
@@ -149,6 +160,10 @@ class HostController extends Controller
             'disk_total_gb' => $host->disk_total_gb,
             'os' => $host->os,
             'docker_version' => $host->docker_version,
+            // Latest-snapshot glance for the index CPU / memory column.
+            // Null when the host has never reported telemetry.
+            'cpu_percent' => $latestSnapshot?->cpu_percent,
+            'memory_percent' => $latestSnapshot?->memoryPercent(),
             'archived_at' => $host->archived_at?->toIso8601String(),
             'project' => $host->project ? [
                 'id' => $host->project->id,

--- a/app/Models/Host.php
+++ b/app/Models/Host.php
@@ -78,4 +78,13 @@ class Host extends Model
     {
         return $this->hasMany(HostMetricSnapshot::class);
     }
+
+    /**
+     * The most recent telemetry snapshot. Eager-loaded on the hosts
+     * index so the CPU / memory column doesn't N+1 (spec 028).
+     */
+    public function latestMetricSnapshot(): HasOne
+    {
+        return $this->hasOne(HostMetricSnapshot::class)->latestOfMany('recorded_at');
+    }
 }

--- a/app/Models/HostMetricSnapshot.php
+++ b/app/Models/HostMetricSnapshot.php
@@ -44,4 +44,21 @@ class HostMetricSnapshot extends Model
     {
         return $this->belongsTo(Host::class);
     }
+
+    /**
+     * Memory utilisation as a 0–100 percentage, or null when either
+     * side of the ratio is missing. `host_metric_snapshots` stores the
+     * raw used / total MB; the percentage is derived on read.
+     */
+    public function memoryPercent(): ?float
+    {
+        if ($this->memory_used_mb === null
+            || $this->memory_total_mb === null
+            || $this->memory_total_mb === 0
+        ) {
+            return null;
+        }
+
+        return round($this->memory_used_mb / $this->memory_total_mb * 100, 1);
+    }
 }

--- a/resources/js/Components/Hosts/ContainerTable.vue
+++ b/resources/js/Components/Hosts/ContainerTable.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import { containerHealthTone, containerStateTone } from '@/lib/hostStyles';
+import { Boxes } from 'lucide-vue-next';
+
+interface ContainerRow {
+    id: number;
+    container_id: string;
+    name: string;
+    image: string;
+    image_tag: string | null;
+    status: string | null;
+    state: string | null;
+    health_status: string | null;
+    cpu_percent: number | null;
+    memory_usage_mb: number | null;
+    memory_limit_mb: number | null;
+    memory_percent: number | null;
+    last_seen_at: string | null;
+}
+
+defineProps<{
+    containers: ContainerRow[];
+}>();
+
+const formatPercent = (pct: number | null): string =>
+    pct === null ? '—' : `${pct.toFixed(1)}%`;
+
+const formatMemory = (usage: number | null, limit: number | null): string => {
+    if (usage === null) return '—';
+    return limit === null ? `${usage} MB` : `${usage} / ${limit} MB`;
+};
+
+const imageRef = (row: ContainerRow): string =>
+    row.image_tag ? `${row.image}:${row.image_tag}` : row.image;
+
+// `health_status` is meaningful only when the container declares a
+// Docker HEALTHCHECK — 'none' / null is "no healthcheck", not a fault.
+const hasHealth = (health: string | null): boolean =>
+    health !== null && health !== 'none' && health !== '';
+</script>
+
+<template>
+    <section class="glass-card flex flex-col gap-4 p-6">
+        <header class="flex items-center justify-between gap-3">
+            <h3
+                class="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-text-secondary"
+            >
+                <Boxes class="h-3.5 w-3.5 text-accent-cyan" aria-hidden="true" />
+                Containers
+            </h3>
+            <span class="text-[11px] text-text-muted">
+                {{ containers.length }}
+                {{ containers.length === 1 ? 'container' : 'containers' }}
+            </span>
+        </header>
+
+        <p
+            v-if="containers.length === 0"
+            class="rounded-lg border border-dashed border-border-subtle px-4 py-8 text-center text-xs text-text-muted"
+        >
+            No containers reported. The agent posts the container list on its
+            next telemetry tick.
+        </p>
+
+        <div v-else class="overflow-x-auto">
+            <table class="w-full min-w-[640px] text-left text-xs">
+                <thead>
+                    <tr
+                        class="border-b border-border-subtle font-mono uppercase tracking-[0.16em] text-text-muted"
+                    >
+                        <th class="px-2 py-2 font-medium">Container</th>
+                        <th class="px-2 py-2 font-medium">State</th>
+                        <th class="px-2 py-2 font-medium">CPU</th>
+                        <th class="px-2 py-2 font-medium">Memory</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr
+                        v-for="container in containers"
+                        :key="container.id"
+                        class="border-b border-border-subtle/50 last:border-0"
+                    >
+                        <td class="px-2 py-2.5">
+                            <div class="flex flex-col gap-0.5">
+                                <span
+                                    class="font-semibold text-text-primary"
+                                >
+                                    {{ container.name }}
+                                </span>
+                                <span class="truncate font-mono text-text-muted">
+                                    {{ imageRef(container) }}
+                                </span>
+                            </div>
+                        </td>
+                        <td class="px-2 py-2.5">
+                            <div class="flex flex-wrap items-center gap-1">
+                                <StatusBadge
+                                    :tone="containerStateTone(container.state)"
+                                >
+                                    {{ container.state ?? 'unknown' }}
+                                </StatusBadge>
+                                <StatusBadge
+                                    v-if="hasHealth(container.health_status)"
+                                    :tone="
+                                        containerHealthTone(
+                                            container.health_status,
+                                        )
+                                    "
+                                >
+                                    {{ container.health_status }}
+                                </StatusBadge>
+                            </div>
+                        </td>
+                        <td class="px-2 py-2.5 font-mono text-text-secondary">
+                            {{ formatPercent(container.cpu_percent) }}
+                        </td>
+                        <td class="px-2 py-2.5 font-mono text-text-secondary">
+                            {{
+                                formatMemory(
+                                    container.memory_usage_mb,
+                                    container.memory_limit_mb,
+                                )
+                            }}
+                            <span
+                                v-if="container.memory_percent !== null"
+                                class="text-text-muted"
+                            >
+                                · {{ container.memory_percent.toFixed(1) }}%
+                            </span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+</template>

--- a/resources/js/Components/Hosts/HostMetricsPanel.vue
+++ b/resources/js/Components/Hosts/HostMetricsPanel.vue
@@ -1,0 +1,167 @@
+<script setup lang="ts">
+import { Activity, ArrowDown, ArrowUp } from 'lucide-vue-next';
+import { computed } from 'vue';
+
+interface CurrentMetrics {
+    cpu_percent: number | null;
+    memory_used_mb: number | null;
+    memory_total_mb: number | null;
+    memory_percent: number | null;
+    disk_used_gb: number | null;
+    disk_total_gb: number | null;
+    load_average: number | null;
+    network_rx_bytes: number | null;
+    network_tx_bytes: number | null;
+    recorded_at: string | null;
+}
+
+const props = defineProps<{
+    current: CurrentMetrics;
+}>();
+
+const diskPercent = computed<number | null>(() => {
+    const used = props.current.disk_used_gb;
+    const total = props.current.disk_total_gb;
+    if (used === null || total === null || total === 0) return null;
+    return Math.round((used / total) * 1000) / 10;
+});
+
+// <70 healthy, 70–90 warning, ≥90 danger — same thresholds the
+// Overview host card uses.
+const usageBarClass = (pct: number | null): string => {
+    if (pct === null) return 'bg-text-muted';
+    if (pct >= 90) return 'bg-status-danger';
+    if (pct >= 70) return 'bg-status-warning';
+    return 'bg-status-success';
+};
+
+const clampWidth = (pct: number | null): string =>
+    pct === null ? '0%' : `${Math.min(Math.max(pct, 0), 100)}%`;
+
+const formatPercent = (pct: number | null): string =>
+    pct === null ? '—' : `${pct}%`;
+
+const formatGb = (mb: number | null): string =>
+    mb === null ? '—' : `${(mb / 1024).toFixed(1)} GB`;
+
+const formatBytes = (bytes: number | null): string => {
+    if (bytes === null) return '—';
+    if (bytes === 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.min(
+        Math.floor(Math.log(bytes) / Math.log(1024)),
+        units.length - 1,
+    );
+    return `${(bytes / 1024 ** i).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+};
+
+interface Bar {
+    label: string;
+    percent: number | null;
+    detail: string;
+}
+
+const bars = computed<Bar[]>(() => [
+    {
+        label: 'CPU',
+        percent: props.current.cpu_percent,
+        detail: formatPercent(props.current.cpu_percent),
+    },
+    {
+        label: 'Memory',
+        percent: props.current.memory_percent,
+        detail: `${formatGb(props.current.memory_used_mb)} / ${formatGb(props.current.memory_total_mb)}`,
+    },
+    {
+        label: 'Disk',
+        percent: diskPercent.value,
+        detail:
+            props.current.disk_used_gb !== null &&
+            props.current.disk_total_gb !== null
+                ? `${props.current.disk_used_gb} / ${props.current.disk_total_gb} GB`
+                : '—',
+    },
+]);
+</script>
+
+<template>
+    <section class="glass-card flex flex-col gap-4 p-6">
+        <header class="flex items-center justify-between gap-3">
+            <h3
+                class="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-text-secondary"
+            >
+                <Activity class="h-3.5 w-3.5 text-accent-cyan" aria-hidden="true" />
+                Host metrics
+            </h3>
+            <span v-if="current.recorded_at" class="text-[11px] text-text-muted">
+                as of {{ new Date(current.recorded_at).toLocaleString() }}
+            </span>
+        </header>
+
+        <div class="flex flex-col gap-3">
+            <div v-for="bar in bars" :key="bar.label" class="flex flex-col gap-1">
+                <div class="flex items-baseline justify-between text-xs">
+                    <span
+                        class="font-mono uppercase tracking-[0.18em] text-text-muted"
+                    >
+                        {{ bar.label }}
+                    </span>
+                    <span class="text-text-secondary">
+                        {{ bar.detail }}
+                        <span class="text-text-muted">
+                            · {{ formatPercent(bar.percent) }}
+                        </span>
+                    </span>
+                </div>
+                <div
+                    class="h-1.5 w-full overflow-hidden rounded-full bg-background-panel-hover"
+                >
+                    <div
+                        class="h-full rounded-full transition-[width]"
+                        :class="usageBarClass(bar.percent)"
+                        :style="{ width: clampWidth(bar.percent) }"
+                    />
+                </div>
+            </div>
+        </div>
+
+        <dl
+            class="grid grid-cols-3 gap-4 border-t border-border-subtle pt-4 text-xs"
+        >
+            <div class="flex flex-col gap-1">
+                <dt class="uppercase tracking-[0.18em] text-text-muted">
+                    Load avg
+                </dt>
+                <dd class="font-mono text-sm text-text-primary">
+                    {{
+                        current.load_average !== null
+                            ? current.load_average.toFixed(2)
+                            : '—'
+                    }}
+                </dd>
+            </div>
+            <div class="flex flex-col gap-1">
+                <dt
+                    class="flex items-center gap-1 uppercase tracking-[0.18em] text-text-muted"
+                >
+                    <ArrowDown class="h-3 w-3" aria-hidden="true" />
+                    Net in
+                </dt>
+                <dd class="font-mono text-sm text-text-primary">
+                    {{ formatBytes(current.network_rx_bytes) }}
+                </dd>
+            </div>
+            <div class="flex flex-col gap-1">
+                <dt
+                    class="flex items-center gap-1 uppercase tracking-[0.18em] text-text-muted"
+                >
+                    <ArrowUp class="h-3 w-3" aria-hidden="true" />
+                    Net out
+                </dt>
+                <dd class="font-mono text-sm text-text-primary">
+                    {{ formatBytes(current.network_tx_bytes) }}
+                </dd>
+            </div>
+        </dl>
+    </section>
+</template>

--- a/resources/js/Pages/Monitoring/Hosts/Index.vue
+++ b/resources/js/Pages/Monitoring/Hosts/Index.vue
@@ -35,6 +35,8 @@ interface HostRow {
         | string
         | null;
     last_seen_at: string | null;
+    cpu_percent: number | null;
+    memory_percent: number | null;
     project: ProjectChip | null;
     active_agent_token: ActiveAgentToken | null;
 }
@@ -54,6 +56,19 @@ const projectAccentClass = (color: string | null) =>
             warning: 'text-status-warning',
         }) as const
     )[color ?? ''] ?? 'text-text-muted';
+
+// At-a-glance utilisation tone for the CPU / memory column. <70 is
+// healthy, 70–90 warns, ≥90 alerts. Matches the bar thresholds in
+// `HostMetricsPanel`.
+const usageTextClass = (pct: number | null): string => {
+    if (pct === null) return 'text-text-muted';
+    if (pct >= 90) return 'text-status-danger';
+    if (pct >= 70) return 'text-status-warning';
+    return 'text-status-success';
+};
+
+const formatPercent = (pct: number | null): string =>
+    pct === null ? '—' : `${Math.round(pct)}%`;
 </script>
 
 <template>
@@ -82,8 +97,7 @@ const projectAccentClass = (color: string | null) =>
                     <p class="text-sm text-text-secondary">
                         Hosts running the Nexus agent. Mint a token,
                         install the agent, and the host's CPU, memory,
-                        and containers stream into Nexus. Telemetry
-                        ingestion lands in spec 027.
+                        and containers stream into Nexus.
                     </p>
                 </div>
                 <Link
@@ -162,6 +176,18 @@ const projectAccentClass = (color: string | null) =>
                                 </span>
                                 <span v-else class="text-text-muted/70">
                                     · Awaiting first telemetry
+                                </span>
+                                <span
+                                    class="font-mono text-[10px] tracking-[0.18em]"
+                                    :class="usageTextClass(host.cpu_percent)"
+                                >
+                                    · CPU {{ formatPercent(host.cpu_percent) }}
+                                </span>
+                                <span
+                                    class="font-mono text-[10px] tracking-[0.18em]"
+                                    :class="usageTextClass(host.memory_percent)"
+                                >
+                                    · MEM {{ formatPercent(host.memory_percent) }}
                                 </span>
                             </p>
                         </div>

--- a/resources/js/Pages/Monitoring/Hosts/Show.vue
+++ b/resources/js/Pages/Monitoring/Hosts/Show.vue
@@ -1,15 +1,22 @@
 <script setup lang="ts">
+import Sparkline from '@/Components/Dashboard/Sparkline.vue';
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import AgentTokenPanel from '@/Components/Hosts/AgentTokenPanel.vue';
+import ContainerTable from '@/Components/Hosts/ContainerTable.vue';
+import HostMetricsPanel from '@/Components/Hosts/HostMetricsPanel.vue';
 import { hostStatusTone as statusTone } from '@/lib/hostStyles';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import { Head, Link, router } from '@inertiajs/vue3';
+import type { PageProps } from '@/types';
+import { Head, Link, router, usePage } from '@inertiajs/vue3';
 import {
     ChevronLeft,
+    Clock,
     ExternalLink,
     PencilLine,
     Trash2,
+    WifiOff,
 } from 'lucide-vue-next';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 
 interface ActiveAgentToken {
     id: number;
@@ -47,16 +54,62 @@ interface HostPayload {
     disk_total_gb: number | null;
     os: string | null;
     docker_version: string | null;
+    cpu_percent: number | null;
+    memory_percent: number | null;
     project: ProjectChip | null;
     active_agent_token: ActiveAgentToken | null;
 }
 
+interface CurrentMetrics {
+    cpu_percent: number | null;
+    memory_used_mb: number | null;
+    memory_total_mb: number | null;
+    memory_percent: number | null;
+    disk_used_gb: number | null;
+    disk_total_gb: number | null;
+    load_average: number | null;
+    network_rx_bytes: number | null;
+    network_tx_bytes: number | null;
+    recorded_at: string | null;
+}
+
+interface SeriesPoint {
+    cpu_percent: number | null;
+    memory_percent: number | null;
+    recorded_at: string | null;
+}
+
+interface ContainerRow {
+    id: number;
+    container_id: string;
+    name: string;
+    image: string;
+    image_tag: string | null;
+    status: string | null;
+    state: string | null;
+    health_status: string | null;
+    cpu_percent: number | null;
+    memory_usage_mb: number | null;
+    memory_limit_mb: number | null;
+    memory_percent: number | null;
+    last_seen_at: string | null;
+}
+
+interface TelemetryShape {
+    current: CurrentMetrics | null;
+    series: SeriesPoint[];
+    containers: ContainerRow[];
+}
+
 const props = defineProps<{
     host: HostPayload;
+    telemetry: TelemetryShape;
     canUpdate: boolean;
     canDelete: boolean;
     canManageTokens: boolean;
 }>();
+
+const page = usePage<PageProps>();
 
 const archive = () => {
     if (
@@ -68,6 +121,111 @@ const archive = () => {
     }
     router.delete(route('monitoring.hosts.destroy', props.host.id));
 };
+
+// ─── Sparkline series (leading-null skip + carry-forward) ───────────
+// Same pattern as spec 025's response-time sparkline: nulls inherit
+// the previous known value once one exists, so a brief metric gap
+// doesn't pull the chart to 0.
+const sparklineFrom = (
+    pick: (point: SeriesPoint) => number | null,
+): number[] => {
+    const points: number[] = [];
+    let last: number | null = null;
+    for (const point of props.telemetry.series) {
+        const value = pick(point);
+        if (value !== null) {
+            last = value;
+        }
+        if (last === null) continue;
+        points.push(last);
+    }
+    return points;
+};
+
+const cpuSeries = computed<number[]>(() =>
+    sparklineFrom((p) => p.cpu_percent),
+);
+const memorySeries = computed<number[]>(() =>
+    sparklineFrom((p) => p.memory_percent),
+);
+
+const currentCpu = computed<number | null>(
+    () => props.telemetry.current?.cpu_percent ?? null,
+);
+const currentMemory = computed<number | null>(
+    () => props.telemetry.current?.memory_percent ?? null,
+);
+
+// ─── Reverb subscription (spec 028) ──────────────────────────────────
+// `HostTelemetryRecorded` fires on `users.{ownerId}.hosts` when an
+// agent posts telemetry. Filter client-side by host_id and partial-
+// reload host + telemetry props on a match. Mirrors spec 025.
+const realtimeConnected = ref<boolean | null>(null);
+let teardown: (() => void) | null = null;
+
+onMounted(() => {
+    if (typeof window === 'undefined' || !window.Echo) {
+        return;
+    }
+    const userId = page.props.auth?.user?.id;
+    if (userId == null) return;
+
+    const channelName = `users.${userId}.hosts`;
+    const channel = window.Echo.private(channelName);
+
+    channel.listen(
+        '.HostTelemetryRecorded',
+        (payload: { host_id: number }) => {
+            if (payload.host_id !== props.host.id) return;
+            router.reload({ only: ['host', 'telemetry'] });
+        },
+    );
+
+    const connector = window.Echo.connector;
+    const pusher = (
+        connector as {
+            pusher?: {
+                connection?: {
+                    state?: string;
+                    bind: (e: string, cb: () => void) => void;
+                    unbind: (e: string, cb: () => void) => void;
+                };
+            };
+        }
+    )?.pusher;
+
+    const onConnect = () => {
+        realtimeConnected.value = true;
+    };
+    const onDisconnect = () => {
+        realtimeConnected.value = false;
+    };
+
+    if (pusher?.connection) {
+        if (pusher.connection.state === 'connected') {
+            realtimeConnected.value = true;
+        }
+        pusher.connection.bind('connected', onConnect);
+        pusher.connection.bind('disconnected', onDisconnect);
+        pusher.connection.bind('unavailable', onDisconnect);
+        pusher.connection.bind('failed', onDisconnect);
+    }
+
+    teardown = () => {
+        channel.stopListening('.HostTelemetryRecorded');
+        window.Echo?.leave(`users.${userId}.hosts`);
+        if (pusher?.connection) {
+            pusher.connection.unbind('connected', onConnect);
+            pusher.connection.unbind('disconnected', onDisconnect);
+            pusher.connection.unbind('unavailable', onDisconnect);
+            pusher.connection.unbind('failed', onDisconnect);
+        }
+    };
+});
+
+onBeforeUnmount(() => {
+    teardown?.();
+});
 </script>
 
 <template>
@@ -131,6 +289,14 @@ const archive = () => {
                         </p>
                     </div>
                     <div class="flex shrink-0 items-center gap-2">
+                        <span
+                            v-if="realtimeConnected === false"
+                            class="inline-flex items-center gap-1.5 rounded-full border border-status-warning/40 bg-status-warning/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-status-warning"
+                            title="Live updates offline. Telemetry still records; refresh to see the latest."
+                        >
+                            <WifiOff class="h-3 w-3" aria-hidden="true" />
+                            Live offline
+                        </span>
                         <Link
                             v-if="canUpdate"
                             :href="route('monitoring.hosts.edit', host.id)"
@@ -227,24 +393,115 @@ const archive = () => {
                 </p>
             </section>
 
+            <section
+                v-if="telemetry.current === null"
+                class="glass-card flex flex-col items-center gap-3 border-dashed p-8 text-center"
+            >
+                <Clock
+                    class="h-6 w-6 text-text-muted"
+                    aria-hidden="true"
+                />
+                <p class="text-sm font-semibold text-text-secondary">
+                    Waiting for first telemetry
+                </p>
+                <p class="max-w-sm text-xs text-text-muted">
+                    Mint an agent token below and point the reference agent
+                    at this host. Metrics and the container table appear
+                    here as soon as the first tick lands.
+                </p>
+            </section>
+
+            <template v-else>
+                <HostMetricsPanel :current="telemetry.current" />
+
+                <section class="glass-card flex flex-col gap-4 p-6">
+                    <header class="flex items-center justify-between gap-3">
+                        <h3
+                            class="text-xs font-semibold uppercase tracking-[0.2em] text-text-secondary"
+                        >
+                            History
+                        </h3>
+                        <span class="text-[11px] text-text-muted">
+                            last {{ telemetry.series.length }}
+                            {{
+                                telemetry.series.length === 1
+                                    ? 'tick'
+                                    : 'ticks'
+                            }}
+                        </span>
+                    </header>
+                    <div class="grid gap-6 sm:grid-cols-2">
+                        <div class="flex flex-col gap-2">
+                            <div
+                                class="flex items-baseline justify-between text-xs"
+                            >
+                                <span
+                                    class="font-mono uppercase tracking-[0.18em] text-text-muted"
+                                >
+                                    CPU
+                                </span>
+                                <span class="text-text-secondary">
+                                    {{
+                                        currentCpu !== null
+                                            ? `${currentCpu.toFixed(1)}%`
+                                            : '—'
+                                    }}
+                                </span>
+                            </div>
+                            <Sparkline
+                                v-if="cpuSeries.length >= 2"
+                                :points="cpuSeries"
+                                accent="cyan"
+                                :height="40"
+                            />
+                            <p
+                                v-else
+                                class="text-[11px] text-text-muted"
+                            >
+                                Not enough data yet.
+                            </p>
+                        </div>
+                        <div class="flex flex-col gap-2">
+                            <div
+                                class="flex items-baseline justify-between text-xs"
+                            >
+                                <span
+                                    class="font-mono uppercase tracking-[0.18em] text-text-muted"
+                                >
+                                    Memory
+                                </span>
+                                <span class="text-text-secondary">
+                                    {{
+                                        currentMemory !== null
+                                            ? `${currentMemory.toFixed(1)}%`
+                                            : '—'
+                                    }}
+                                </span>
+                            </div>
+                            <Sparkline
+                                v-if="memorySeries.length >= 2"
+                                :points="memorySeries"
+                                accent="purple"
+                                :height="40"
+                            />
+                            <p
+                                v-else
+                                class="text-[11px] text-text-muted"
+                            >
+                                Not enough data yet.
+                            </p>
+                        </div>
+                    </div>
+                </section>
+
+                <ContainerTable :containers="telemetry.containers" />
+            </template>
+
             <AgentTokenPanel
                 :host-id="host.id"
                 :active-token="host.active_agent_token"
                 :can-manage-tokens="canManageTokens"
             />
-
-            <section
-                class="glass-card flex flex-col gap-2 border-dashed p-6 text-xs text-text-muted"
-            >
-                <p class="font-semibold uppercase tracking-[0.2em] text-text-secondary">
-                    Coming in spec 027 / 028
-                </p>
-                <p>
-                    Telemetry ingestion (CPU, memory, container stats)
-                    and the host's container table arrive in the next
-                    two specs of phase 6.
-                </p>
-            </section>
         </div>
     </AppLayout>
 </template>

--- a/resources/js/Pages/Monitoring/Hosts/Show.vue
+++ b/resources/js/Pages/Monitoring/Hosts/Show.vue
@@ -167,6 +167,12 @@ onMounted(() => {
     if (typeof window === 'undefined' || !window.Echo) {
         return;
     }
+    // Phase-1 owns the realtime ACL: the viewer of a host's Show page
+    // is the project owner, and `HostTelemetryRecorded` broadcasts on
+    // `users.{owner_user_id}.hosts`. Viewer === owner today, so the
+    // current user's id is the correct channel id. When multi-tenant
+    // ACL lands, swap this for an explicit owner-id prop passed by
+    // `HostController@show`.
     const userId = page.props.auth?.user?.id;
     if (userId == null) return;
 

--- a/resources/js/lib/hostStyles.ts
+++ b/resources/js/lib/hostStyles.ts
@@ -27,3 +27,39 @@ export const hostStatusTone = (
             archived: 'muted',
         }) as const
     )[status ?? ''] ?? 'muted';
+
+/**
+ * Tone for a container's Docker `state` (spec 028). `running` is the
+ * healthy steady state; transient states warn; `exited` is neutral
+ * (could be a finished one-shot) and `dead` is a hard failure.
+ */
+export const containerStateTone = (
+    state: string | null,
+): 'muted' | 'success' | 'warning' | 'danger' =>
+    (
+        ({
+            running: 'success',
+            created: 'warning',
+            restarting: 'warning',
+            paused: 'warning',
+            exited: 'muted',
+            dead: 'danger',
+        }) as const
+    )[state ?? ''] ?? 'muted';
+
+/**
+ * Tone for a container's healthcheck `health_status` (spec 028). Only
+ * containers that declare a Docker `HEALTHCHECK` report anything other
+ * than `none`.
+ */
+export const containerHealthTone = (
+    health: string | null,
+): 'muted' | 'success' | 'warning' | 'danger' =>
+    (
+        ({
+            healthy: 'success',
+            unhealthy: 'danger',
+            starting: 'warning',
+            none: 'muted',
+        }) as const
+    )[health ?? ''] ?? 'muted';

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -30,3 +30,11 @@ Broadcast::channel('users.{userId}.deployments', function ($user, $userId) {
 Broadcast::channel('users.{userId}.monitoring', function ($user, $userId) {
     return (int) $user->id === (int) $userId;
 });
+
+// Spec 028 — per-user hosts channel. `HostTelemetryRecorded`
+// broadcasts here on every agent telemetry tick so the Host Show
+// page reflects fresh CPU / memory / container stats without a
+// manual refresh. Mirrors the monitoring channel above.
+Broadcast::channel('users.{userId}.hosts', function ($user, $userId) {
+    return (int) $user->id === (int) $userId;
+});

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,7 +41,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 3 | GitHub Webhooks & Activity Feed | 🟢 | 3/3 specs done (017–019). Phase complete. |
 | 4 | Deployments & CI/CD | 🟢 | 3/3 specs done (020–022). Phase complete. |
 | 5 | Website Monitoring | 🟢 | 3/3 specs done (023–025). Phase complete. |
-| 6 | Docker Host Agent MVP | 🟡 | 2/4 specs done (026–029). 026, 027 shipped. |
+| 6 | Docker Host Agent MVP | 🟡 | 3/4 specs done (026–029). 026, 027, 028 shipped. |
 | 7 | Alerts Engine | ⬜ | — |
 | 8 | Analytics & Health Scores | ⬜ | — |
 | 9 | Polish & Production Readiness | ⬜ | — |

--- a/specs/phase-6-docker-hosts/028-hosts-ui.md
+++ b/specs/phase-6-docker-hosts/028-hosts-ui.md
@@ -1,10 +1,10 @@
 ---
 spec: hosts-ui
 phase: 6
-status: in-progress   # not-started | in-progress | blocked | done
+status: done   # not-started | in-progress | blocked | done
 owner: Yoany
 created: 2026-05-21
-updated: 2026-05-21
+updated: 2026-05-26
 ---
 
 # 028 — Hosts UI (telemetry display)
@@ -191,24 +191,24 @@ list, container stats chart), §19 Phase 6.
       `HostTelemetryRecorded` on the host owner's `users.{id}.hosts` channel.
 
 ## Acceptance criteria
-- [ ] Host Show page renders current CPU / memory / disk / load / network from
+- [x] Host Show page renders current CPU / memory / disk / load / network from
       the latest snapshot, a CPU+memory history sparkline, and a container
       table — no placeholder card remains.
-- [ ] A host that has never reported telemetry shows a "Waiting for first
+- [x] A host that has never reported telemetry shows a "Waiting for first
       telemetry" state, not an error or empty crash.
-- [ ] A host with telemetry but no containers shows a "No containers reported"
+- [x] A host with telemetry but no containers shows a "No containers reported"
       state.
-- [ ] Host Index shows a CPU / memory glance per row; hosts with no telemetry
+- [x] Host Index shows a CPU / memory glance per row; hosts with no telemetry
       render a dash, not a crash.
-- [ ] No N+1 on the index (latest snapshot eager-loaded via `latestOfMany`).
-- [ ] A telemetry ingest broadcasts `HostTelemetryRecorded` on the host
+- [x] No N+1 on the index (latest snapshot eager-loaded via `latestOfMany`).
+- [x] A telemetry ingest broadcasts `HostTelemetryRecorded` on the host
       owner's `users.{id}.hosts` channel; the Show page partial-reloads
       `host` + `telemetry` on the pulse without a manual refresh.
-- [ ] Show page shows a "Live updates offline" pill when the socket is down;
+- [x] Show page shows a "Live updates offline" pill when the socket is down;
       page-load reads still surface the latest telemetry.
-- [ ] Sidebar `Hosts` and the project `Hosts` tab continue to work (regression
+- [x] Sidebar `Hosts` and the project `Hosts` tab continue to work (regression
       check — both were wired pre-028).
-- [ ] Pint clean, `php artisan test` green (new tests added), `npm run build`
+- [x] Pint clean, `php artisan test` green (new tests added), `npm run build`
       clean.
 
 ## Files touched
@@ -235,6 +235,12 @@ Fill in as work progresses.
 - Spec drafted for review.
 - Realtime (Reverb live updates) pulled into scope per review.
 - Issue [#85](https://github.com/Copxer/nexus/issues/85) opened, branch `spec/028-hosts-ui` cut off `main`.
+
+### 2026-05-26
+- Backend: `Host::latestMetricSnapshot` relation, `GetHostTelemetryQuery`, `HostMetricSnapshot::memoryPercent`, controller wiring, `HostTelemetryRecorded` (ShouldBroadcastNow + ShouldDispatchAfterCommit), channels.php auth.
+- Frontend: `HostMetricsPanel`, `ContainerTable`, full `Show.vue` rewrite (metrics + sparklines + container table + Echo + Live-offline pill + Waiting state), `Index.vue` CPU / MEM column, `hostStyles.ts` container tones.
+- Tests: 12 new (5 unit query, 2 broadcast feature, 4 controller telemetry, 1 event-surface). Full suite 480 green pre-fixes, 487 after, Pint clean, build clean.
+- Self-review via `superpowers:code-reviewer`. Addressed: (1) added dedicated `HostTelemetryRecordedTest` mirroring `WebsiteCheckRecordedTest`, (2) hardened `HostTelemetryRecorded` with `ShouldDispatchAfterCommit` to survive any future outer-transaction wrapping, (3) inline comment in `Show.vue` documenting the phase-1 viewer-==-owner realtime ACL assumption.
 
 ## Open questions / blockers
 - **Realtime — resolved (in scope).** Pulled into 028 per review: the Host

--- a/specs/phase-6-docker-hosts/028-hosts-ui.md
+++ b/specs/phase-6-docker-hosts/028-hosts-ui.md
@@ -1,0 +1,249 @@
+---
+spec: hosts-ui
+phase: 6
+status: in-progress   # not-started | in-progress | blocked | done
+owner: Yoany
+created: 2026-05-21
+updated: 2026-05-21
+---
+
+# 028 — Hosts UI (telemetry display)
+
+## Goal
+Render the telemetry that 027 ingests. Specs 026 + 027 stood up the data layer
+(`hosts`, `containers`, `host_metric_snapshots`, `container_metric_snapshots`),
+the CRUD pages, and the `POST /agent/telemetry` endpoint — but the host detail
+page still shows a dashed "Coming in spec 027 / 028" placeholder and the index
+is a metadata-only table. 028 closes that gap: after this spec a user opens a
+host and sees its current CPU / memory / disk / load / network, a short
+CPU+memory history chart, and the table of containers with per-container
+CPU / memory. The index gains an at-a-glance CPU / memory column.
+
+Roadmap refs: §8.7 Docker Hosts ("UX Requirements" — host cards, CPU/memory
+bars, status badges, running container count, last seen, drill-down container
+list, container stats chart), §19 Phase 6.
+
+## Scope
+
+**In scope:**
+
+- **Host Show page** (`Monitoring/Hosts/Show.vue`) — replace the placeholder
+  card (lines ~237–247) with three real sections:
+  - *Current metrics panel* — the latest `host_metric_snapshot`: CPU %, a
+    memory used/total bar, a disk used/total bar, load average, and network
+    rx/tx (humanised bytes). Sits alongside the existing host facts
+    (`cpu_count`, `os`, `docker_version`).
+  - *Host metrics chart* — a CPU % and memory % `Sparkline` (reuse
+    `Components/Dashboard/Sparkline.vue` from spec 025) over the last 50
+    `host_metric_snapshots`, oldest→newest.
+  - *Container table* — every `Container` for the host: name, `image:tag`,
+    status / state, health badge, CPU %, memory usage/limit (+ percent).
+    Reuse `StatusBadge`.
+- **Host Index page** (`Monitoring/Hosts/Index.vue`) — add a compact CPU /
+  memory column per row, sourced from each host's latest snapshot. Keep the
+  table layout (consistent with `Monitoring/Websites/Index.vue`; the roadmap's
+  "host cards" is a visual nicety, not worth diverging the established index
+  pattern for).
+- **Empty / waiting states:**
+  - Host that has never reported telemetry (no snapshot rows, `status =
+    pending`) → "Waiting for first telemetry" panel pointing at the agent
+    token panel below.
+  - Host online but zero containers → "No containers reported" row in the
+    container table.
+  - `<2` snapshots → the chart renders a "not enough data yet" placeholder
+    (mirrors spec 025's Sparkline guard).
+- **Backend:**
+  - `Host::latestMetricSnapshot()` — a `hasOne()->latestOfMany('recorded_at')`
+    relation so the index can eager-load one snapshot per host without an N+1.
+  - `app/Domain/Docker/Queries/GetHostTelemetryQuery.php` — for Show: returns
+    the latest host snapshot, the last 50 snapshots (chart series), and the
+    container list with each container's latest stats. One query class so the
+    controller stays thin.
+  - `HostController@index` eager-loads `latestMetricSnapshot`; `@show` calls
+    the query. `transform()` (or a sibling shape method) gains the metric
+    fields. Container memory_percent is already computed at ingest time
+    (027's `SyncContainerSnapshotsAction`) — read it, don't recompute.
+- **Components:**
+  - `resources/js/Components/Hosts/HostMetricsPanel.vue` — the current-metrics
+    panel (bars + load + network).
+  - `resources/js/Components/Hosts/ContainerTable.vue` — the container table.
+- **Realtime (Reverb).** The Host Show page updates without a reload when fresh
+  telemetry lands, mirroring spec 025's `WebsiteCheckRecorded` pattern:
+  - `app/Events/HostTelemetryRecorded.php` — a `ShouldBroadcastNow` event on a
+    private `users.{id}.hosts` channel, lightweight `{host_id}` payload. The
+    recipient `user_id` is pre-resolved (host → project → `owner_user_id`) so
+    `broadcastOn()` does no query.
+  - Dispatched from 027's `IngestHostTelemetryAction` **after** the DB
+    transaction commits (`DB::afterCommit` / `ShouldDispatchAfterCommit`) so
+    the browser never partial-reloads ahead of the write.
+  - `routes/channels.php` — authorize `users.{id}.hosts` (own-user only),
+    matching the existing `users.{id}.{activity,deployments,monitoring}`
+    entries.
+  - `Show.vue` subscribes via Echo, filters client-side by `host_id`, and
+    partial-reloads the `host` + `telemetry` props on each pulse. A small
+    "Live updates offline" pill shows when the socket is down (same treatment
+    as the activity rail). Index stays page-load only — realtime is the detail
+    page's concern, consistent with spec 025 (website *show* only).
+- **Tests:** feature tests for Show (renders metrics + container rows; the
+  waiting state when no snapshot exists; the no-containers state) and Index
+  (renders the CPU/memory column from the latest snapshot; host with no
+  telemetry shows blank/placeholder, not a crash); a broadcast test that
+  `HostTelemetryRecorded` fires on telemetry ingest and resolves the host
+  owner's channel. Sibling-isolation already covered by 026's
+  `HostControllerTest`.
+
+**Out of scope:**
+
+- Host offline detection, the `pending|online|offline` heartbeat-timeout
+  transition, and `host.offline` / `host.recovered` activity events — **029**.
+- The Overview "Hosts" KPI (still proxied off `Repository::count()`) — **029**.
+- Host event log (roadmap §8.7 UX) — it's the per-host slice of the activity
+  feed, and depends on 029's host activity events.
+- Per-container drill-down page and per-container metric history charts. 028
+  shows the container table with *current* stats only.
+- Container removal / stale-row sweep — deferred (027 open question).
+- Project "Hosts" tab — already wired in fix #82; 028 touches it only if the
+  shared `projectHosts` prop shape changes (it should not).
+
+## Plan
+
+1. **`Host::latestMetricSnapshot` relation.** In `app/Models/Host.php`:
+   ```php
+   public function latestMetricSnapshot(): HasOne
+   {
+       return $this->hasOne(HostMetricSnapshot::class)->latestOfMany('recorded_at');
+   }
+   ```
+   Confirm `hostMetricSnapshots()` (hasMany) and `containers()` already exist
+   from 026; add whichever is missing.
+
+2. **`GetHostTelemetryQuery`.** New `app/Domain/Docker/Queries/GetHostTelemetryQuery.php`.
+   `execute(Host $host): array` returns:
+   - `current` — the latest `host_metric_snapshot` as an array (or `null`).
+   - `series` — last 50 snapshots `recorded_at` ASC, each `{cpu_percent,
+     memory_percent, recorded_at}`. `memory_percent` = `memory_used_mb /
+     memory_total_mb * 100` when both present, else `null` (leading-null skip
+     + carry-forward is the Sparkline's job, per spec 025).
+   - `containers` — the host's `containers` ordered by `name`, each with
+     `{container_id, name, image, image_tag, status, state, health_status,
+     cpu_percent, memory_usage_mb, memory_limit_mb, memory_percent,
+     last_seen_at}`.
+
+3. **`HostController`.**
+   - `index` — add `latestMetricSnapshot` to the `with([...])`; extend
+     `transform()` with `cpu_percent` + `memory_percent` pulled off the
+     relation (nullable when the host has never reported).
+   - `show` — call `GetHostTelemetryQuery` and pass a `telemetry` prop
+     (`{current, series, containers}`) alongside the existing `host` prop.
+     Keep the auth + `canUpdate/canDelete/canManageTokens` props as-is.
+
+4. **`HostMetricsPanel.vue`.** Props: `current` (the latest snapshot or null).
+   Renders CPU % , memory used/total bar, disk used/total bar, load average,
+   network rx/tx (humanised). When `current` is null, render nothing — the
+   page-level waiting state owns the empty case.
+
+5. **`ContainerTable.vue`.** Props: `containers` (array). Renders a table;
+   per-row health/state via `StatusBadge` tone. Empty array → a single
+   "No containers reported" row.
+
+6. **`Show.vue`.** Replace the placeholder block. Order: host facts +
+   `HostMetricsPanel` → metrics `Sparkline` card → `ContainerTable` → existing
+   `AgentTokenPanel`. When `telemetry.current` is null show the "Waiting for
+   first telemetry" panel instead of the metrics panel + chart.
+
+7. **`Index.vue`.** Add a CPU / memory column — small inline bars or `NN%`
+   text from `host.cpu_percent` / `host.memory_percent`. Dash when null.
+
+8. **`hostStyles.ts`.** Reuse the existing `hostStatusTone()`. Add a
+   `containerHealthTone()` map if container `health_status` needs its own
+   tone set (`healthy|unhealthy|starting|none`); otherwise reuse status tones.
+
+9. **Realtime event.** New `app/Events/HostTelemetryRecorded.php` —
+   `ShouldBroadcastNow`, constructor takes `(int $hostId, int $ownerUserId)`,
+   `broadcastOn()` returns `new PrivateChannel("users.{$this->ownerUserId}.hosts")`,
+   `broadcastWith()` returns `['host_id' => $this->hostId]`. In 027's
+   `IngestHostTelemetryAction`, resolve the owner once
+   (`$host->project->owner_user_id`) and dispatch the event via
+   `DB::afterCommit(...)` (or implement `ShouldDispatchAfterCommit`) so it
+   never races the write. Authorize `users.{id}.hosts` in
+   `routes/channels.php` — `(int) $user->id === (int) $id`, copying the
+   shape of the existing `users.{id}.monitoring` entry.
+
+10. **Echo subscription.** In `Show.vue`, subscribe to
+    `users.{ownerId}.hosts` via Echo (the owner id rides in as a prop or is
+    read from the shared auth prop), filter pulses by `host_id`, and on a
+    match call `router.reload({ only: ['host', 'telemetry'] })`. Track socket
+    connectivity and render a "Live updates offline" pill when down — reuse
+    the pattern in `lib/useActivityFeed.ts` / the activity rail. Tear the
+    subscription down on unmount.
+
+11. **Tests.** `tests/Feature/Monitoring/HostControllerTest.php` (extend) or a
+    new `HostTelemetryViewTest.php`:
+    - Show renders `telemetry.current` + container rows when snapshots exist.
+    - Show renders the waiting state when the host has no snapshots.
+    - Show renders the no-containers state when snapshots exist but no
+      containers.
+    - Index `transform` exposes `cpu_percent` / `memory_percent` from the
+      latest snapshot, and `null` for a host that never reported.
+    - `GetHostTelemetryQuery` unit test: `series` ordering + `memory_percent`
+      computation + 50-row cap.
+    - Broadcast test (`Event::fake()`): a telemetry ingest dispatches
+      `HostTelemetryRecorded` on the host owner's `users.{id}.hosts` channel.
+
+## Acceptance criteria
+- [ ] Host Show page renders current CPU / memory / disk / load / network from
+      the latest snapshot, a CPU+memory history sparkline, and a container
+      table — no placeholder card remains.
+- [ ] A host that has never reported telemetry shows a "Waiting for first
+      telemetry" state, not an error or empty crash.
+- [ ] A host with telemetry but no containers shows a "No containers reported"
+      state.
+- [ ] Host Index shows a CPU / memory glance per row; hosts with no telemetry
+      render a dash, not a crash.
+- [ ] No N+1 on the index (latest snapshot eager-loaded via `latestOfMany`).
+- [ ] A telemetry ingest broadcasts `HostTelemetryRecorded` on the host
+      owner's `users.{id}.hosts` channel; the Show page partial-reloads
+      `host` + `telemetry` on the pulse without a manual refresh.
+- [ ] Show page shows a "Live updates offline" pill when the socket is down;
+      page-load reads still surface the latest telemetry.
+- [ ] Sidebar `Hosts` and the project `Hosts` tab continue to work (regression
+      check — both were wired pre-028).
+- [ ] Pint clean, `php artisan test` green (new tests added), `npm run build`
+      clean.
+
+## Files touched
+Fill in as work progresses.
+
+- `app/Models/Host.php` — add `latestMetricSnapshot` relation
+- `app/Domain/Docker/Queries/GetHostTelemetryQuery.php` — new
+- `app/Events/HostTelemetryRecorded.php` — new (ShouldBroadcastNow)
+- `app/Domain/Docker/Actions/IngestHostTelemetryAction.php` — dispatch `HostTelemetryRecorded` after commit
+- `routes/channels.php` — authorize `users.{id}.hosts`
+- `app/Http/Controllers/Monitoring/HostController.php` — index eager-load + show telemetry prop + transform fields
+- `resources/js/Pages/Monitoring/Hosts/Show.vue` — replace placeholder with metrics + chart + container table + Echo subscription
+- `resources/js/Pages/Monitoring/Hosts/Index.vue` — CPU/memory column
+- `resources/js/Components/Hosts/HostMetricsPanel.vue` — new
+- `resources/js/Components/Hosts/ContainerTable.vue` — new
+- `resources/js/lib/hostStyles.ts` — add `containerHealthTone()` if needed
+- `tests/Feature/Monitoring/HostControllerTest.php` — extend (or new `HostTelemetryViewTest.php`)
+- `tests/Unit/Domain/Docker/GetHostTelemetryQueryTest.php` — new
+- `tests/Feature/Monitoring/HostTelemetryBroadcastTest.php` — new
+
+## Work log
+
+### 2026-05-21
+- Spec drafted for review.
+- Realtime (Reverb live updates) pulled into scope per review.
+- Issue [#85](https://github.com/Copxer/nexus/issues/85) opened, branch `spec/028-hosts-ui` cut off `main`.
+
+## Open questions / blockers
+- **Realtime — resolved (in scope).** Pulled into 028 per review: the Host
+  Show page subscribes to a `users.{id}.hosts` Reverb channel and
+  partial-reloads on each telemetry pulse, mirroring spec 025's
+  `WebsiteCheckRecorded`. The Index stays page-load only.
+- **Index: table vs cards.** Roadmap §8.7 UX says "host cards". 028 keeps the
+  table for consistency with the websites index. If we want cards, that's a
+  visual-reference call worth making explicitly.
+- **Container table depth.** 028 shows current per-container stats only. Per
+  the roadmap a "container stats chart" exists — deferred to a later spec
+  since `container_metric_snapshots` history is already being persisted.

--- a/specs/phase-6-docker-hosts/README.md
+++ b/specs/phase-6-docker-hosts/README.md
@@ -11,7 +11,7 @@ Stand up Docker host + container monitoring end-to-end via a pull-from-agent mod
 |---|------|--------|
 | 026 | Hosts + agent tokens scaffolding (CRUD + token rotation) | 🟢 |
 | 027 | Telemetry ingestion endpoint + reference agent script | 🟢 |
-| 028 | Hosts UI (index + show + project Hosts tab) | ⬜ |
+| 028 | Hosts UI (index + show + project Hosts tab) | 🟢 |
 | 029 | Host offline detection + activity events + Overview KPI wiring | ⬜ |
 
 ## Acceptance criteria (phase-level)

--- a/tests/Feature/Events/HostTelemetryRecordedTest.php
+++ b/tests/Feature/Events/HostTelemetryRecordedTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Events;
+
+use App\Events\HostTelemetryRecorded;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+use Tests\TestCase;
+
+class HostTelemetryRecordedTest extends TestCase
+{
+    public function test_implements_should_broadcast_now(): void
+    {
+        $event = new HostTelemetryRecorded(hostId: 1, ownerUserId: 2);
+
+        $this->assertInstanceOf(ShouldBroadcastNow::class, $event);
+    }
+
+    public function test_implements_should_dispatch_after_commit(): void
+    {
+        $event = new HostTelemetryRecorded(hostId: 1, ownerUserId: 2);
+
+        $this->assertInstanceOf(ShouldDispatchAfterCommit::class, $event);
+    }
+
+    public function test_broadcasts_on_owner_hosts_channel(): void
+    {
+        $event = new HostTelemetryRecorded(hostId: 1, ownerUserId: 99);
+
+        $channels = $event->broadcastOn();
+
+        $this->assertCount(1, $channels);
+        $this->assertInstanceOf(PrivateChannel::class, $channels[0]);
+        // PrivateChannel internally prefixes with "private-"; assert by
+        // the suffix the JS client subscribes to.
+        $this->assertStringEndsWith('users.99.hosts', $channels[0]->name);
+    }
+
+    public function test_no_channels_when_owner_user_id_is_null(): void
+    {
+        $event = new HostTelemetryRecorded(hostId: 1, ownerUserId: null);
+
+        $this->assertSame([], $event->broadcastOn());
+    }
+
+    public function test_broadcast_with_payload_carries_just_the_host_id(): void
+    {
+        $event = new HostTelemetryRecorded(hostId: 42, ownerUserId: 1);
+
+        $this->assertSame(['host_id' => 42], $event->broadcastWith());
+    }
+
+    public function test_broadcast_as_uses_stable_dotted_name(): void
+    {
+        $event = new HostTelemetryRecorded(hostId: 1, ownerUserId: 2);
+
+        $this->assertSame('HostTelemetryRecorded', $event->broadcastAs());
+    }
+}

--- a/tests/Feature/Monitoring/HostControllerTest.php
+++ b/tests/Feature/Monitoring/HostControllerTest.php
@@ -4,7 +4,9 @@ namespace Tests\Feature\Monitoring;
 
 use App\Enums\HostStatus;
 use App\Models\AgentToken;
+use App\Models\Container;
 use App\Models\Host;
+use App\Models\HostMetricSnapshot;
 use App\Models\Project;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -153,6 +155,135 @@ class HostControllerTest extends TestCase
                     ->where('canDelete', true)
                     ->where('canManageTokens', true)
             );
+    }
+
+    public function test_show_returns_telemetry_with_current_metrics_and_containers(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+
+        HostMetricSnapshot::factory()->create([
+            'host_id' => $host->id,
+            'cpu_percent' => 12.5,
+            'memory_used_mb' => 1024,
+            'memory_total_mb' => 4096,
+            'recorded_at' => now()->subMinute(),
+        ]);
+        HostMetricSnapshot::factory()->create([
+            'host_id' => $host->id,
+            'cpu_percent' => 33.3,
+            'memory_used_mb' => 2048,
+            'memory_total_mb' => 4096,
+            'recorded_at' => now(),
+        ]);
+        Container::factory()->create([
+            'host_id' => $host->id,
+            'name' => 'web',
+            'image' => 'ghcr.io/acme/web',
+            'state' => 'running',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('monitoring.hosts.show', $host))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Monitoring/Hosts/Show')
+                    // `current` is the latest snapshot. Whole-number
+                    // floats are JSON-encoded as ints, so 50.0 → 50.
+                    ->where('telemetry.current.cpu_percent', 33.3)
+                    ->where('telemetry.current.memory_percent', 50)
+                    // Series oldest→newest.
+                    ->has('telemetry.series', 2)
+                    ->where('telemetry.series.0.cpu_percent', 12.5)
+                    ->where('telemetry.series.1.cpu_percent', 33.3)
+                    // Containers ordered by name, projected fields present.
+                    ->has('telemetry.containers', 1)
+                    ->where('telemetry.containers.0.name', 'web')
+                    ->where('telemetry.containers.0.state', 'running')
+            );
+    }
+
+    public function test_show_returns_a_null_current_telemetry_when_the_host_never_reported(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+
+        $this->actingAs($user)
+            ->get(route('monitoring.hosts.show', $host))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Monitoring/Hosts/Show')
+                    ->where('telemetry.current', null)
+                    ->where('telemetry.series', [])
+                    ->where('telemetry.containers', [])
+            );
+    }
+
+    public function test_show_returns_empty_containers_when_telemetry_exists_without_any(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+        HostMetricSnapshot::factory()->create([
+            'host_id' => $host->id,
+            'recorded_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('monitoring.hosts.show', $host))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->where('telemetry.containers', [])
+                    ->has('telemetry.current')
+            );
+    }
+
+    public function test_index_exposes_cpu_and_memory_percent_from_the_latest_snapshot(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $reportingHost = Host::factory()->create([
+            'project_id' => $project->id,
+            'name' => 'host-with-data',
+        ]);
+        $silentHost = Host::factory()->create([
+            'project_id' => $project->id,
+            'name' => 'host-no-data',
+        ]);
+        // Older snapshot — index should ignore it in favour of the latest.
+        HostMetricSnapshot::factory()->create([
+            'host_id' => $reportingHost->id,
+            'cpu_percent' => 1.1,
+            'memory_used_mb' => 100,
+            'memory_total_mb' => 1000,
+            'recorded_at' => now()->subMinute(),
+        ]);
+        HostMetricSnapshot::factory()->create([
+            'host_id' => $reportingHost->id,
+            'cpu_percent' => 44.4,
+            'memory_used_mb' => 600,
+            'memory_total_mb' => 1000,
+            'recorded_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('monitoring.hosts.index'))
+            ->assertSuccessful()
+            ->assertInertia(function (AssertableInertia $page) {
+                $page->component('Monitoring/Hosts/Index')->has('hosts', 2);
+                // Index is ordered by host name, so host-no-data is first.
+                $page->where('hosts.0.name', 'host-no-data')
+                    ->where('hosts.0.cpu_percent', null)
+                    ->where('hosts.0.memory_percent', null)
+                    ->where('hosts.1.name', 'host-with-data')
+                    ->where('hosts.1.cpu_percent', 44.4)
+                    ->where('hosts.1.memory_percent', 60);
+            });
     }
 
     public function test_update_changes_the_host_for_owner(): void

--- a/tests/Feature/Monitoring/HostTelemetryBroadcastTest.php
+++ b/tests/Feature/Monitoring/HostTelemetryBroadcastTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature\Monitoring;
+
+use App\Domain\Docker\Actions\IssueAgentTokenAction;
+use App\Events\HostTelemetryRecorded;
+use App\Models\Host;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+/**
+ * Spec 028 — every successful agent telemetry post should fire
+ * `HostTelemetryRecorded` on the host owner's `users.{id}.hosts`
+ * private channel. The Host Show page listens for this pulse and
+ * partial-reloads the host + telemetry props.
+ */
+class HostTelemetryBroadcastTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_telemetry_post_dispatches_host_telemetry_recorded_with_resolved_owner(): void
+    {
+        Event::fake([HostTelemetryRecorded::class]);
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+        $plaintext = app(IssueAgentTokenAction::class)->execute($host)->plaintext;
+
+        $this->postJson(
+            route('agent.telemetry'),
+            $this->payload(),
+            ['Authorization' => 'Bearer '.$plaintext],
+        )->assertNoContent();
+
+        Event::assertDispatched(
+            HostTelemetryRecorded::class,
+            fn (HostTelemetryRecorded $event): bool => $event->hostId === $host->id
+                && $event->ownerUserId === $user->id,
+        );
+        Event::assertDispatchedTimes(HostTelemetryRecorded::class, 1);
+    }
+
+    public function test_a_rejected_telemetry_post_does_not_dispatch_the_event(): void
+    {
+        Event::fake([HostTelemetryRecorded::class]);
+
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+        $plaintext = app(IssueAgentTokenAction::class)->execute($host)->plaintext;
+
+        $payload = $this->payload();
+        $payload['host']['metrics']['cpu_percent'] = 250; // out of [0,100]
+
+        $this->postJson(
+            route('agent.telemetry'),
+            $payload,
+            ['Authorization' => 'Bearer '.$plaintext],
+        )->assertStatus(422);
+
+        Event::assertNotDispatched(HostTelemetryRecorded::class);
+    }
+
+    private function payload(): array
+    {
+        return [
+            'recorded_at' => now()->toIso8601String(),
+            'host' => [
+                'metrics' => [
+                    'cpu_percent' => 17.5,
+                    'memory_used_mb' => 2048,
+                    'memory_total_mb' => 8192,
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Domain/Docker/GetHostTelemetryQueryTest.php
+++ b/tests/Unit/Domain/Docker/GetHostTelemetryQueryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Unit\Domain\Docker;
+
+use App\Domain\Docker\Queries\GetHostTelemetryQuery;
+use App\Models\Container;
+use App\Models\Host;
+use App\Models\HostMetricSnapshot;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GetHostTelemetryQueryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_returns_null_current_and_empty_arrays_for_a_host_without_snapshots(): void
+    {
+        $host = Host::factory()->create();
+
+        $result = app(GetHostTelemetryQuery::class)->execute($host);
+
+        $this->assertNull($result['current']);
+        $this->assertSame([], $result['series']);
+        $this->assertSame([], $result['containers']);
+    }
+
+    public function test_series_orders_oldest_to_newest_and_caps_at_50(): void
+    {
+        $host = Host::factory()->create();
+
+        // 60 snapshots, recorded_at strictly increasing. The query
+        // keeps the 50 newest and emits them oldest→newest.
+        for ($i = 1; $i <= 60; $i++) {
+            HostMetricSnapshot::factory()->create([
+                'host_id' => $host->id,
+                'cpu_percent' => (float) $i,
+                'memory_used_mb' => null,
+                'memory_total_mb' => null,
+                'recorded_at' => now()->subMinutes(60 - $i),
+            ]);
+        }
+
+        $result = app(GetHostTelemetryQuery::class)->execute($host);
+
+        $this->assertCount(50, $result['series']);
+        // Oldest of the 50 newest is i = 11; newest is i = 60.
+        $this->assertSame(11.0, $result['series'][0]['cpu_percent']);
+        $this->assertSame(60.0, $result['series'][49]['cpu_percent']);
+        // `current` is the latest of all.
+        $this->assertSame(60.0, $result['current']['cpu_percent']);
+    }
+
+    public function test_memory_percent_is_derived_when_both_sides_present_else_null(): void
+    {
+        $host = Host::factory()->create();
+        HostMetricSnapshot::factory()->create([
+            'host_id' => $host->id,
+            'memory_used_mb' => 250,
+            'memory_total_mb' => 1000,
+            'recorded_at' => now()->subMinute(),
+        ]);
+        HostMetricSnapshot::factory()->create([
+            'host_id' => $host->id,
+            'memory_used_mb' => null,
+            'memory_total_mb' => 1000,
+            'recorded_at' => now(),
+        ]);
+
+        $result = app(GetHostTelemetryQuery::class)->execute($host);
+
+        // Series ordered oldest→newest.
+        $this->assertSame(25.0, $result['series'][0]['memory_percent']);
+        $this->assertNull($result['series'][1]['memory_percent']);
+        // `current` is the latest row, whose memory_used_mb is null.
+        $this->assertNull($result['current']['memory_percent']);
+    }
+
+    public function test_containers_are_ordered_by_name(): void
+    {
+        $host = Host::factory()->create();
+        Container::factory()->create(['host_id' => $host->id, 'name' => 'web']);
+        Container::factory()->create(['host_id' => $host->id, 'name' => 'api']);
+        Container::factory()->create(['host_id' => $host->id, 'name' => 'db']);
+
+        $result = app(GetHostTelemetryQuery::class)->execute($host);
+
+        $this->assertSame(
+            ['api', 'db', 'web'],
+            array_column($result['containers'], 'name'),
+        );
+    }
+
+    public function test_containers_from_another_host_do_not_leak(): void
+    {
+        $host = Host::factory()->create();
+        $otherHost = Host::factory()->create();
+        Container::factory()->create(['host_id' => $host->id, 'name' => 'mine']);
+        Container::factory()->create(['host_id' => $otherHost->id, 'name' => 'theirs']);
+
+        $result = app(GetHostTelemetryQuery::class)->execute($host);
+
+        $this->assertCount(1, $result['containers']);
+        $this->assertSame('mine', $result['containers'][0]['name']);
+    }
+}


### PR DESCRIPTION
Closes #85

Spec: `specs/phase-6-docker-hosts/028-hosts-ui.md`

## Summary
- Replaces the "Coming in spec 027 / 028" placeholder on the host detail page with a real CPU / memory / disk metrics panel, CPU & memory history sparklines, and a container table (state / health / CPU / memory).
- Adds `HostTelemetryRecorded` (`ShouldBroadcastNow` + `ShouldDispatchAfterCommit`) — dispatched from `IngestHostTelemetryAction` after the telemetry transaction commits, broadcasting on `users.{id}.hosts`. The Show page subscribes via Echo, filters by `host_id`, and partial-reloads `host` + `telemetry` props on each pulse; a "Live offline" pill appears when the socket is down.
- Hosts index gains a per-row CPU / MEM column from each host's latest snapshot (eager-loaded via `Host::latestMetricSnapshot` → `latestOfMany`, no N+1).
- `GetHostTelemetryQuery` returns `{current, series, containers}` so `HostController@show` stays thin; `HostMetricSnapshot::memoryPercent()` derives the bar value at read time.
- New empty states: "Waiting for first telemetry" when the host has no snapshots yet, "No containers reported" when telemetry exists but no containers.

## Test plan
- [x] Host Show renders current CPU / memory / disk / load / network, a CPU+memory history sparkline, and a container table — no placeholder card remains
- [x] Host with no telemetry shows a "Waiting for first telemetry" state
- [x] Host with telemetry but no containers shows a "No containers reported" state
- [x] Host Index shows a CPU / memory glance per row; no-telemetry hosts render a dash
- [x] No N+1 on the index (latest snapshot eager-loaded via `latestOfMany`)
- [x] Telemetry ingest broadcasts `HostTelemetryRecorded` on the host owner's `users.{id}.hosts` channel
- [x] "Live updates offline" pill when the socket is down
- [x] Sidebar `Hosts` + project `Hosts` tab regression check
- [x] Pint clean, `php artisan test` green (12 new tests), `npm run build` clean

## Self-review notes
Reviewed via `superpowers:code-reviewer` — assessed ready to PR, no critical/blocking issues. Addressed in the close-out commit:
- `HostTelemetryRecorded` now also implements `ShouldDispatchAfterCommit` (defense against any future caller wrapping the ingest action in an outer transaction).
- Added `tests/Feature/Events/HostTelemetryRecordedTest.php` mirroring `WebsiteCheckRecordedTest` (channel routing, `broadcastAs`, `broadcastWith`, null-owner short-circuit).
- Inline comment in `Show.vue` documenting the phase-1 viewer-==-owner realtime ACL assumption.

Deferred / conscious choices (non-blocking, captured in the spec's Open Questions):
- Index stays as a table (consistent with `Monitoring/Websites/Index`) rather than the roadmap's "host cards" — visual-reference call.
- Per-container metric history charts and a host event log are out of scope; the container table shows current stats only. Both have data already persisted by spec 027.