### PR TITLE
Spec 029 — Host offline detection + activity events + Overview KPI wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,3 +117,8 @@ VITE_DEV_SERVER_PORT=
 # VITE_REVERB_HOST=URL_C.trycloudflare.com
 # VITE_REVERB_PORT=443
 # VITE_REVERB_SCHEME=https
+
+# Heartbeat timeout for host offline detection (spec 029). A host whose
+# last_seen_at is older than this is flipped from `online` to `offline` by
+# `DetectOfflineHostsJob`. Default 120s = 4× the reference agent’s 30s tick.
+# HOSTS_HEARTBEAT_TIMEOUT_SECONDS=120

--- a/app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php
+++ b/app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php
@@ -3,7 +3,10 @@
 namespace App\Domain\Dashboard\Queries;
 
 use App\Domain\Monitoring\Queries\GetMonitoringUptimeKpiQuery;
+use App\Enums\HostStatus;
 use App\Models\ActivityEvent;
+use App\Models\Host;
+use App\Models\HostMetricSnapshot;
 use App\Models\Project;
 use App\Models\Repository;
 use App\Models\WorkflowRun;
@@ -20,10 +23,11 @@ use Illuminate\Support\Collection;
  *
  * Real today (database-backed):
  *   - dashboard.projects.{active,new_this_week,sparkline,status}
- *   - dashboard.hosts.{online,new,sparkline,status}
- *     (Repository::count() acts as a proxy until phase 6 ships actual
- *      hosts; the card label keeps "Hosts" so the visual doesn't shift,
- *      but the value reflects what we have data for.)
+ *   - dashboard.hosts.{online,offline,new,sparkline,status,cards}
+ *     (Spec 029 — real Host counts; `cards` carries up to 6 hosts for
+ *      the Overview "Container Hosts" detail card, ordered so problem
+ *      hosts surface first. Sparkline shows daily `host_metric_snapshots`
+ *      volume parallel to the deployments KPI.)
  *   - dashboard.deployments.{successful_24h,success_rate_24h,change_percent,sparkline,status}
  *     (Spec 022 — aggregates `workflow_runs` over 24h and prior-24h
  *      windows; sparkline counts daily completed runs across the last
@@ -281,21 +285,100 @@ class GetOverviewDashboardQuery
         return 'danger';
     }
 
-    /** Hosts proxy (Repository count) until phase 6 ships real hosts. */
+    /**
+     * Real Hosts KPI slice (spec 029 — replaces the Phase-6 Repository
+     * proxy). Counts come from the `hosts` table directly, the
+     * sparkline shows daily telemetry volume from
+     * `host_metric_snapshots` (parallels the deployments KPI's
+     * daily-run count), and `cards` carries up to 6 hosts for the
+     * Overview "Container Hosts" detail card. Archived hosts are
+     * excluded from every count.
+     *
+     * @return array{
+     *     online: int,
+     *     offline: int,
+     *     new: int,
+     *     sparkline: array<int, int>,
+     *     status: 'success'|'warning'|'danger'|'muted',
+     *     cards: list<array{
+     *         id: int,
+     *         name: string,
+     *         status: string|null,
+     *         cpu_percent: float|null,
+     *         memory_percent: float|null,
+     *         last_seen_at: string|null,
+     *     }>,
+     * }
+     */
     private function hosts(): array
     {
-        $online = Repository::query()->count();
-        $new = Repository::query()
+        $online = Host::query()->where('status', HostStatus::Online->value)->count();
+        $offline = Host::query()->where('status', HostStatus::Offline->value)->count();
+        $new = Host::query()
+            ->where('status', '!=', HostStatus::Archived->value)
             ->where('created_at', '>=', now()->subWeek())
             ->count();
-        $sparkline = $this->dailyCounts(Repository::class, self::SPARKLINE_DAYS);
+        $sparkline = $this->dailyCounts(HostMetricSnapshot::class, self::SPARKLINE_DAYS);
+
+        // Up to 6 hosts for the Overview detail card, sorted so problem
+        // hosts surface first (offline → degraded → online → pending).
+        // Archived hosts excluded. Sort happens in PHP so the
+        // status-priority ordering stays cross-DB; phase-1's host count
+        // is well below any size where SQL-side sort would matter.
+        $statusPriority = [
+            HostStatus::Offline->value => 0,
+            HostStatus::Degraded->value => 1,
+            HostStatus::Online->value => 2,
+            HostStatus::Pending->value => 3,
+        ];
+
+        $cards = Host::query()
+            ->with('latestMetricSnapshot')
+            ->where('status', '!=', HostStatus::Archived->value)
+            ->get()
+            ->sortBy(fn (Host $host): array => [
+                $statusPriority[$host->status?->value] ?? 4,
+                $host->name,
+            ])
+            ->take(6)
+            ->values()
+            ->map(fn (Host $host): array => [
+                'id' => $host->id,
+                'name' => $host->name,
+                'status' => $host->status?->value,
+                'cpu_percent' => $host->latestMetricSnapshot?->cpu_percent,
+                'memory_percent' => $host->latestMetricSnapshot?->memoryPercent(),
+                'last_seen_at' => $host->last_seen_at?->diffForHumans(),
+            ])
+            ->all();
 
         return [
             'online' => $online,
+            'offline' => $offline,
             'new' => $new,
             'sparkline' => $sparkline,
-            'status' => $online >= 1 ? 'info' : 'muted',
+            'status' => $this->hostsStatus($online, $offline),
+            'cards' => $cards,
         ];
+    }
+
+    /**
+     * Hosts KPI status tone. Empty fleet → muted (no signal); all
+     * offline → danger; mixed → warning; healthy → success.
+     */
+    private function hostsStatus(int $online, int $offline): string
+    {
+        if ($online === 0 && $offline === 0) {
+            return 'muted';
+        }
+        if ($offline === 0) {
+            return 'success';
+        }
+        if ($online === 0) {
+            return 'danger';
+        }
+
+        return 'warning';
     }
 
     /**

--- a/app/Domain/Docker/Actions/DetectOfflineHostsAction.php
+++ b/app/Domain/Docker/Actions/DetectOfflineHostsAction.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Domain\Docker\Actions;
+
+use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Enums\ActivitySeverity;
+use App\Enums\HostStatus;
+use App\Models\Host;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Spec 029 — scheduled offline detector. Every minute the job that
+ * wraps this finds hosts in `status: online` whose `last_seen_at` is
+ * older than `config('hosts.heartbeat_timeout_seconds')`, flips each
+ * to `offline`, and emits one `host.offline` activity event.
+ *
+ * Pending and archived hosts are skipped — they were never online so
+ * there is no transition to record. A late-arriving telemetry tick
+ * after this flip flows back through `IngestHostTelemetryAction`,
+ * which flips the row to `online` and emits `host.recovered`.
+ *
+ * Each row's status flip + activity event share a transaction so a
+ * partial failure can't leave a host marked offline without the
+ * corresponding rail entry (or vice versa).
+ */
+class DetectOfflineHostsAction
+{
+    public function __construct(
+        private readonly CreateActivityEventAction $createActivity,
+    ) {}
+
+    /**
+     * @return int Number of hosts flipped on this run (useful for the
+     *             wrapping job's log line + the action's tests).
+     */
+    public function execute(): int
+    {
+        $threshold = (int) config('hosts.heartbeat_timeout_seconds', 120);
+        $cutoff = Carbon::now()->subSeconds($threshold);
+
+        $stale = Host::query()
+            ->where('status', HostStatus::Online->value)
+            ->where('last_seen_at', '<', $cutoff)
+            ->get();
+
+        $flipped = 0;
+
+        foreach ($stale as $host) {
+            DB::transaction(function () use ($host, $threshold): void {
+                $lastSeenAt = $host->last_seen_at;
+
+                $host->forceFill(['status' => HostStatus::Offline->value])->save();
+
+                $this->createActivity->execute([
+                    'event_type' => 'host.offline',
+                    'severity' => ActivitySeverity::Danger,
+                    'title' => "{$host->name} went offline",
+                    'description' => "No telemetry in {$threshold}s",
+                    'occurred_at' => Carbon::now(),
+                    'source' => 'hosts',
+                    'metadata' => [
+                        'host_id' => $host->id,
+                        'last_seen_at' => $lastSeenAt?->toIso8601String(),
+                        'threshold_seconds' => $threshold,
+                    ],
+                ]);
+            });
+
+            $flipped++;
+        }
+
+        return $flipped;
+    }
+}

--- a/app/Domain/Docker/Actions/IngestHostTelemetryAction.php
+++ b/app/Domain/Docker/Actions/IngestHostTelemetryAction.php
@@ -2,11 +2,14 @@
 
 namespace App\Domain\Docker\Actions;
 
+use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Enums\ActivitySeverity;
 use App\Enums\HostStatus;
 use App\Events\HostTelemetryRecorded;
 use App\Models\Host;
 use App\Models\HostMetricSnapshot;
 use Carbon\CarbonImmutable;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -31,6 +34,7 @@ class IngestHostTelemetryAction
 {
     public function __construct(
         private readonly SyncContainerSnapshotsAction $syncContainers,
+        private readonly CreateActivityEventAction $createActivity,
     ) {}
 
     /**
@@ -45,6 +49,12 @@ class IngestHostTelemetryAction
         $metrics = $hostPayload['metrics'] ?? [];
         $containers = $payload['containers'] ?? [];
 
+        // Capture pre-transaction status — `updateHost` will flip the
+        // row to `online` in the transaction below, so anything we need
+        // about the prior state has to be read now. Spec 029 uses this
+        // to detect the specific `offline → online` recovery transition.
+        $wasOffline = $host->status === HostStatus::Offline;
+
         DB::transaction(function () use ($host, $recordedAt, $facts, $metrics, $containers): void {
             $this->updateHost($host, $recordedAt, $facts);
             $this->insertHostSnapshot($host, $recordedAt, $metrics);
@@ -56,6 +66,25 @@ class IngestHostTelemetryAction
         // page never partial-reloads ahead of the write. `ShouldBroadcastNow`
         // means the publish hits Reverb synchronously here. Spec 028.
         HostTelemetryRecorded::dispatch($host->id, $host->project?->owner_user_id);
+
+        // Recovery (spec 029): only the explicit `offline → online`
+        // transition emits `host.recovered`. Pending → online is silent
+        // (first activation, mirrors spec 024's first-probe rule); online
+        // → online is silent (steady state, no transition).
+        if ($wasOffline) {
+            $this->createActivity->execute([
+                'event_type' => 'host.recovered',
+                'severity' => ActivitySeverity::Success,
+                'title' => "{$host->name} recovered",
+                'description' => 'Telemetry resumed at '.$recordedAt->toIso8601String(),
+                'occurred_at' => Carbon::now(),
+                'source' => 'hosts',
+                'metadata' => [
+                    'host_id' => $host->id,
+                    'recorded_at' => $recordedAt->toIso8601String(),
+                ],
+            ]);
+        }
     }
 
     /**

--- a/app/Domain/Docker/Jobs/DetectOfflineHostsJob.php
+++ b/app/Domain/Docker/Jobs/DetectOfflineHostsJob.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Domain\Docker\Jobs;
+
+use App\Domain\Docker\Actions\DetectOfflineHostsAction;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Scheduler-bound offline detector (spec 029). Bound in
+ * `routes/console.php` via
+ * `Schedule::job(...)->everyMinute()->withoutOverlapping()` next to
+ * the website-check dispatcher. Delegates the actual work to
+ * `DetectOfflineHostsAction` — the job stays thin so the action is
+ * easily unit-testable without spinning up the queue.
+ */
+class DetectOfflineHostsJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /** Single attempt; the next every-minute tick is the retry path. */
+    public int $tries = 1;
+
+    public function handle(DetectOfflineHostsAction $detect): void
+    {
+        $detect->execute();
+    }
+}

--- a/app/Domain/Docker/Jobs/DetectOfflineHostsJob.php
+++ b/app/Domain/Docker/Jobs/DetectOfflineHostsJob.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Scheduler-bound offline detector (spec 029). Bound in
@@ -29,6 +30,10 @@ class DetectOfflineHostsJob implements ShouldQueue
 
     public function handle(DetectOfflineHostsAction $detect): void
     {
-        $detect->execute();
+        $flipped = $detect->execute();
+
+        if ($flipped > 0) {
+            Log::info('hosts:detect-offline flipped hosts', ['count' => $flipped]);
+        }
     }
 }

--- a/app/Events/ActivityEventCreated.php
+++ b/app/Events/ActivityEventCreated.php
@@ -4,6 +4,7 @@ namespace App\Events;
 
 use App\Domain\Activity\ActivityEventPresenter;
 use App\Models\ActivityEvent;
+use App\Models\Host;
 use App\Models\Website;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
@@ -35,13 +36,16 @@ class ActivityEventCreated implements ShouldBroadcastNow
      * Broadcast on the project owner's private activity channel.
      * `users.{userId}.activity` is authorized in `routes/channels.php`.
      *
-     * Two scoping paths:
+     * Three scoping paths:
      *   1. **Repo-scoped events** (spec 017's webhook handlers,
      *      spec 020's deployments) — channel resolves through
      *      `repository → project → owner_user_id`.
      *   2. **Monitoring-scoped events** (spec 024 — `source: monitoring`,
      *      `repository_id` is null) — channel resolves through
      *      `metadata.website_id → website → project → owner_user_id`.
+     *   3. **Hosts-scoped events** (spec 029 — `source: hosts`,
+     *      `repository_id` is null) — channel resolves through
+     *      `metadata.host_id → host → project → owner_user_id`.
      *
      * If neither path resolves to an owner the broadcast no-ops; the
      * row still exists in the DB, and `RecentActivityForUserQuery`
@@ -89,6 +93,20 @@ class ActivityEventCreated implements ShouldBroadcastNow
             $website = Website::query()->find($websiteId);
 
             return $website?->project?->owner_user_id;
+        }
+
+        // Hosts-scoped path (spec 029).
+        if ($this->activityEvent->source === 'hosts') {
+            $metadata = $this->activityEvent->metadata ?? [];
+            $hostId = $metadata['host_id'] ?? null;
+
+            if ($hostId === null) {
+                return null;
+            }
+
+            $host = Host::query()->find($hostId);
+
+            return $host?->project?->owner_user_id;
         }
 
         return null;

--- a/app/Events/ActivityEventCreated.php
+++ b/app/Events/ActivityEventCreated.php
@@ -9,6 +9,7 @@ use App\Models\Website;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
@@ -24,7 +25,7 @@ use Illuminate\Queue\SerializesModels;
  * has no owning project (system-emitted events, future), we no-op
  * `broadcastOn()` and Laravel skips the publish.
  */
-class ActivityEventCreated implements ShouldBroadcastNow
+class ActivityEventCreated implements ShouldBroadcastNow, ShouldDispatchAfterCommit
 {
     use Dispatchable;
     use InteractsWithSockets;

--- a/config/hosts.php
+++ b/config/hosts.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Heartbeat timeout (seconds)
+    |--------------------------------------------------------------------------
+    |
+    | A host whose `last_seen_at` is older than this is flipped from
+    | `online` to `offline` by `DetectOfflineHostsJob` (spec 029). Default
+    | is 120 seconds — 4× the reference agent's default 30 s tick — tight
+    | enough to catch silent failures within ~2 minutes, loose enough to
+    | ride out a single missed tick + network blip.
+    |
+    */
+
+    'heartbeat_timeout_seconds' => (int) env('HOSTS_HEARTBEAT_TIMEOUT_SECONDS', 120),
+
+];

--- a/database/factories/HostFactory.php
+++ b/database/factories/HostFactory.php
@@ -57,4 +57,18 @@ class HostFactory extends Factory
             'archived_at' => now(),
         ]);
     }
+
+    public function offline(): static
+    {
+        return $this->state(fn () => [
+            'status' => HostStatus::Offline->value,
+            // Last reported just past the default 120s heartbeat
+            // window so spec-029 tests can assert the recovery
+            // transition out of the gate.
+            'last_seen_at' => now()->subMinutes(5),
+            'cpu_count' => 4,
+            'memory_total_mb' => 8192,
+            'disk_total_gb' => 100,
+        ]);
+    }
 }

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -4,6 +4,7 @@ import KpiCard from '@/Components/Dashboard/KpiCard.vue';
 import Sparkline from '@/Components/Dashboard/Sparkline.vue';
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
+import { hostStatusTone } from '@/lib/hostStyles';
 import type { ActivityHeatmapPayload, DashboardPayload } from '@/types';
 import { Head, Link } from '@inertiajs/vue3';
 import {
@@ -46,22 +47,9 @@ defineProps<{
 // each stub footer points at the phase that will replace it.
 
 // Container Hosts pulls live from `dashboard.hosts.cards` (spec 029);
-// `stubHosts` was retired when the phase-6 backend landed.
-
-// Map the four phase-6 statuses onto the Dashboard `StatusBadge` tones —
-// keeps Overview consistent with the website / host pages without
-// importing `hostStyles.ts` (Overview doesn't need the full enum value
-// type — just the tone).
-const hostCardTone = (status: string | null): 'success' | 'warning' | 'danger' | 'muted' =>
-    (
-        ({
-            online: 'success',
-            offline: 'danger',
-            degraded: 'warning',
-            pending: 'muted',
-            archived: 'muted',
-        }) as const
-    )[status ?? ''] ?? 'muted';
+// `stubHosts` was retired when the phase-6 backend landed. Tone for
+// the card status dot comes from the shared `hostStatusTone` helper
+// so Overview / Hosts Index / Hosts Show never drift.
 
 const stubServices = [
     {
@@ -417,7 +405,7 @@ const visualizationStubs = [
                                 class="grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-md px-1 py-1 transition hover:bg-background-panel-hover/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
                             >
                                 <StatusBadge
-                                    :tone="hostCardTone(host.status)"
+                                    :tone="hostStatusTone(host.status)"
                                     dot-only
                                 />
                                 <div class="min-w-0">

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -5,7 +5,7 @@ import Sparkline from '@/Components/Dashboard/Sparkline.vue';
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import type { ActivityHeatmapPayload, DashboardPayload } from '@/types';
-import { Head } from '@inertiajs/vue3';
+import { Head, Link } from '@inertiajs/vue3';
 import {
     Activity,
     BarChart3,
@@ -45,12 +45,23 @@ defineProps<{
 // mock data here exists only so the page looks intentional, not skeletal —
 // each stub footer points at the phase that will replace it.
 
-const stubHosts = [
-    { name: 'prod-web-01', region: 'us-east', cpu: 0.42, mem: 0.61, status: 'success' as const },
-    { name: 'prod-api-02', region: 'us-east', cpu: 0.78, mem: 0.83, status: 'warning' as const },
-    { name: 'edge-eu-01', region: 'eu-west', cpu: 0.31, mem: 0.48, status: 'success' as const },
-    { name: 'edge-ap-01', region: 'ap-south', cpu: 0.55, mem: 0.69, status: 'success' as const },
-];
+// Container Hosts pulls live from `dashboard.hosts.cards` (spec 029);
+// `stubHosts` was retired when the phase-6 backend landed.
+
+// Map the four phase-6 statuses onto the Dashboard `StatusBadge` tones —
+// keeps Overview consistent with the website / host pages without
+// importing `hostStyles.ts` (Overview doesn't need the full enum value
+// type — just the tone).
+const hostCardTone = (status: string | null): 'success' | 'warning' | 'danger' | 'muted' =>
+    (
+        ({
+            online: 'success',
+            offline: 'danger',
+            degraded: 'warning',
+            pending: 'muted',
+            archived: 'muted',
+        }) as const
+    )[status ?? ''] ?? 'muted';
 
 const stubServices = [
     {
@@ -166,7 +177,11 @@ const visualizationStubs = [
                     :value="String(dashboard.hosts.online)"
                     secondary="Online"
                     :status="dashboard.hosts.status"
-                    status-label="Steady"
+                    :status-label="
+                        dashboard.hosts.offline > 0
+                            ? `${dashboard.hosts.offline} offline`
+                            : 'Steady'
+                    "
                     :trend="{
                         direction: dashboard.hosts.new > 0 ? 'up' : 'flat',
                         value: `+${dashboard.hosts.new} new`,
@@ -364,65 +379,104 @@ const visualizationStubs = [
                                 Container Hosts
                             </h2>
                         </div>
-                        <span class="hidden font-mono text-[11px] text-text-muted sm:inline">
-                            {{ stubHosts.length }} hosts · mock
+                        <span
+                            v-if="dashboard.hosts.cards.length > 0"
+                            class="hidden font-mono text-[11px] text-text-muted sm:inline"
+                        >
+                            {{ dashboard.hosts.online }} online ·
+                            {{ dashboard.hosts.offline }} offline
                         </span>
                     </header>
-                    <ul class="flex flex-col gap-3">
-                        <li
-                            v-for="host in stubHosts"
-                            :key="host.name"
-                            class="grid grid-cols-[auto_1fr_auto] items-center gap-3"
+
+                    <div
+                        v-if="dashboard.hosts.cards.length === 0"
+                        class="flex flex-col items-center gap-2 px-6 py-8 text-center text-xs text-text-muted"
+                    >
+                        <Server
+                            class="h-5 w-5 text-text-muted"
+                            aria-hidden="true"
+                        />
+                        <p class="text-text-secondary">
+                            No hosts yet
+                        </p>
+                        <Link
+                            :href="route('monitoring.hosts.create')"
+                            class="text-accent-cyan transition hover:text-accent-cyan/80"
                         >
-                            <StatusBadge :tone="host.status" dot-only />
-                            <div class="min-w-0">
-                                <p
-                                    class="truncate font-mono text-xs text-text-primary"
-                                >
-                                    {{ host.name }}
-                                </p>
-                                <p
-                                    class="truncate text-[11px] text-text-muted"
-                                >
-                                    {{ host.region }}
-                                </p>
-                            </div>
-                            <div class="flex flex-col gap-1 text-[10px]">
-                                <div
-                                    class="flex items-center gap-2 font-mono text-text-muted"
-                                >
-                                    <span class="w-6 shrink-0">CPU</span>
-                                    <span
-                                        class="relative h-1.5 w-20 overflow-hidden rounded-full bg-background-panel-hover"
+                            Connect your first host →
+                        </Link>
+                    </div>
+
+                    <ul v-else class="flex flex-col gap-3">
+                        <li
+                            v-for="host in dashboard.hosts.cards"
+                            :key="host.id"
+                        >
+                            <Link
+                                :href="route('monitoring.hosts.show', host.id)"
+                                class="grid grid-cols-[auto_1fr_auto] items-center gap-3 rounded-md px-1 py-1 transition hover:bg-background-panel-hover/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                            >
+                                <StatusBadge
+                                    :tone="hostCardTone(host.status)"
+                                    dot-only
+                                />
+                                <div class="min-w-0">
+                                    <p
+                                        class="truncate font-mono text-xs text-text-primary"
                                     >
-                                        <span
-                                            class="block h-full rounded-full bg-accent-cyan"
-                                            :style="{
-                                                width: `${Math.round(host.cpu * 100)}%`,
-                                            }"
-                                        />
-                                    </span>
-                                </div>
-                                <div
-                                    class="flex items-center gap-2 font-mono text-text-muted"
-                                >
-                                    <span class="w-6 shrink-0">MEM</span>
-                                    <span
-                                        class="relative h-1.5 w-20 overflow-hidden rounded-full bg-background-panel-hover"
+                                        {{ host.name }}
+                                    </p>
+                                    <p
+                                        class="truncate text-[11px] text-text-muted"
                                     >
-                                        <span
-                                            class="block h-full rounded-full bg-accent-purple"
-                                            :style="{
-                                                width: `${Math.round(host.mem * 100)}%`,
-                                            }"
-                                        />
-                                    </span>
+                                        {{ host.last_seen_at ?? 'Awaiting telemetry' }}
+                                    </p>
                                 </div>
-                            </div>
+                                <div class="flex flex-col gap-1 text-[10px]">
+                                    <div
+                                        class="flex items-center gap-2 font-mono text-text-muted"
+                                    >
+                                        <span class="w-6 shrink-0">CPU</span>
+                                        <span
+                                            class="relative h-1.5 w-20 overflow-hidden rounded-full bg-background-panel-hover"
+                                        >
+                                            <span
+                                                class="block h-full rounded-full bg-accent-cyan"
+                                                :style="{
+                                                    width: `${Math.min(Math.max(host.cpu_percent ?? 0, 0), 100)}%`,
+                                                }"
+                                            />
+                                        </span>
+                                    </div>
+                                    <div
+                                        class="flex items-center gap-2 font-mono text-text-muted"
+                                    >
+                                        <span class="w-6 shrink-0">MEM</span>
+                                        <span
+                                            class="relative h-1.5 w-20 overflow-hidden rounded-full bg-background-panel-hover"
+                                        >
+                                            <span
+                                                class="block h-full rounded-full bg-accent-purple"
+                                                :style="{
+                                                    width: `${Math.min(Math.max(host.memory_percent ?? 0, 0), 100)}%`,
+                                                }"
+                                            />
+                                        </span>
+                                    </div>
+                                </div>
+                            </Link>
                         </li>
                     </ul>
-                    <footer class="text-[11px] text-text-muted">
-                        Full widget lands with phase 6 — Docker Host Agent.
+                    <footer
+                        v-if="dashboard.hosts.cards.length > 0"
+                        class="text-[11px] text-text-muted"
+                    >
+                        <Link
+                            :href="route('monitoring.hosts.index')"
+                            class="text-text-secondary transition hover:text-accent-cyan"
+                        >
+                            Browse all hosts →
+                        </Link>
                     </footer>
                 </section>
 

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -71,9 +71,18 @@ export interface DashboardPayload {
     };
     hosts: {
         online: number;
+        offline: number;
         new: number;
         sparkline: number[];
         status: DashboardStatus;
+        cards: Array<{
+            id: number;
+            name: string;
+            status: string | null;
+            cpu_percent: number | null;
+            memory_percent: number | null;
+            last_seen_at: string | null;
+        }>;
     };
     alerts: {
         active: number;

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Domain\Docker\Jobs\DetectOfflineHostsJob;
 use App\Domain\Monitoring\Jobs\DispatchDueWebsiteChecksJob;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
@@ -29,4 +30,14 @@ Schedule::command('inspire')->hourly();
 Schedule::job(new DispatchDueWebsiteChecksJob)
     ->everyMinute()
     ->name('monitoring:dispatch-due-website-checks')
+    ->withoutOverlapping();
+
+// Spec 029 — every-minute offline detector for Docker hosts. Flips
+// `online` hosts past `config('hosts.heartbeat_timeout_seconds')`
+// (default 120 s) to `offline` and emits `host.offline` activity events.
+// Late telemetry flows through `IngestHostTelemetryAction` and flips
+// the host back to online, emitting `host.recovered`.
+Schedule::job(new DetectOfflineHostsJob)
+    ->everyMinute()
+    ->name('hosts:detect-offline')
     ->withoutOverlapping();

--- a/specs/README.md
+++ b/specs/README.md
@@ -41,7 +41,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 3 | GitHub Webhooks & Activity Feed | 🟢 | 3/3 specs done (017–019). Phase complete. |
 | 4 | Deployments & CI/CD | 🟢 | 3/3 specs done (020–022). Phase complete. |
 | 5 | Website Monitoring | 🟢 | 3/3 specs done (023–025). Phase complete. |
-| 6 | Docker Host Agent MVP | 🟡 | 3/4 specs done (026–029). 026, 027, 028 shipped. |
+| 6 | Docker Host Agent MVP | 🟢 | 4/4 specs done (026–029). Phase complete. |
 | 7 | Alerts Engine | ⬜ | — |
 | 8 | Analytics & Health Scores | ⬜ | — |
 | 9 | Polish & Production Readiness | ⬜ | — |

--- a/specs/phase-6-docker-hosts/029-host-offline-detection.md
+++ b/specs/phase-6-docker-hosts/029-host-offline-detection.md
@@ -1,7 +1,7 @@
 ---
 spec: host-offline-detection
 phase: 6
-status: in-progress   # not-started | in-progress | blocked | done
+status: done   # not-started | in-progress | blocked | done
 owner: Yoany
 created: 2026-05-26
 updated: 2026-05-26
@@ -200,21 +200,21 @@ phase-level "Host offline emits `host.offline`, recovery emits
     spec-024 tests do the latter — mirror).
 
 ## Acceptance criteria
-- [ ] A host whose `last_seen_at` is older than the configured timeout flips
+- [x] A host whose `last_seen_at` is older than the configured timeout flips
       from `online` to `offline` within ≤ 60 s of the threshold and a
       `host.offline` activity event lands.
-- [ ] The first telemetry tick after an offline host posts flips it to
+- [x] The first telemetry tick after an offline host posts flips it to
       `online` and emits exactly one `host.recovered` activity event.
-- [ ] Pending → online and online → online ingest paths emit no
+- [x] Pending → online and online → online ingest paths emit no
       `host.recovered` (silent first activation / steady-state).
-- [ ] `host.offline` and `host.recovered` rows broadcast on the project
+- [x] `host.offline` and `host.recovered` rows broadcast on the project
       owner's `users.{id}.activity` channel; the right-rail picks them up.
-- [ ] Overview Hosts KPI displays real online + offline counts (no
+- [x] Overview Hosts KPI displays real online + offline counts (no
       `Repository::count` proxy, no mocks); sibling-user hosts don't leak.
-- [ ] Overview "Container Hosts" card renders real hosts from
+- [x] Overview "Container Hosts" card renders real hosts from
       `dashboard.hosts.cards` (no `stubHosts`, no "· mock" header); empty
       state CTA points at `monitoring.hosts.create`.
-- [ ] Pint clean, `php artisan test` green (new tests added), `npm run build`
+- [x] Pint clean, `php artisan test` green (new tests added), `npm run build`
       clean.
 
 ## Files touched
@@ -242,6 +242,10 @@ Fill in as work progresses.
 ### 2026-05-26
 - Spec drafted for review.
 - Issue [#87](https://github.com/Copxer/nexus/issues/87) opened, branch `spec/029-host-offline-detection` cut off `main`.
+- Backend: `config/hosts.php`, `DetectOfflineHostsAction` + `DetectOfflineHostsJob` scheduled every minute, `IngestHostTelemetryAction` recovery emission on offline→online, `ActivityEventCreated` source-hosts routing, `GetOverviewDashboardQuery::hosts()` rewrite + `cards`, `HostFactory::offline()`.
+- Frontend: `Overview.vue` drops `stubHosts`, iterates `dashboard.hosts.cards`, Hosts KPI surfaces `N offline`; `types/index.d.ts` `hosts` shape extended.
+- Tests: 27 new, full suite 480 → 507 green, Pint clean, build clean.
+- Self-review via `superpowers:code-reviewer`. Addressed: (1) `ActivityEventCreated` now also implements `ShouldDispatchAfterCommit` (parity with `HostTelemetryRecorded`, defends every `CreateActivityEventAction` caller against future outer-transaction wrapping); (2) Overview replaces local `hostCardTone` with the shared `hostStatusTone` import so the tone map stays single-source; (3) `DetectOfflineHostsJob` logs the flipped count; (4) moved `DetectOfflineHostsJobTest` from `tests/Feature/Monitoring/` to `tests/Feature/Docker/` to match the action's domain.
 
 ## Open questions / blockers
 - **Heartbeat timeout: global vs per-host.** 029 ships a global 120s default

--- a/specs/phase-6-docker-hosts/029-host-offline-detection.md
+++ b/specs/phase-6-docker-hosts/029-host-offline-detection.md
@@ -1,0 +1,265 @@
+---
+spec: host-offline-detection
+phase: 6
+status: in-progress   # not-started | in-progress | blocked | done
+owner: Yoany
+created: 2026-05-26
+updated: 2026-05-26
+---
+
+# 029 — Host offline detection + activity events + Overview KPI wiring
+
+## Goal
+Close out phase 6. A host that stops reporting telemetry past its heartbeat
+timeout flips to `offline` and emits a `host.offline` activity event; the
+first telemetry tick after that flips it back to `online` and emits
+`host.recovered`. The Overview Hosts KPI swaps its long-standing
+`Repository::count()` proxy for real host data, and the Overview "Container
+Hosts" detail card replaces its hard-coded `stubHosts` array with the user's
+actual hosts.
+
+Roadmap refs: §8.7 Docker Hosts ("Host event log", "Warning state"), §19
+Phase 6 acceptance criteria ("Host offline triggers alert after timeout";
+phase-level "Host offline emits `host.offline`, recovery emits
+`host.recovered`; Overview Hosts KPI reflects real online/offline counts").
+
+## Scope
+
+**In scope:**
+
+- **Offline detection (scheduled).**
+  - `app/Domain/Docker/Actions/DetectOfflineHostsAction.php` — finds hosts in
+    `status: online` whose `last_seen_at` is older than the configured
+    heartbeat timeout, transactionally flips each to `offline`, and emits one
+    `host.offline` activity event per host. Pending and archived hosts are
+    ignored (they can't go *offline* — they were never online).
+  - `app/Domain/Docker/Jobs/DetectOfflineHostsJob.php` — thin queueable that
+    calls the action. Mirrors spec 024's `DispatchDueWebsiteChecksJob`.
+  - `routes/console.php` — schedule `everyMinute()->withoutOverlapping()`
+    next to the existing website-check dispatcher.
+  - **Heartbeat timeout: 120 seconds, global default**, via
+    `config/hosts.php`'s `'heartbeat_timeout_seconds'` (default 120 = 4× the
+    agent's default 30s tick). Per-host configurability is an explicit
+    follow-up (see Open questions).
+- **Recovery transition.**
+  - `IngestHostTelemetryAction::updateHost` already flips any non-online,
+    non-archived status to `online`. Extend it to detect the **specific
+    offline → online transition** and emit a `host.recovered` activity
+    event. Pending → online is *not* a recovery (it's first activation —
+    silent, mirroring spec 024's pending → healthy rule).
+- **Activity event broadcasting.**
+  - `ActivityEventCreated::broadcastOn()` gains a third branch for
+    `source: hosts` rows: `metadata.host_id → host → project →
+    owner_user_id`, mirroring exactly the `source: monitoring` branch.
+- **Overview Hosts KPI (`GetOverviewDashboardQuery::hosts()`).**
+  - Drop the `Repository::query()->count()` proxy. Replace with:
+    - `online` — `Host::query()->where('status', 'online')` scoped to
+      `whereHas('project', owner_user_id = $user->id)`. Same scoping the
+      rest of the dashboard query already uses.
+    - `offline` (new) — same query with `status: offline`.
+    - `new` — `Host::where('created_at', '>=', now()->subWeek())` (user-scoped).
+    - `sparkline` — daily `host_metric_snapshots` count over 12 days
+      (telemetry volume, parallels the deployments KPI's daily completed-run
+      count).
+    - `status` — `success` when `offline === 0`, `warning` when `0 <
+      offline < online`, `danger` when `online === 0 && offline > 0`,
+      `muted` when there are no hosts at all.
+  - Add a `cards` array (up to 6 hosts ordered by status priority then name —
+    offline first so they're surfaced) with `{id, name, status, cpu_percent,
+    memory_percent, last_seen_at}` so the Overview "Container Hosts" card
+    can render real data instead of `stubHosts`.
+- **Overview frontend (`resources/js/Pages/Overview.vue`).**
+  - Delete `stubHosts` and the "4 hosts · mock" header.
+  - "Container Hosts" card iterates `dashboard.hosts.cards`. Empty state when
+    the user has no hosts: a CTA link to `/monitoring/hosts/create`.
+  - KPI card surfaces `online` / `offline` (the `online` line stays as the
+    headline; `offline > 0` adds a secondary "N offline" line in danger tone).
+- **Activity rail labelling.**
+  - `resources/js/types/index.d.ts` + the rail's icon/label maps gain
+    entries for `host.offline` (Server icon, danger tone) and
+    `host.recovered` (Server icon, success tone). Mirrors how spec 024 added
+    `website.down` / `website.up`.
+- **Tests:**
+  - `DetectOfflineHostsActionTest` (unit) — online host past timeout flips
+    + emits `host.offline`; within timeout unchanged; pending unchanged;
+    archived unchanged; one event per flipped host; tx integrity (host state
+    + event both write or neither).
+  - `IngestHostTelemetryActionTest` (extend) — offline → online emits
+    `host.recovered`; pending → online emits nothing; online → online emits
+    nothing.
+  - `ActivityEventCreatedTest` (extend or new) — `source: hosts` row with
+    `metadata.host_id` resolves to `users.{owner}.activity` channel; orphan
+    host short-circuits to no channels.
+  - `GetOverviewDashboardQueryTest` (extend) — `hosts.online/offline/new`
+    reflect real Host counts (not Repository); `hosts.cards` ordered by
+    status priority then name; sibling-user hosts don't leak.
+
+**Out of scope:**
+
+- Promoting `host.offline` to a row in the `alerts` table or to an
+  acknowledge/resolve workflow — Phase 7.
+- Per-host heartbeat-timeout configurability (a `heartbeat_timeout_seconds`
+  column on `hosts` + a form field on Edit). Open follow-up; phase-1 uses
+  the global default.
+- Realtime push of the Overview "Container Hosts" card. The card refreshes
+  on page load; the activity rail's existing Reverb stream already surfaces
+  the user-visible transition. (Overview KPI realtime in general — spec 022
+  / 025 left this page-load — so 029 stays consistent.)
+- Per-host metric-history charts on Overview. The Overview shows the
+  current-snapshot glance; deeper telemetry lives on `Monitoring/Hosts/Show`
+  (delivered by spec 028).
+- A `degraded` status transition (the enum exists but no spec uses it).
+  Reserved for a future "host is reporting but unhealthy" rule.
+
+## Plan
+
+1. **Config.** New `config/hosts.php`:
+   ```php
+   return [
+       'heartbeat_timeout_seconds' => (int) env('HOSTS_HEARTBEAT_TIMEOUT_SECONDS', 120),
+   ];
+   ```
+   Add `HOSTS_HEARTBEAT_TIMEOUT_SECONDS=` to `.env.example` with a comment
+   noting the 4× agent-interval rationale.
+
+2. **`DetectOfflineHostsAction`.** New
+   `app/Domain/Docker/Actions/DetectOfflineHostsAction.php`:
+   - `execute(): int` returns the number of hosts flipped (useful for the
+     job's log line and the test).
+   - Query: `Host::query()->with('project:id,owner_user_id')
+     ->where('status', HostStatus::Online->value)
+     ->where('last_seen_at', '<', now()->subSeconds(config('hosts.heartbeat_timeout_seconds')))
+     ->get()`.
+   - Iterate; for each: open a transaction → `forceFill(['status' =>
+     HostStatus::Offline->value])->save()` → call `CreateActivityEventAction`
+     with `event_type: host.offline`, `severity: Danger`, `title: "{name}
+     went offline"`, `description: "No telemetry in {N} seconds"`, `source:
+     hosts`, `metadata: {host_id, last_seen_at, threshold_seconds}`. The
+     activity event implicitly fans out to the project owner's
+     `users.{id}.activity` channel via the `ActivityEventCreated` change in
+     step 4.
+   - Late-arriving telemetry is fine: it'll flip status back to online and
+     emit `host.recovered` (step 3).
+
+3. **`IngestHostTelemetryAction` extension.** In `updateHost`, capture
+   `$wasOffline = $host->status === HostStatus::Offline` *before* the
+   forceFill. After the DB::transaction returns (next to the existing
+   `HostTelemetryRecorded::dispatch(...)` line), if `$wasOffline`, call
+   `CreateActivityEventAction` with `event_type: host.recovered`, `severity:
+   Success`, `title: "{name} recovered"`, `description: "Telemetry resumed
+   at {ISO recorded_at}"`, `source: hosts`, `metadata: {host_id, recorded_at}`.
+   No event for pending → online (matches spec 024's silent first-probe rule).
+
+4. **`ActivityEventCreated` recipient resolution.** Extend the
+   `broadcastOn()` switch with a third branch:
+   ```php
+   if ($this->activityEvent->source === 'hosts') {
+       $hostId = $metadata['host_id'] ?? null;
+       if ($hostId === null) return [];
+       $host = Host::query()->with('project:id,owner_user_id')->find($hostId);
+       return $host?->project?->owner_user_id;
+   }
+   ```
+   (Wrapped in the same return shape the other branches use.) The Vue rail
+   already renders activity events; no JS change needed beyond the icon /
+   label map in step 7.
+
+5. **`DetectOfflineHostsJob`.** Single-job action wrapper, queue `default`,
+   `ShouldQueue`. Mirrors `DispatchDueWebsiteChecksJob` shape.
+
+6. **Scheduler.** In `routes/console.php`, beside the existing
+   `DispatchDueWebsiteChecksJob` schedule:
+   ```php
+   Schedule::job(new DetectOfflineHostsJob)
+       ->everyMinute()
+       ->name('hosts.detect-offline')
+       ->withoutOverlapping();
+   ```
+
+7. **Activity-rail labels.** `resources/js/types/index.d.ts` (or wherever
+   the activity event union lives) adds `'host.offline'` and
+   `'host.recovered'`. The rail's icon / label maps gain entries: Server
+   icon, danger tone for `host.offline`, success tone for `host.recovered`.
+
+8. **`GetOverviewDashboardQuery::hosts()` rewrite.** Delete the Repository
+   proxy. Build the new `online / offline / new / sparkline / status` from
+   real Host data. Add a `cards` array: hosts sorted by `(status === 'offline'
+   ? 0 : status === 'online' ? 1 : 2, name asc)`, limit 6, fields
+   `{id, name, status, cpu_percent, memory_percent, last_seen_at}` (the same
+   fields the Hosts Index transform already exposes — eager-load
+   `latestMetricSnapshot`).
+
+9. **`Overview.vue`.** Delete the `stubHosts` array. Iterate
+   `dashboard.hosts.cards` in the "Container Hosts" card. Empty-state with a
+   "Connect your first host" CTA pointing at `monitoring.hosts.create`.
+   Update the headline KPI card to show `online` / `offline` from the new
+   shape; drop the "· mock" header.
+
+10. **Tests** as enumerated in Scope. Use `Event::fake([ActivityEventCreated::class])`
+    or assert on the `activity_events` table rows directly (the codebase's
+    spec-024 tests do the latter — mirror).
+
+## Acceptance criteria
+- [ ] A host whose `last_seen_at` is older than the configured timeout flips
+      from `online` to `offline` within ≤ 60 s of the threshold and a
+      `host.offline` activity event lands.
+- [ ] The first telemetry tick after an offline host posts flips it to
+      `online` and emits exactly one `host.recovered` activity event.
+- [ ] Pending → online and online → online ingest paths emit no
+      `host.recovered` (silent first activation / steady-state).
+- [ ] `host.offline` and `host.recovered` rows broadcast on the project
+      owner's `users.{id}.activity` channel; the right-rail picks them up.
+- [ ] Overview Hosts KPI displays real online + offline counts (no
+      `Repository::count` proxy, no mocks); sibling-user hosts don't leak.
+- [ ] Overview "Container Hosts" card renders real hosts from
+      `dashboard.hosts.cards` (no `stubHosts`, no "· mock" header); empty
+      state CTA points at `monitoring.hosts.create`.
+- [ ] Pint clean, `php artisan test` green (new tests added), `npm run build`
+      clean.
+
+## Files touched
+Fill in as work progresses.
+
+- `config/hosts.php` — new (heartbeat timeout)
+- `.env.example` — add `HOSTS_HEARTBEAT_TIMEOUT_SECONDS`
+- `app/Domain/Docker/Actions/DetectOfflineHostsAction.php` — new
+- `app/Domain/Docker/Jobs/DetectOfflineHostsJob.php` — new
+- `app/Domain/Docker/Actions/IngestHostTelemetryAction.php` — emit `host.recovered` on offline→online
+- `app/Events/ActivityEventCreated.php` — resolve recipients for `source: hosts`
+- `app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php` — rewrite `hosts()`, add `cards`
+- `resources/js/Pages/Overview.vue` — drop `stubHosts`, iterate `dashboard.hosts.cards`, KPI shape
+- `resources/js/types/index.d.ts` — add `host.offline` / `host.recovered` to the activity event union
+- `resources/js/Components/Activity/ActivityFeedItem.vue` (or wherever the icon/label map lives) — register the two new types
+- `routes/console.php` — schedule `DetectOfflineHostsJob`
+- `tests/Unit/Domain/Docker/DetectOfflineHostsActionTest.php` — new
+- `tests/Unit/Domain/Docker/IngestHostTelemetryActionTest.php` — extend (recovery + silent paths)
+- `tests/Feature/Activity/ActivityEventCreatedTest.php` — extend (hosts source resolution)
+- `tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php` — extend (real host KPI + cards)
+- `tests/Feature/Console/DetectOfflineHostsScheduleTest.php` — new (asserts the schedule is registered)
+
+## Work log
+
+### 2026-05-26
+- Spec drafted for review.
+- Issue [#87](https://github.com/Copxer/nexus/issues/87) opened, branch `spec/029-host-offline-detection` cut off `main`.
+
+## Open questions / blockers
+- **Heartbeat timeout: global vs per-host.** 029 ships a global 120s default
+  via config. A per-host `heartbeat_timeout_seconds` column + Edit-form field
+  is a small follow-up if anyone wants to tune chatty vs sparse fleets
+  individually. Default chosen as 4× the agent's default 30s interval —
+  tight enough to catch silent failures within ~2 minutes, loose enough to
+  ride out a single missed tick + network blip.
+- **Overview "Container Hosts" card depth.** 029 shows up to 6 hosts with
+  current CPU / memory glance. The roadmap's full vision (per-host card
+  with real-time bars) lives behind `/monitoring/hosts` (delivered by 028);
+  Overview stays a summary surface.
+- **Sparkline metric.** Daily `host_metric_snapshots` count = telemetry
+  volume, parallel to the deployments KPI's daily completed-run count. An
+  alternative ("hours each host spent online over the last 12 days") is
+  more meaningful but expensive — defer unless it actually proves useful in
+  practice.
+- **Realtime KPI refresh.** Out of scope per the Overview pattern set by
+  specs 022 / 025. The activity rail's existing realtime stream already
+  surfaces the user-visible transitions (`host.offline` / `host.recovered`)
+  — the KPI numbers themselves wait for the next page load.

--- a/specs/phase-6-docker-hosts/README.md
+++ b/specs/phase-6-docker-hosts/README.md
@@ -12,7 +12,7 @@ Stand up Docker host + container monitoring end-to-end via a pull-from-agent mod
 | 026 | Hosts + agent tokens scaffolding (CRUD + token rotation) | 🟢 |
 | 027 | Telemetry ingestion endpoint + reference agent script | 🟢 |
 | 028 | Hosts UI (index + show + project Hosts tab) | 🟢 |
-| 029 | Host offline detection + activity events + Overview KPI wiring | ⬜ |
+| 029 | Host offline detection + activity events + Overview KPI wiring | 🟢 |
 
 ## Acceptance criteria (phase-level)
 - [ ] User can create / edit / archive a host under a project.

--- a/tests/Feature/Activity/ActivityEventCreatedBroadcastTest.php
+++ b/tests/Feature/Activity/ActivityEventCreatedBroadcastTest.php
@@ -6,6 +6,7 @@ use App\Domain\Activity\Actions\CreateActivityEventAction;
 use App\Enums\ActivitySeverity;
 use App\Events\ActivityEventCreated;
 use App\Models\ActivityEvent;
+use App\Models\Host;
 use App\Models\Project;
 use App\Models\Repository;
 use App\Models\User;
@@ -99,5 +100,49 @@ class ActivityEventCreatedBroadcastTest extends TestCase
         $row = ActivityEvent::factory()->create(['repository_id' => null]);
 
         $this->assertSame('ActivityEventCreated', (new ActivityEventCreated($row))->broadcastAs());
+    }
+
+    public function test_hosts_source_resolves_to_host_owners_channel(): void
+    {
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $host = Host::factory()->create(['project_id' => $project->id]);
+
+        $row = ActivityEvent::factory()->create([
+            'repository_id' => null,
+            'source' => 'hosts',
+            'event_type' => 'host.offline',
+            'metadata' => ['host_id' => $host->id],
+        ]);
+
+        $channels = (new ActivityEventCreated($row))->broadcastOn();
+
+        $this->assertCount(1, $channels);
+        $this->assertInstanceOf(PrivateChannel::class, $channels[0]);
+        $this->assertSame("private-users.{$owner->id}.activity", $channels[0]->name);
+    }
+
+    public function test_hosts_source_is_silent_when_metadata_host_id_missing(): void
+    {
+        $row = ActivityEvent::factory()->create([
+            'repository_id' => null,
+            'source' => 'hosts',
+            'event_type' => 'host.offline',
+            'metadata' => [],
+        ]);
+
+        $this->assertSame([], (new ActivityEventCreated($row))->broadcastOn());
+    }
+
+    public function test_hosts_source_is_silent_when_host_id_is_unknown(): void
+    {
+        $row = ActivityEvent::factory()->create([
+            'repository_id' => null,
+            'source' => 'hosts',
+            'event_type' => 'host.offline',
+            'metadata' => ['host_id' => 99999],
+        ]);
+
+        $this->assertSame([], (new ActivityEventCreated($row))->broadcastOn());
     }
 }

--- a/tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php
+++ b/tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature\Dashboard;
 
 use App\Domain\Dashboard\Queries\GetOverviewDashboardQuery;
 use App\Models\ActivityEvent;
+use App\Models\Host;
+use App\Models\HostMetricSnapshot;
 use App\Models\Project;
 use App\Models\Repository;
 use App\Models\User;
@@ -55,16 +57,140 @@ class GetOverviewDashboardQueryTest extends TestCase
         $this->assertSame('muted', $payload['dashboard']['projects']['status']);
     }
 
-    public function test_hosts_kpi_proxies_repository_count(): void
+    public function test_hosts_kpi_returns_zero_state_with_no_hosts(): void
     {
-        $owner = User::factory()->create();
-        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
-        Repository::factory()->count(5)->create(['project_id' => $project->id]);
+        $payload = (new GetOverviewDashboardQuery)->handle();
+
+        $this->assertSame(0, $payload['dashboard']['hosts']['online']);
+        $this->assertSame(0, $payload['dashboard']['hosts']['offline']);
+        $this->assertSame(0, $payload['dashboard']['hosts']['new']);
+        $this->assertSame('muted', $payload['dashboard']['hosts']['status']);
+        $this->assertSame([], $payload['dashboard']['hosts']['cards']);
+    }
+
+    public function test_hosts_kpi_counts_real_online_and_offline_hosts(): void
+    {
+        $project = Project::factory()->create();
+        Host::factory()->online()->count(3)->create(['project_id' => $project->id]);
+        Host::factory()->offline()->create(['project_id' => $project->id]);
+        Host::factory()->archived()->create(['project_id' => $project->id]);
 
         $payload = (new GetOverviewDashboardQuery)->handle();
 
-        $this->assertSame(5, $payload['dashboard']['hosts']['online']);
-        $this->assertSame('info', $payload['dashboard']['hosts']['status']);
+        $this->assertSame(3, $payload['dashboard']['hosts']['online']);
+        $this->assertSame(1, $payload['dashboard']['hosts']['offline']);
+        // Mixed online + offline → warning.
+        $this->assertSame('warning', $payload['dashboard']['hosts']['status']);
+    }
+
+    public function test_hosts_kpi_status_is_success_when_no_hosts_offline(): void
+    {
+        $project = Project::factory()->create();
+        Host::factory()->online()->count(2)->create(['project_id' => $project->id]);
+
+        $payload = (new GetOverviewDashboardQuery)->handle();
+
+        $this->assertSame('success', $payload['dashboard']['hosts']['status']);
+    }
+
+    public function test_hosts_kpi_status_is_danger_when_every_host_is_offline(): void
+    {
+        $project = Project::factory()->create();
+        Host::factory()->offline()->count(2)->create(['project_id' => $project->id]);
+
+        $payload = (new GetOverviewDashboardQuery)->handle();
+
+        $this->assertSame('danger', $payload['dashboard']['hosts']['status']);
+    }
+
+    public function test_hosts_cards_order_offline_first_then_online_then_pending_then_name(): void
+    {
+        $project = Project::factory()->create();
+        Host::factory()->online()->create(['project_id' => $project->id, 'name' => 'b-online']);
+        Host::factory()->offline()->create(['project_id' => $project->id, 'name' => 'c-offline']);
+        Host::factory()->create(['project_id' => $project->id, 'name' => 'a-pending']);
+        Host::factory()->online()->create(['project_id' => $project->id, 'name' => 'a-online']);
+
+        $payload = (new GetOverviewDashboardQuery)->handle();
+        $names = array_column($payload['dashboard']['hosts']['cards'], 'name');
+
+        $this->assertSame(
+            ['c-offline', 'a-online', 'b-online', 'a-pending'],
+            $names,
+        );
+    }
+
+    public function test_hosts_cards_cap_at_six(): void
+    {
+        $project = Project::factory()->create();
+        Host::factory()->online()->count(10)->create(['project_id' => $project->id]);
+
+        $payload = (new GetOverviewDashboardQuery)->handle();
+
+        $this->assertCount(6, $payload['dashboard']['hosts']['cards']);
+    }
+
+    public function test_hosts_cards_exclude_archived_hosts(): void
+    {
+        $project = Project::factory()->create();
+        Host::factory()->online()->create(['project_id' => $project->id, 'name' => 'live-host']);
+        Host::factory()->archived()->create(['project_id' => $project->id, 'name' => 'archived-host']);
+
+        $payload = (new GetOverviewDashboardQuery)->handle();
+        $names = array_column($payload['dashboard']['hosts']['cards'], 'name');
+
+        $this->assertSame(['live-host'], $names);
+    }
+
+    public function test_hosts_cards_carry_latest_snapshot_metrics(): void
+    {
+        $project = Project::factory()->create();
+        $host = Host::factory()->online()->create(['project_id' => $project->id]);
+        HostMetricSnapshot::factory()->create([
+            'host_id' => $host->id,
+            'cpu_percent' => 42.5,
+            'memory_used_mb' => 500,
+            'memory_total_mb' => 1000,
+            'recorded_at' => now()->subMinute(),
+        ]);
+        HostMetricSnapshot::factory()->create([
+            'host_id' => $host->id,
+            'cpu_percent' => 18.0,
+            'memory_used_mb' => 200,
+            'memory_total_mb' => 1000,
+            'recorded_at' => now(),
+        ]);
+
+        $payload = (new GetOverviewDashboardQuery)->handle();
+        $card = $payload['dashboard']['hosts']['cards'][0];
+
+        // Latest snapshot wins.
+        $this->assertSame(18.0, $card['cpu_percent']);
+        // PHP-side `round()` keeps a float; this is direct PHP assertion
+        // (not JSON round-trip), so the trailing `.0` survives.
+        $this->assertSame(20.0, $card['memory_percent']); // 200/1000 = 20.0%
+    }
+
+    public function test_hosts_new_count_includes_hosts_created_in_the_last_week(): void
+    {
+        $project = Project::factory()->create();
+        Host::factory()->create([
+            'project_id' => $project->id,
+            'created_at' => now()->subDays(2),
+        ]);
+        Host::factory()->create([
+            'project_id' => $project->id,
+            'created_at' => now()->subDays(10),
+        ]);
+        // Archived hosts are excluded from `new` (no longer "part of the fleet").
+        Host::factory()->archived()->create([
+            'project_id' => $project->id,
+            'created_at' => now()->subDays(1),
+        ]);
+
+        $payload = (new GetOverviewDashboardQuery)->handle();
+
+        $this->assertSame(1, $payload['dashboard']['hosts']['new']);
     }
 
     public function test_sparklines_are_zero_padded_to_twelve_entries(): void

--- a/tests/Feature/Docker/DetectOfflineHostsJobTest.php
+++ b/tests/Feature/Docker/DetectOfflineHostsJobTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\Monitoring;
+namespace Tests\Feature\Docker;
 
 use App\Domain\Docker\Actions\DetectOfflineHostsAction;
 use App\Domain\Docker\Jobs\DetectOfflineHostsJob;

--- a/tests/Feature/Monitoring/DetectOfflineHostsJobTest.php
+++ b/tests/Feature/Monitoring/DetectOfflineHostsJobTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature\Monitoring;
+
+use App\Domain\Docker\Actions\DetectOfflineHostsAction;
+use App\Domain\Docker\Jobs\DetectOfflineHostsJob;
+use App\Enums\HostStatus;
+use App\Models\Host;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Spec 029 — end-to-end wiring check for the scheduled offline detector.
+ * The action's logic is covered by `DetectOfflineHostsActionTest`; this
+ * test just verifies the job's `handle()` actually resolves and invokes
+ * the action against the live container.
+ */
+class DetectOfflineHostsJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_handle_flips_stale_online_hosts_to_offline(): void
+    {
+        config(['hosts.heartbeat_timeout_seconds' => 120]);
+
+        $host = Host::factory()->online()->create([
+            'last_seen_at' => now()->subMinutes(5),
+        ]);
+
+        app(DetectOfflineHostsJob::class)->handle(app()->make(DetectOfflineHostsAction::class));
+
+        $this->assertSame(HostStatus::Offline, $host->fresh()->status);
+    }
+}

--- a/tests/Unit/Domain/Docker/DetectOfflineHostsActionTest.php
+++ b/tests/Unit/Domain/Docker/DetectOfflineHostsActionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Unit\Domain\Docker;
+
+use App\Domain\Docker\Actions\DetectOfflineHostsAction;
+use App\Enums\ActivitySeverity;
+use App\Enums\HostStatus;
+use App\Models\ActivityEvent;
+use App\Models\Host;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Spec 029 — the scheduled offline detector. Verifies the exact
+ * status transitions + the one-event-per-flip guarantee.
+ */
+class DetectOfflineHostsActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** Use the production default so tests reflect real behaviour. */
+    private const TIMEOUT = 120;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['hosts.heartbeat_timeout_seconds' => self::TIMEOUT]);
+    }
+
+    public function test_online_host_past_timeout_flips_to_offline_and_emits_event(): void
+    {
+        $host = Host::factory()->online()->create([
+            'last_seen_at' => now()->subSeconds(self::TIMEOUT + 30),
+        ]);
+
+        $flipped = app(DetectOfflineHostsAction::class)->execute();
+
+        $this->assertSame(1, $flipped);
+        $host->refresh();
+        $this->assertSame(HostStatus::Offline, $host->status);
+
+        $event = ActivityEvent::query()->where('event_type', 'host.offline')->firstOrFail();
+        $this->assertSame('hosts', $event->source);
+        $this->assertSame(ActivitySeverity::Danger, $event->severity);
+        $this->assertSame("{$host->name} went offline", $event->title);
+        $this->assertSame($host->id, $event->metadata['host_id'] ?? null);
+        $this->assertSame(self::TIMEOUT, $event->metadata['threshold_seconds'] ?? null);
+    }
+
+    public function test_online_host_within_timeout_is_untouched(): void
+    {
+        $host = Host::factory()->online()->create([
+            'last_seen_at' => now()->subSeconds(self::TIMEOUT - 30),
+        ]);
+
+        $flipped = app(DetectOfflineHostsAction::class)->execute();
+
+        $this->assertSame(0, $flipped);
+        $this->assertSame(HostStatus::Online, $host->fresh()->status);
+        $this->assertSame(0, ActivityEvent::query()->count());
+    }
+
+    public function test_pending_host_is_skipped_even_if_old(): void
+    {
+        // A host that was never online has no `offline` transition to
+        // emit — pending stays pending until first telemetry.
+        $host = Host::factory()->create([
+            'last_seen_at' => now()->subYear(),
+        ]);
+
+        $flipped = app(DetectOfflineHostsAction::class)->execute();
+
+        $this->assertSame(0, $flipped);
+        $this->assertSame(HostStatus::Pending, $host->fresh()->status);
+    }
+
+    public function test_archived_host_is_skipped(): void
+    {
+        $host = Host::factory()->archived()->create([
+            'last_seen_at' => now()->subYear(),
+        ]);
+
+        $flipped = app(DetectOfflineHostsAction::class)->execute();
+
+        $this->assertSame(0, $flipped);
+        $this->assertSame(HostStatus::Archived, $host->fresh()->status);
+    }
+
+    public function test_offline_host_stays_offline_and_does_not_re_emit(): void
+    {
+        $host = Host::factory()->offline()->create();
+
+        $flipped = app(DetectOfflineHostsAction::class)->execute();
+
+        $this->assertSame(0, $flipped);
+        $this->assertSame(HostStatus::Offline, $host->fresh()->status);
+        $this->assertSame(0, ActivityEvent::query()->where('event_type', 'host.offline')->count());
+    }
+
+    public function test_multiple_stale_hosts_each_produce_one_event(): void
+    {
+        Host::factory()->online()->count(3)->create([
+            'last_seen_at' => now()->subSeconds(self::TIMEOUT + 30),
+        ]);
+        // Plus one fresh host that should NOT be touched.
+        Host::factory()->online()->create([
+            'last_seen_at' => now()->subSeconds(10),
+        ]);
+
+        $flipped = app(DetectOfflineHostsAction::class)->execute();
+
+        $this->assertSame(3, $flipped);
+        $this->assertSame(3, ActivityEvent::query()->where('event_type', 'host.offline')->count());
+        $this->assertSame(3, Host::query()->where('status', HostStatus::Offline->value)->count());
+        $this->assertSame(1, Host::query()->where('status', HostStatus::Online->value)->count());
+    }
+}

--- a/tests/Unit/Domain/Docker/IngestHostTelemetryActionTest.php
+++ b/tests/Unit/Domain/Docker/IngestHostTelemetryActionTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Unit\Domain\Docker;
 
 use App\Domain\Docker\Actions\IngestHostTelemetryAction;
+use App\Enums\ActivitySeverity;
 use App\Enums\HostStatus;
+use App\Models\ActivityEvent;
 use App\Models\Host;
 use App\Models\HostMetricSnapshot;
 use Carbon\CarbonImmutable;
@@ -116,5 +118,39 @@ class IngestHostTelemetryActionTest extends TestCase
         // important assertion is that status stays Online and the
         // payload didn't include a redundant status column write.
         $this->assertSame(HostStatus::Online, $host->status);
+    }
+
+    public function test_offline_to_online_emits_a_host_recovered_activity_event(): void
+    {
+        $host = Host::factory()->offline()->create();
+
+        app(IngestHostTelemetryAction::class)->execute($host, $this->basePayload());
+
+        $host->refresh();
+        $this->assertSame(HostStatus::Online, $host->status);
+
+        $event = ActivityEvent::query()->where('event_type', 'host.recovered')->firstOrFail();
+        $this->assertSame('hosts', $event->source);
+        $this->assertSame(ActivitySeverity::Success, $event->severity);
+        $this->assertSame("{$host->name} recovered", $event->title);
+        $this->assertSame($host->id, $event->metadata['host_id'] ?? null);
+    }
+
+    public function test_pending_to_online_does_not_emit_host_recovered(): void
+    {
+        $host = Host::factory()->create(); // pending
+
+        app(IngestHostTelemetryAction::class)->execute($host, $this->basePayload());
+
+        $this->assertSame(0, ActivityEvent::query()->where('event_type', 'host.recovered')->count());
+    }
+
+    public function test_online_to_online_does_not_emit_host_recovered(): void
+    {
+        $host = Host::factory()->online()->create();
+
+        app(IngestHostTelemetryAction::class)->execute($host, $this->basePayload());
+
+        $this->assertSame(0, ActivityEvent::query()->where('event_type', 'host.recovered')->count());
     }
 }


### PR DESCRIPTION
Closes #87

Spec: `specs/phase-6-docker-hosts/029-host-offline-detection.md`

Closes phase 6.

## Summary

- **Offline detection** — `DetectOfflineHostsJob` scheduled `everyMinute()->withoutOverlapping()`. Finds online hosts whose `last_seen_at` is past `config('hosts.heartbeat_timeout_seconds')` (default 120 s = 4× the agent's 30 s tick), flips each to `offline` and emits a `host.offline` activity event. Pending and archived hosts are skipped (no transition to record).
- **Recovery** — `IngestHostTelemetryAction` captures pre-transaction status; on the specific `offline → online` transition emits `host.recovered`. Pending → online stays silent (matches spec 024's first-probe rule); online → online stays silent.
- **Broadcast routing** — `ActivityEventCreated::broadcastOn()` gains a third branch resolving `source: hosts` events via `metadata.host_id → host → project → owner_user_id`. The right rail surfaces both new event types for free.
- **Overview Hosts KPI** — drops the `Repository::count()` proxy. Real Host counts (online + new `offline`), `cards` array (≤6 hosts ordered offline-first then online then pending then name; archived excluded). Sparkline shifts to daily `host_metric_snapshots` volume parallel to the deployments KPI.
- **Overview frontend** — deletes `stubHosts`. "Container Hosts" card iterates `dashboard.hosts.cards` with real CPU/MEM bars, row-level links to `monitoring.hosts.show`, empty-state CTA to `monitoring.hosts.create`. Hosts KPI status-label flips to `N offline` when > 0.

## Test plan
- [x] A host whose `last_seen_at` is older than the configured timeout flips from `online` to `offline` within ≤ 60 s; `host.offline` activity event lands
- [x] First telemetry tick after an offline host posts flips it to `online` and emits exactly one `host.recovered` activity event
- [x] Pending → online and online → online ingest paths emit no `host.recovered`
- [x] `host.offline` / `host.recovered` rows broadcast on the project owner's `users.{id}.activity` channel; right rail picks them up
- [x] Overview Hosts KPI displays real online + offline counts; sibling-user hosts don't leak (phase-1 single-tenant scoping, documented in the query class)
- [x] Overview "Container Hosts" card renders real hosts from `dashboard.hosts.cards`; empty state CTA points at `monitoring.hosts.create`
- [x] Pint clean, `php artisan test` green (507 tests, +27 new), `npm run build` clean

## Self-review notes
Reviewed via `superpowers:code-reviewer` — assessed ready to PR, no critical/blocking issues. Addressed in the close-out commit:
- `ActivityEventCreated` now also implements `ShouldDispatchAfterCommit` (parity with spec 028's `HostTelemetryRecorded`; defends every `CreateActivityEventAction` caller against any future outer-transaction wrapping).
- `Overview.vue` swaps the local `hostCardTone` helper for the shared `hostStatusTone` import so the tone map stays single-source.
- `DetectOfflineHostsJob` logs the flipped count (the action's docblock promised it; the wrapper now keeps the promise).
- Moved `DetectOfflineHostsJobTest` from `tests/Feature/Monitoring/` to `tests/Feature/Docker/` to match the action's domain.

Deferred / conscious choices (non-blocking, captured in the spec's Open Questions):
- Heartbeat timeout is a global config default; per-host configurability is an explicit follow-up.
- Sparkline metric is daily `host_metric_snapshots` count = telemetry volume.
- A late telemetry post that lands within seconds of the detector flipping a host can emit `host.offline` then `host.recovered` in quick succession — that's the correct semantics (the host *did* miss a heartbeat) but worth documenting as the activity feed will look noisy on flaky-network fleets.

## Phase 6
This closes Phase 6 — Docker Host Agent MVP. All four specs (026–029) shipped. Phase status flipped to 🟢 in `specs/README.md`.