### PR TITLE
Spec 030 — Alerts scaffolding + transition-based promotion

### DIFF
--- a/app/Domain/Alerts/Actions/ResolveAlertAction.php
+++ b/app/Domain/Alerts/Actions/ResolveAlertAction.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Domain\Alerts\Actions;
+
+use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Enums\ActivitySeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
+use App\Models\Alert;
+use Illuminate\Support\Carbon;
+
+/**
+ * Close every open or acknowledged Alert matching a recovery
+ * transition (spec 030). One Alert per `(source, source_id, type)` —
+ * see `TriggerAlertAction`'s idempotency contract — so the closer
+ * normally touches at most one row. `type` is optional so a single
+ * recovery call can fan-close every Alert for the source if needed.
+ *
+ * Ack'd rows are closed alongside open rows: an ack'd outage that
+ * recovers is still resolved. If the user wants ack to "stick"
+ * through recovery they can mute (031).
+ *
+ * For each closed row the action emits an `alert.resolved` activity
+ * event so the rail picks up the recovery in realtime. A no-op call
+ * (nothing matches) emits nothing.
+ */
+class ResolveAlertAction
+{
+    public function __construct(
+        private readonly CreateActivityEventAction $createActivity,
+    ) {}
+
+    /**
+     * @param  array{
+     *     source: AlertSource|string,
+     *     source_id: int|null,
+     *     type?: string,
+     * }  $criteria
+     * @return int Number of Alerts resolved.
+     */
+    public function execute(array $criteria): int
+    {
+        $source = $criteria['source'] instanceof AlertSource
+            ? $criteria['source']->value
+            : (string) $criteria['source'];
+
+        $query = Alert::query()
+            ->where('source', $source)
+            ->where('source_id', $criteria['source_id'])
+            ->whereIn('status', [
+                AlertStatus::Open->value,
+                AlertStatus::Acknowledged->value,
+            ]);
+
+        if (isset($criteria['type'])) {
+            $query->where('type', $criteria['type']);
+        }
+
+        $resolving = $query->get();
+
+        if ($resolving->isEmpty()) {
+            return 0;
+        }
+
+        $now = Carbon::now();
+
+        foreach ($resolving as $alert) {
+            $alert->forceFill([
+                'status' => AlertStatus::Resolved->value,
+                'resolved_at' => $now,
+                'last_seen_at' => $now,
+            ])->save();
+
+            $this->createActivity->execute([
+                'event_type' => 'alert.resolved',
+                'severity' => ActivitySeverity::Success,
+                'title' => "{$alert->title} resolved",
+                'occurred_at' => $now,
+                'source' => 'alerts',
+                'metadata' => [
+                    'alert_id' => $alert->id,
+                    'alert_source' => $source,
+                    'alert_source_id' => $alert->source_id,
+                ],
+            ]);
+        }
+
+        return $resolving->count();
+    }
+}

--- a/app/Domain/Alerts/Actions/TriggerAlertAction.php
+++ b/app/Domain/Alerts/Actions/TriggerAlertAction.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Domain\Alerts\Actions;
+
+use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
+use App\Models\Alert;
+use Illuminate\Support\Carbon;
+
+/**
+ * Promote a transition event into a durable Alert row (spec 030).
+ *
+ * Idempotent on `(source, source_id, type)`: a second identical
+ * trigger inside the open window bumps `last_seen_at` and returns the
+ * same row — no duplicate Alert, no second activity event. This makes
+ * the action safe to call from emitters that fire on every probe /
+ * tick rather than only on transitions, even though spec 030's call
+ * sites all fire on transitions.
+ *
+ * On a fresh trigger the action also emits an `alert.triggered`
+ * activity event with `source: 'alerts'` so the right-rail picks up
+ * the alert in realtime through the existing `ActivityEventCreated`
+ * fan-out (the `source: alerts` branch resolves the recipient via
+ * `metadata.alert_id`).
+ */
+class TriggerAlertAction
+{
+    public function __construct(
+        private readonly CreateActivityEventAction $createActivity,
+    ) {}
+
+    /**
+     * @param  array{
+     *     project_id: int,
+     *     source: AlertSource|string,
+     *     source_id: int|null,
+     *     type: string,
+     *     severity: AlertSeverity|string,
+     *     title: string,
+     *     description?: string|null,
+     *     metadata?: array<string, mixed>,
+     * }  $attrs
+     */
+    public function execute(array $attrs): Alert
+    {
+        $source = $attrs['source'] instanceof AlertSource
+            ? $attrs['source']->value
+            : (string) $attrs['source'];
+        $severity = $attrs['severity'] instanceof AlertSeverity
+            ? $attrs['severity']
+            : AlertSeverity::from((string) $attrs['severity']);
+
+        $now = Carbon::now();
+
+        $existing = Alert::query()
+            ->where('source', $source)
+            ->where('source_id', $attrs['source_id'])
+            ->where('type', $attrs['type'])
+            ->whereIn('status', [
+                AlertStatus::Open->value,
+                AlertStatus::Acknowledged->value,
+            ])
+            ->first();
+
+        if ($existing !== null) {
+            // Steady-state: the alert is still firing. Bump
+            // `last_seen_at` so the UI can show "5 minutes ago"
+            // freshness without inserting a sibling row. No second
+            // activity event — that would flood the rail.
+            $existing->forceFill(['last_seen_at' => $now])->save();
+
+            return $existing;
+        }
+
+        $alert = Alert::query()->create([
+            'project_id' => $attrs['project_id'],
+            'source' => $source,
+            'source_id' => $attrs['source_id'],
+            'type' => $attrs['type'],
+            'severity' => $severity->value,
+            'status' => AlertStatus::Open->value,
+            'title' => $attrs['title'],
+            'description' => $attrs['description'] ?? null,
+            'triggered_at' => $now,
+            'last_seen_at' => $now,
+            'metadata' => $attrs['metadata'] ?? null,
+        ]);
+
+        $this->createActivity->execute([
+            'event_type' => 'alert.triggered',
+            'severity' => $severity->toActivitySeverity(),
+            'title' => $alert->title,
+            'description' => $alert->description,
+            'occurred_at' => $now,
+            'source' => 'alerts',
+            'metadata' => [
+                'alert_id' => $alert->id,
+                'alert_source' => $source,
+                'alert_source_id' => $alert->source_id,
+                'alert_type' => $alert->type,
+            ],
+        ]);
+
+        return $alert;
+    }
+}

--- a/app/Domain/Alerts/Actions/TriggerAlertAction.php
+++ b/app/Domain/Alerts/Actions/TriggerAlertAction.php
@@ -24,6 +24,16 @@ use Illuminate\Support\Carbon;
  * the alert in realtime through the existing `ActivityEventCreated`
  * fan-out (the `source: alerts` branch resolves the recipient via
  * `metadata.alert_id`).
+ *
+ * Concurrency note: the idempotency check is `SELECT … WHERE status
+ * IN (open, acknowledged) … LIMIT 1` followed by an `INSERT`, not an
+ * atomic upsert. Two callers racing simultaneously could in theory
+ * both miss the existing row and both insert. The 030 call sites
+ * serialize (per-website scheduler / queued telemetry job / sequential
+ * webhook handler) so this is theoretical today; if a future caller
+ * arrives with real concurrency, add a partial unique index on
+ * `(source, source_id, type) WHERE status IN ('open', 'acknowledged')`
+ * (PostgreSQL) or a uniqueness guard at the action layer.
  */
 class TriggerAlertAction
 {

--- a/app/Domain/Docker/Actions/DetectOfflineHostsAction.php
+++ b/app/Domain/Docker/Actions/DetectOfflineHostsAction.php
@@ -3,7 +3,10 @@
 namespace App\Domain\Docker\Actions;
 
 use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Domain\Alerts\Actions\TriggerAlertAction;
 use App\Enums\ActivitySeverity;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
 use App\Enums\HostStatus;
 use App\Models\Host;
 use Illuminate\Support\Carbon;
@@ -28,6 +31,7 @@ class DetectOfflineHostsAction
 {
     public function __construct(
         private readonly CreateActivityEventAction $createActivity,
+        private readonly TriggerAlertAction $triggerAlert,
     ) {}
 
     /**
@@ -61,6 +65,23 @@ class DetectOfflineHostsAction
                     'source' => 'hosts',
                     'metadata' => [
                         'host_id' => $host->id,
+                        'last_seen_at' => $lastSeenAt?->toIso8601String(),
+                        'threshold_seconds' => $threshold,
+                    ],
+                ]);
+
+                // Spec 030 — promote into a durable Alert. Inside the
+                // same transaction as the status flip + activity event
+                // so the trio is atomic.
+                $this->triggerAlert->execute([
+                    'project_id' => $host->project_id,
+                    'source' => AlertSource::Docker,
+                    'source_id' => $host->id,
+                    'type' => 'host.offline',
+                    'severity' => AlertSeverity::Critical,
+                    'title' => "{$host->name} went offline",
+                    'description' => "No telemetry in {$threshold}s",
+                    'metadata' => [
                         'last_seen_at' => $lastSeenAt?->toIso8601String(),
                         'threshold_seconds' => $threshold,
                     ],

--- a/app/Domain/Docker/Actions/IngestHostTelemetryAction.php
+++ b/app/Domain/Docker/Actions/IngestHostTelemetryAction.php
@@ -3,7 +3,9 @@
 namespace App\Domain\Docker\Actions;
 
 use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Domain\Alerts\Actions\ResolveAlertAction;
 use App\Enums\ActivitySeverity;
+use App\Enums\AlertSource;
 use App\Enums\HostStatus;
 use App\Events\HostTelemetryRecorded;
 use App\Models\Host;
@@ -35,6 +37,7 @@ class IngestHostTelemetryAction
     public function __construct(
         private readonly SyncContainerSnapshotsAction $syncContainers,
         private readonly CreateActivityEventAction $createActivity,
+        private readonly ResolveAlertAction $resolveAlert,
     ) {}
 
     /**
@@ -83,6 +86,13 @@ class IngestHostTelemetryAction
                     'host_id' => $host->id,
                     'recorded_at' => $recordedAt->toIso8601String(),
                 ],
+            ]);
+
+            // Spec 030 — auto-resolve any open or acknowledged
+            // host.offline Alert. No-op when nothing's open.
+            $this->resolveAlert->execute([
+                'source' => AlertSource::Docker,
+                'source_id' => $host->id,
             ]);
         }
     }

--- a/app/Domain/GitHub/WebhookHandlers/WorkflowRunWebhookHandler.php
+++ b/app/Domain/GitHub/WebhookHandlers/WorkflowRunWebhookHandler.php
@@ -128,13 +128,16 @@ class WorkflowRunWebhookHandler
         // Spec 030 — promote `workflow.failed` runs on the repo's
         // default branch into a durable Alert. Feature-branch failures
         // stay rail-only to keep alert noise in check; revisit with a
-        // per-repo monitored-branches allowlist later.
+        // per-repo monitored-branches allowlist later. Pass the RAW
+        // payload `head_branch` (not the fallback'd display value) so
+        // a malformed delivery missing the field doesn't accidentally
+        // pass the default-branch filter.
         $this->maybePromoteWorkflowAlert(
             rule: $rule,
             workflowRun: $workflowRun,
             repository: $repository,
             run: $run,
-            headBranch: $headBranch,
+            rawHeadBranch: $run['head_branch'] ?? null,
             title: $title,
             sender: $sender,
         );
@@ -151,7 +154,7 @@ class WorkflowRunWebhookHandler
         ?WorkflowRun $workflowRun,
         Repository $repository,
         array $run,
-        string $headBranch,
+        ?string $rawHeadBranch,
         string $title,
         ?string $sender,
     ): void {
@@ -161,8 +164,12 @@ class WorkflowRunWebhookHandler
         if ($workflowRun === null) {
             return; // normalizer rejected; no local row to point at
         }
+        if (! is_string($rawHeadBranch) || $rawHeadBranch === '') {
+            return; // unknown branch — don't alert (defends against
+            // malformed payloads that omit `head_branch`)
+        }
         $defaultBranch = $repository->default_branch;
-        if ($defaultBranch === null || $defaultBranch === '' || $headBranch !== $defaultBranch) {
+        if ($defaultBranch === null || $defaultBranch === '' || $rawHeadBranch !== $defaultBranch) {
             return; // feature-branch failures stay rail-only in 030
         }
         $projectId = $repository->project?->id;
@@ -181,7 +188,7 @@ class WorkflowRunWebhookHandler
             'metadata' => [
                 'workflow_run_id' => $workflowRun->id,
                 'github_run_id' => $workflowRun->github_id,
-                'head_branch' => $headBranch,
+                'head_branch' => $rawHeadBranch,
                 'conclusion' => (string) ($run['conclusion'] ?? ''),
                 'actor' => $sender,
                 'html_url' => $run['html_url'] ?? null,

--- a/app/Domain/GitHub/WebhookHandlers/WorkflowRunWebhookHandler.php
+++ b/app/Domain/GitHub/WebhookHandlers/WorkflowRunWebhookHandler.php
@@ -3,8 +3,11 @@
 namespace App\Domain\GitHub\WebhookHandlers;
 
 use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Domain\Alerts\Actions\TriggerAlertAction;
 use App\Domain\GitHub\Actions\NormalizeGitHubWorkflowRunAction;
 use App\Enums\ActivitySeverity;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
 use App\Enums\WebhookDeliveryStatus;
 use App\Events\WorkflowRunUpserted;
 use App\Models\Repository;
@@ -43,6 +46,7 @@ class WorkflowRunWebhookHandler
     public function __construct(
         private readonly CreateActivityEventAction $createActivity,
         private readonly NormalizeGitHubWorkflowRunAction $normalizer,
+        private readonly TriggerAlertAction $triggerAlert,
     ) {}
 
     public function handle(WebhookDelivery $delivery): WebhookDeliveryStatus
@@ -74,7 +78,7 @@ class WorkflowRunWebhookHandler
         // states (queued / in_progress / cancelled / etc.). Activity-event
         // creation below remains gated to terminal outcomes so the rail
         // doesn't thrash.
-        $this->upsertWorkflowRun($repository, $run);
+        $workflowRun = $this->upsertWorkflowRun($repository, $run);
 
         if ($action !== 'completed') {
             $delivery->forceFill([
@@ -121,7 +125,68 @@ class WorkflowRunWebhookHandler
             ],
         ]);
 
+        // Spec 030 — promote `workflow.failed` runs on the repo's
+        // default branch into a durable Alert. Feature-branch failures
+        // stay rail-only to keep alert noise in check; revisit with a
+        // per-repo monitored-branches allowlist later.
+        $this->maybePromoteWorkflowAlert(
+            rule: $rule,
+            workflowRun: $workflowRun,
+            repository: $repository,
+            run: $run,
+            headBranch: $headBranch,
+            title: $title,
+            sender: $sender,
+        );
+
         return WebhookDeliveryStatus::Processed;
+    }
+
+    /**
+     * @param  array{type: string, severity: ActivitySeverity}  $rule
+     * @param  array<string, mixed>  $run
+     */
+    private function maybePromoteWorkflowAlert(
+        array $rule,
+        ?WorkflowRun $workflowRun,
+        Repository $repository,
+        array $run,
+        string $headBranch,
+        string $title,
+        ?string $sender,
+    ): void {
+        if ($rule['type'] !== 'workflow.failed') {
+            return;
+        }
+        if ($workflowRun === null) {
+            return; // normalizer rejected; no local row to point at
+        }
+        $defaultBranch = $repository->default_branch;
+        if ($defaultBranch === null || $defaultBranch === '' || $headBranch !== $defaultBranch) {
+            return; // feature-branch failures stay rail-only in 030
+        }
+        $projectId = $repository->project?->id;
+        if ($projectId === null) {
+            return; // orphan repo (shouldn't happen — defensive)
+        }
+
+        $this->triggerAlert->execute([
+            'project_id' => $projectId,
+            'source' => AlertSource::Deployment,
+            'source_id' => $workflowRun->id,
+            'type' => 'workflow.failed',
+            'severity' => AlertSeverity::Warning,
+            'title' => $title,
+            'description' => $repository->full_name,
+            'metadata' => [
+                'workflow_run_id' => $workflowRun->id,
+                'github_run_id' => $workflowRun->github_id,
+                'head_branch' => $headBranch,
+                'conclusion' => (string) ($run['conclusion'] ?? ''),
+                'actor' => $sender,
+                'html_url' => $run['html_url'] ?? null,
+            ],
+        ]);
     }
 
     private function resolveRepository(WebhookDelivery $delivery): ?Repository
@@ -151,12 +216,12 @@ class WorkflowRunWebhookHandler
      *
      * @param  array<string, mixed>  $run
      */
-    private function upsertWorkflowRun(Repository $repository, array $run): void
+    private function upsertWorkflowRun(Repository $repository, array $run): ?WorkflowRun
     {
         $normalized = $this->normalizer->execute($run);
 
         if ($normalized === null) {
-            return;
+            return null;
         }
 
         $workflowRun = WorkflowRun::query()->updateOrCreate(
@@ -179,6 +244,8 @@ class WorkflowRunWebhookHandler
             $workflowRun->repository_id,
             $ownerUserId,
         );
+
+        return $workflowRun;
     }
 
     private function occurredAt(array $run): Carbon

--- a/app/Domain/Monitoring/Actions/RecordWebsiteCheckAction.php
+++ b/app/Domain/Monitoring/Actions/RecordWebsiteCheckAction.php
@@ -3,8 +3,12 @@
 namespace App\Domain\Monitoring\Actions;
 
 use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Domain\Alerts\Actions\ResolveAlertAction;
+use App\Domain\Alerts\Actions\TriggerAlertAction;
 use App\Domain\Monitoring\Probes\WebsiteProbeResult;
 use App\Enums\ActivitySeverity;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
 use App\Enums\WebsiteCheckStatus;
 use App\Enums\WebsiteStatus;
 use App\Events\WebsiteCheckRecorded;
@@ -47,6 +51,8 @@ class RecordWebsiteCheckAction
 {
     public function __construct(
         private readonly CreateActivityEventAction $createActivity,
+        private readonly TriggerAlertAction $triggerAlert,
+        private readonly ResolveAlertAction $resolveAlert,
     ) {}
 
     public function execute(Website $website, WebsiteProbeResult $result): WebsiteCheck
@@ -142,6 +148,26 @@ class RecordWebsiteCheckAction
                 ],
             ]);
 
+            // Spec 030 — promote the transition into a durable Alert.
+            // Idempotent on (source, source_id, type) so re-entering
+            // the failed bucket via a different status (Down vs Error)
+            // bumps `last_seen_at` on the existing alert instead of
+            // duplicating.
+            $this->triggerAlert->execute([
+                'project_id' => $website->project_id,
+                'source' => AlertSource::Website,
+                'source_id' => $website->id,
+                'type' => 'website.down',
+                'severity' => AlertSeverity::Critical,
+                'title' => "{$website->name} went down",
+                'description' => $this->failureDescription($result),
+                'metadata' => [
+                    'url' => $website->url,
+                    'http_status_code' => $result->httpStatusCode,
+                    'error_message' => $result->errorMessage,
+                ],
+            ]);
+
             return;
         }
 
@@ -161,6 +187,14 @@ class RecordWebsiteCheckAction
                 'http_status_code' => $result->httpStatusCode,
                 'response_time_ms' => $result->responseTimeMs,
             ],
+        ]);
+
+        // Spec 030 — close any open/acknowledged Alert for this
+        // website. No-op when nothing's open (eg. a recovery that
+        // beat the alert pipeline).
+        $this->resolveAlert->execute([
+            'source' => AlertSource::Website,
+            'source_id' => $website->id,
         ]);
     }
 

--- a/app/Enums/AlertSeverity.php
+++ b/app/Enums/AlertSeverity.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Severity rung of an Alert (spec 030). Matches roadmap §8.12.
+ *
+ * Tones map to `StatusBadge`:
+ *   info     → info
+ *   warning  → warning
+ *   critical → danger
+ *
+ * Activity-event severity maps similarly: `critical` Alerts surface as
+ * `ActivitySeverity::Danger` on the rail.
+ */
+enum AlertSeverity: string
+{
+    case Info = 'info';
+    case Warning = 'warning';
+    case Critical = 'critical';
+
+    public function badgeTone(): string
+    {
+        return match ($this) {
+            self::Info => 'info',
+            self::Warning => 'warning',
+            self::Critical => 'danger',
+        };
+    }
+
+    public function toActivitySeverity(): ActivitySeverity
+    {
+        return match ($this) {
+            self::Info => ActivitySeverity::Info,
+            self::Warning => ActivitySeverity::Warning,
+            self::Critical => ActivitySeverity::Danger,
+        };
+    }
+}

--- a/app/Enums/AlertSource.php
+++ b/app/Enums/AlertSource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Origin domain of an Alert (spec 030). Matches roadmap §8.12.
+ *
+ * Spec 030 only emits `website` / `docker` / `deployment`; `github` is
+ * reserved for future repo-scoped alerts (stale PR, merge conflict);
+ * `manual` is the user-pressed-the-button path; `system` is for Nexus's
+ * own self-checks.
+ *
+ * `source_id` points into the corresponding domain table:
+ *   website     → websites.id
+ *   docker      → hosts.id
+ *   deployment  → workflow_runs.id
+ *   github      → repositories.id
+ *   manual      → null
+ *   system      → null
+ */
+enum AlertSource: string
+{
+    case Website = 'website';
+    case Docker = 'docker';
+    case Deployment = 'deployment';
+    case Github = 'github';
+    case Manual = 'manual';
+    case System = 'system';
+}

--- a/app/Enums/AlertStatus.php
+++ b/app/Enums/AlertStatus.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Lifecycle of an Alert (spec 030).
+ *
+ * - `open`         — fresh trigger, awaiting human action or recovery.
+ * - `acknowledged` — a user said "I see it" but hasn't fixed it yet.
+ *                    Auto-recovery still closes the row.
+ * - `resolved`     — closed, either by `ResolveAlertAction` (recovery
+ *                    event) or by the user clicking Resolve in 031.
+ * - `muted`        — the user opted out of further surfacing for this
+ *                    specific row. Future triggers for the same
+ *                    `(source, source_id, type)` will still create a
+ *                    fresh open Alert.
+ */
+enum AlertStatus: string
+{
+    case Open = 'open';
+    case Acknowledged = 'acknowledged';
+    case Resolved = 'resolved';
+    case Muted = 'muted';
+}

--- a/app/Events/ActivityEventCreated.php
+++ b/app/Events/ActivityEventCreated.php
@@ -4,6 +4,7 @@ namespace App\Events;
 
 use App\Domain\Activity\ActivityEventPresenter;
 use App\Models\ActivityEvent;
+use App\Models\Alert;
 use App\Models\Host;
 use App\Models\Website;
 use Illuminate\Broadcasting\InteractsWithSockets;
@@ -37,7 +38,7 @@ class ActivityEventCreated implements ShouldBroadcastNow, ShouldDispatchAfterCom
      * Broadcast on the project owner's private activity channel.
      * `users.{userId}.activity` is authorized in `routes/channels.php`.
      *
-     * Three scoping paths:
+     * Four scoping paths:
      *   1. **Repo-scoped events** (spec 017's webhook handlers,
      *      spec 020's deployments) — channel resolves through
      *      `repository → project → owner_user_id`.
@@ -47,6 +48,9 @@ class ActivityEventCreated implements ShouldBroadcastNow, ShouldDispatchAfterCom
      *   3. **Hosts-scoped events** (spec 029 — `source: hosts`,
      *      `repository_id` is null) — channel resolves through
      *      `metadata.host_id → host → project → owner_user_id`.
+     *   4. **Alerts-scoped events** (spec 030 — `source: alerts`,
+     *      `repository_id` is null) — channel resolves through
+     *      `metadata.alert_id → alert → project → owner_user_id`.
      *
      * If neither path resolves to an owner the broadcast no-ops; the
      * row still exists in the DB, and `RecentActivityForUserQuery`
@@ -108,6 +112,20 @@ class ActivityEventCreated implements ShouldBroadcastNow, ShouldDispatchAfterCom
             $host = Host::query()->find($hostId);
 
             return $host?->project?->owner_user_id;
+        }
+
+        // Alerts-scoped path (spec 030).
+        if ($this->activityEvent->source === 'alerts') {
+            $metadata = $this->activityEvent->metadata ?? [];
+            $alertId = $metadata['alert_id'] ?? null;
+
+            if ($alertId === null) {
+                return null;
+            }
+
+            $alert = Alert::query()->find($alertId);
+
+            return $alert?->project?->owner_user_id;
         }
 
         return null;

--- a/app/Models/Alert.php
+++ b/app/Models/Alert.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
+use Database\Factories\AlertFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Alert extends Model
+{
+    /** @use HasFactory<AlertFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'project_id',
+        'source',
+        'source_id',
+        'type',
+        'severity',
+        'status',
+        'title',
+        'description',
+        'triggered_at',
+        'acknowledged_at',
+        'resolved_at',
+        'last_seen_at',
+        'metadata',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'source' => AlertSource::class,
+            'severity' => AlertSeverity::class,
+            'status' => AlertStatus::class,
+            'triggered_at' => 'datetime',
+            'acknowledged_at' => 'datetime',
+            'resolved_at' => 'datetime',
+            'last_seen_at' => 'datetime',
+            'metadata' => 'array',
+        ];
+    }
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+}

--- a/app/Policies/AlertPolicy.php
+++ b/app/Policies/AlertPolicy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Alert;
+use App\Models\User;
+
+/**
+ * Mirrors `HostPolicy` / `WebsitePolicy`: viewing is open to any
+ * verified user (single-tenant phase-1; query scoping handles
+ * row-level isolation), update / delete are gated to the project owner.
+ *
+ * The `update` gate covers all three lifecycle verbs — acknowledge,
+ * resolve, and mute — since the 031 UI maps each button to an
+ * `update`-class controller action.
+ */
+class AlertPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->hasVerifiedEmail();
+    }
+
+    public function view(User $user, Alert $alert): bool
+    {
+        return $user->hasVerifiedEmail();
+    }
+
+    public function update(User $user, Alert $alert): bool
+    {
+        $project = $alert->project;
+
+        return $project !== null
+            && $user->hasVerifiedEmail()
+            && $user->can('update', $project);
+    }
+
+    public function delete(User $user, Alert $alert): bool
+    {
+        return $this->update($user, $alert);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,11 +3,13 @@
 namespace App\Providers;
 
 use App\Models\AgentToken;
+use App\Models\Alert;
 use App\Models\Host;
 use App\Models\Project;
 use App\Models\Repository;
 use App\Models\Website;
 use App\Policies\AgentTokenPolicy;
+use App\Policies\AlertPolicy;
 use App\Policies\HostPolicy;
 use App\Policies\ProjectPolicy;
 use App\Policies\RepositoryPolicy;
@@ -39,6 +41,7 @@ class AppServiceProvider extends ServiceProvider
         Gate::policy(Website::class, WebsitePolicy::class);
         Gate::policy(Host::class, HostPolicy::class);
         Gate::policy(AgentToken::class, AgentTokenPolicy::class);
+        Gate::policy(Alert::class, AlertPolicy::class);
 
         // Per-token rate limiting on `/agent/telemetry` lives inside
         // `AuthenticateAgent` middleware (spec 027). Keeping it there

--- a/database/factories/AlertFactory.php
+++ b/database/factories/AlertFactory.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
+use App\Models\Alert;
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<Alert> */
+class AlertFactory extends Factory
+{
+    protected $model = Alert::class;
+
+    public function definition(): array
+    {
+        $triggeredAt = now()->subMinutes(fake()->numberBetween(0, 30));
+
+        return [
+            'project_id' => Project::factory(),
+            'source' => AlertSource::Website->value,
+            'source_id' => fake()->numberBetween(1, 1000),
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+            'title' => 'Marketing site went down',
+            'description' => 'GET / returned 500 in 1234ms',
+            'triggered_at' => $triggeredAt,
+            'acknowledged_at' => null,
+            'resolved_at' => null,
+            'last_seen_at' => $triggeredAt,
+            'metadata' => null,
+        ];
+    }
+
+    public function acknowledged(): static
+    {
+        return $this->state(fn () => [
+            'status' => AlertStatus::Acknowledged->value,
+            'acknowledged_at' => now(),
+        ]);
+    }
+
+    public function resolved(): static
+    {
+        return $this->state(fn () => [
+            'status' => AlertStatus::Resolved->value,
+            'resolved_at' => now(),
+        ]);
+    }
+
+    public function muted(): static
+    {
+        return $this->state(fn () => [
+            'status' => AlertStatus::Muted->value,
+        ]);
+    }
+
+    public function forHost(): static
+    {
+        return $this->state(fn () => [
+            'source' => AlertSource::Docker->value,
+            'type' => 'host.offline',
+            'title' => 'prod-frankfurt-01 went offline',
+            'description' => 'No telemetry in 120s',
+        ]);
+    }
+
+    public function forWorkflowRun(): static
+    {
+        return $this->state(fn () => [
+            'source' => AlertSource::Deployment->value,
+            'severity' => AlertSeverity::Warning->value,
+            'type' => 'workflow.failed',
+            'title' => 'Workflow failed on main',
+            'description' => 'CI run #421 failed',
+        ]);
+    }
+}

--- a/database/migrations/2026_05_27_080000_create_alerts_table.php
+++ b/database/migrations/2026_05_27_080000_create_alerts_table.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('alerts', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('project_id')
+                ->constrained('projects')
+                ->cascadeOnDelete();
+
+            // website | docker | deployment | github | manual | system
+            // (per AlertSource enum, subset of roadmap §8.12). `github` is
+            // reserved for future repo-scoped alerts; spec 030 only
+            // emits website / docker / deployment.
+            $table->string('source', 16);
+
+            // FK target depends on `source` (a Website / Host / WorkflowRun
+            // id, respectively). Nullable so `manual` and `system`
+            // alerts — emitted by a human or a self-check, with no
+            // domain row to point at — fit the same table.
+            $table->unsignedBigInteger('source_id')->nullable();
+
+            // Discriminator that pairs with `source` / `source_id` for
+            // idempotency. Matches our activity-event vocabulary
+            // ('website.down', 'host.offline', 'workflow.failed', …).
+            $table->string('type', 64);
+
+            // info | warning | critical (per AlertSeverity enum). Maps
+            // 1:1 to ActivitySeverity for the rail.
+            $table->string('severity', 16);
+
+            // open | acknowledged | resolved | muted (per AlertStatus
+            // enum). The Trigger action only opens; Resolve closes; the
+            // 031 UI flips between the four.
+            $table->string('status', 16)->default('open');
+
+            $table->string('title');
+            $table->text('description')->nullable();
+
+            $table->timestamp('triggered_at');
+            $table->timestamp('acknowledged_at')->nullable();
+            $table->timestamp('resolved_at')->nullable();
+
+            // Bumped on every repeat trigger so the UI can show "still
+            // firing 5 minutes later" without proliferating rows.
+            $table->timestamp('last_seen_at');
+
+            // Free-form bag — url, http_status, error_message for
+            // websites; threshold_seconds for hosts; branch + run_id
+            // for deployments. Read by the 031 UI's drill-down.
+            $table->json('metadata')->nullable();
+
+            $table->timestamps();
+
+            // Idempotency lookup in TriggerAlertAction — find the open
+            // or acknowledged row for (source, source_id, type).
+            $table->index(['status', 'source', 'source_id']);
+            // Index-page filters in 031.
+            $table->index(['project_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('alerts');
+    }
+};

--- a/specs/README.md
+++ b/specs/README.md
@@ -42,7 +42,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 4 | Deployments & CI/CD | 🟢 | 3/3 specs done (020–022). Phase complete. |
 | 5 | Website Monitoring | 🟢 | 3/3 specs done (023–025). Phase complete. |
 | 6 | Docker Host Agent MVP | 🟢 | 4/4 specs done (026–029). Phase complete. |
-| 7 | Alerts Engine | 🟡 | 0/3 specs done (030–032). Scoped. |
+| 7 | Alerts Engine | 🟡 | 1/3 specs done (030–032). 030 shipped. |
 | 8 | Analytics & Health Scores | ⬜ | — |
 | 9 | Polish & Production Readiness | ⬜ | — |
 | 10 | Future Innovation | ⬜ | — |

--- a/specs/README.md
+++ b/specs/README.md
@@ -42,7 +42,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 4 | Deployments & CI/CD | 🟢 | 3/3 specs done (020–022). Phase complete. |
 | 5 | Website Monitoring | 🟢 | 3/3 specs done (023–025). Phase complete. |
 | 6 | Docker Host Agent MVP | 🟢 | 4/4 specs done (026–029). Phase complete. |
-| 7 | Alerts Engine | ⬜ | — |
+| 7 | Alerts Engine | 🟡 | 0/3 specs done (030–032). Scoped. |
 | 8 | Analytics & Health Scores | ⬜ | — |
 | 9 | Polish & Production Readiness | ⬜ | — |
 | 10 | Future Innovation | ⬜ | — |

--- a/specs/phase-7-alerts/030-alerts-scaffolding.md
+++ b/specs/phase-7-alerts/030-alerts-scaffolding.md
@@ -1,7 +1,7 @@
 ---
 spec: alerts-scaffolding
 phase: 7
-status: in-progress   # not-started | in-progress | blocked | done
+status: done   # not-started | in-progress | blocked | done
 owner: Yoany
 created: 2026-05-26
 updated: 2026-05-27
@@ -298,28 +298,28 @@ statuses + severities, §6.2 Action class pattern.
     test in `ActivityEventCreatedBroadcastTest`).
 
 ## Acceptance criteria
-- [ ] `alerts` migration applies cleanly on a fresh DB and rolls back.
-- [ ] `Alert` factory + policy work in tinker / tests.
-- [ ] A website's healthy → failed transition creates an open `Alert` with
+- [x] `alerts` migration applies cleanly on a fresh DB and rolls back.
+- [x] `Alert` factory + policy work in tinker / tests.
+- [x] A website's healthy → failed transition creates an open `Alert` with
       `severity: critical`, `source: website`, `source_id: website.id`,
       `type: website.down`.
-- [ ] The matching failed → healthy transition auto-resolves the open
+- [x] The matching failed → healthy transition auto-resolves the open
       Alert and emits an `alert.resolved` activity event.
-- [ ] A host going offline (`DetectOfflineHostsAction` flip) creates one
+- [x] A host going offline (`DetectOfflineHostsAction` flip) creates one
       open Alert with `severity: critical`, `source: docker`.
-- [ ] First telemetry after offline (`IngestHostTelemetryAction` recovery
+- [x] First telemetry after offline (`IngestHostTelemetryAction` recovery
       branch) auto-resolves the open host Alert.
-- [ ] A `workflow.failed` webhook for a run on the default branch creates
+- [x] A `workflow.failed` webhook for a run on the default branch creates
       an open Alert with `severity: warning`, `source: deployment`. The
       same handler does NOT create an Alert for a feature-branch failure.
-- [ ] A second identical `Trigger` call within the open window bumps
+- [x] A second identical `Trigger` call within the open window bumps
       `last_seen_at` and returns the same row — no duplicate Alert, no
       second activity event.
-- [ ] `ResolveAlertAction` is a no-op when no matching open Alert exists.
-- [ ] `ActivityEventCreated` routes `source: alerts` rows to the alert's
+- [x] `ResolveAlertAction` is a no-op when no matching open Alert exists.
+- [x] `ActivityEventCreated` routes `source: alerts` rows to the alert's
       project owner's `users.{id}.activity` channel; unknown alert_id
       short-circuits to no channels.
-- [ ] Pint clean, `php artisan test` green (new tests added), `npm run
+- [x] Pint clean, `php artisan test` green (new tests added), `npm run
       build` clean.
 
 ## Files touched
@@ -356,6 +356,10 @@ Fill in as work progresses.
 ### 2026-05-27
 - Shipping as drafted (all three open-question choices stay: workflow.failed at `warning`, default-branch-only filter, ack→resolve auto-promotion on recovery).
 - Issue [#89](https://github.com/Copxer/nexus/issues/89) opened, branch `spec/030-alerts-scaffolding` cut off `main`. Phase 7 folder created.
+- Backend: alerts migration + Alert model + 3 enums + factory + AlertPolicy + 2 actions; `ActivityEventCreated` extended with `source: alerts` branch.
+- Wired 4 promotion call sites (RecordWebsiteCheckAction, DetectOfflineHostsAction, IngestHostTelemetryAction, WorkflowRunWebhookHandler) to Trigger/Resolve alongside their existing activity events.
+- Tests: 20 new (action-level + integration + broadcast routing). Full suite 507→527 green, Pint clean, build clean.
+- Self-review via `superpowers:code-reviewer`. Addressed: (1) gated the workflow alert filter on the **raw** `head_branch` payload value instead of the display fallback — a malformed delivery missing the field no longer accidentally trips the default-branch match; added a regression test. (2) Documented the no-unique-index idempotency caveat in `TriggerAlertAction`'s docblock. (3) Added a `muted alerts are left alone on resolve` test to pin the load-bearing user-opt-out invariant.
 
 ## Open questions / blockers
 - **`workflow.failed` severity.** 030 ships `warning`. Some teams treat a

--- a/specs/phase-7-alerts/030-alerts-scaffolding.md
+++ b/specs/phase-7-alerts/030-alerts-scaffolding.md
@@ -1,0 +1,379 @@
+---
+spec: alerts-scaffolding
+phase: 7
+status: in-progress   # not-started | in-progress | blocked | done
+owner: Yoany
+created: 2026-05-26
+updated: 2026-05-27
+---
+
+# 030 — Alerts scaffolding + transition-based promotion
+
+## Goal
+Lay the data + promotion layer for Phase 7. Adds the `alerts` table, the
+`Alert` model + policy, three enums, and two actions (`TriggerAlertAction`,
+`ResolveAlertAction`). Then wires the existing transition emitters
+(`website.down` / `website.up`, `host.offline` / `host.recovered`,
+`workflow.failed`) to also promote into `alerts` rows. No UI yet — that
+lands in 031. After 030, every transition that would have produced an
+activity row also produces a durable, acknowledgeable alert that future
+specs can render and act on.
+
+Roadmap refs: §Phase 7 acceptance criteria ("Website down / Failed
+deployment / Host offline creates alert"), §8.12 Alerts fields + sources +
+statuses + severities, §6.2 Action class pattern.
+
+## Scope
+
+**In scope:**
+
+- **Data layer.**
+  - Migration `create_alerts_table` with the fields per roadmap §8.12,
+    minus `team_id` (phase-1 is single-tenant, no `teams` table exists
+    yet). Composite indexes on `(status, source, source_id)` (idempotency
+    lookups) and `(project_id, status)` (index-page filtering).
+  - `app/Models/Alert.php` — belongsTo Project, casts (status, severity,
+    source enums; `triggered_at`/`acknowledged_at`/`resolved_at`/`last_seen_at`
+    datetime; `metadata` array).
+  - `database/factories/AlertFactory.php`.
+  - `app/Policies/AlertPolicy.php` — `viewAny` / `view` / `update`
+    (acknowledge / resolve / mute) / `delete` tied to project ownership,
+    mirrors `HostPolicy` / `WebsitePolicy`.
+  - Register in `AppServiceProvider::boot()` next to the existing
+    `HostPolicy` registration.
+
+- **Enums.**
+  - `app/Enums/AlertStatus.php` — `open | acknowledged | resolved | muted`.
+  - `app/Enums/AlertSeverity.php` — `info | warning | critical`.
+    Includes `badgeTone()` returning `'info' | 'warning' | 'danger'` for
+    `StatusBadge` consumption (critical → danger).
+  - `app/Enums/AlertSource.php` — `website | docker | deployment | github
+    | manual | system`. Subset of roadmap §8.12; `github` reserved for
+    future repo-scoped alerts not promoted in this spec.
+
+- **Actions.**
+  - `app/Domain/Alerts/Actions/TriggerAlertAction.php` — idempotent:
+    queries for an existing `Alert` matching `(source, source_id, type,
+    status IN [open, acknowledged])`. If found, bumps `last_seen_at` and
+    returns the same row (no duplicate, no second activity event). If
+    not, inserts a new `Alert` with `status: open`, then emits an
+    `alert.triggered` activity event via `CreateActivityEventAction`.
+  - `app/Domain/Alerts/Actions/ResolveAlertAction.php` — closes every
+    open or acknowledged `Alert` matching `(source, source_id[, type])`:
+    sets `status: resolved`, stamps `resolved_at`, bumps `last_seen_at`.
+    For each closed row, emits an `alert.resolved` activity event. Returns
+    the count for the caller's logs.
+
+- **Activity routing.** Extend `ActivityEventCreated::broadcastOn()` with
+  a fourth branch resolving `source: alerts` events via
+  `metadata.alert_id → alert → project → owner_user_id`. Mirrors the
+  spec-029 hosts branch line-for-line.
+
+- **Promotion call sites.** Four existing places gain a Trigger / Resolve
+  call alongside the activity event they already emit:
+  - **`RecordWebsiteCheckAction`** (spec 024 — healthy→failed transition):
+    after the existing `website.down` activity event, call
+    `TriggerAlertAction(source: website, source_id: website.id, project_id:
+    website.project_id, type: 'website.down', severity: critical, title:
+    "{name} went down", description: failure summary, metadata: {url,
+    http_status_code, error_message})`. On the failed→healthy transition,
+    after the `website.up` activity event, call
+    `ResolveAlertAction(source: website, source_id: website.id)`.
+  - **`DetectOfflineHostsAction`** (spec 029): after the `host.offline`
+    activity event, call `TriggerAlertAction(source: docker, source_id:
+    host.id, project_id: host.project_id, type: 'host.offline', severity:
+    critical, title: "{name} went offline", description: "No telemetry in
+    {N}s", metadata: {last_seen_at, threshold_seconds})`.
+  - **`IngestHostTelemetryAction`** (spec 029): after the
+    `host.recovered` activity event (the explicit offline→online branch),
+    call `ResolveAlertAction(source: docker, source_id: host.id)`.
+  - **`WorkflowRunWebhookHandler`** (spec 019/020): on a `workflow.failed`
+    handler, **only when `run.head_branch === run.repository.default_branch`**,
+    call `TriggerAlertAction(source: deployment, source_id: run.id,
+    project_id: run.repository.project_id, type: 'workflow.failed',
+    severity: warning, title: "Workflow failed on {branch}", description:
+    workflow name + actor, metadata: {run_id, branch, actor, html_url})`.
+    No auto-resolve — each failed run is its own alert, the user marks
+    them resolved manually (031).
+
+- **Tests.**
+  - **Action-level** (`tests/Unit/Domain/Alerts/`): TriggerAlert happy
+    path inserts row + emits activity; idempotency (second identical
+    call returns same row, bumps `last_seen_at`, doesn't emit a second
+    activity); ResolveAlert closes open and acknowledged rows; ResolveAlert
+    is a no-op when nothing open matches (no spurious activity event);
+    source/type discrimination (two alerts with the same source_id but
+    different types coexist).
+  - **Integration** (extend existing test files): `RecordWebsiteCheckActionTest`
+    proves website-down creates an Alert and website-up auto-resolves it;
+    `DetectOfflineHostsActionTest` proves the offline flip creates an
+    Alert; `IngestHostTelemetryActionTest` proves the recovery transition
+    resolves the open host Alert; `WorkflowRunWebhookHandlerTest` proves a
+    failed main-branch run creates an Alert and a failed feature-branch
+    run does not.
+  - **Broadcast routing** (extend `ActivityEventCreatedBroadcastTest`):
+    `source: alerts` row with `metadata.alert_id` resolves to
+    `users.{owner}.activity`; orphan alert short-circuits to no channels.
+
+**Out of scope:**
+
+- The `/alerts` page UI, filters, severity badges, the "link to affected
+  entity" CTA — **031**.
+- Acknowledge / resolve / mute controllers + buttons — **031**.
+- A dedicated `AlertTriggered` / `AlertResolved` broadcast event +
+  `users.{id}.alerts` Reverb channel — **032**. Realtime visibility in
+  this spec rides on the existing activity rail (the `alert.triggered` /
+  `alert.resolved` activity events broadcast on `users.{id}.activity`
+  through the new `source: alerts` branch).
+- Overview Alerts KPI wiring — **032** (still on `MOCK_KPIS.alerts`
+  after this spec).
+- User-defined `AlertRule` model + `EvaluateAlertRulesJob` against raw
+  metrics — deferred (roadmap §6.8, Phase 7 closes phase 8/9 polish).
+- Outbound notifications (`AlertNotificationService`) — deferred.
+- The `github` alert source (repo-scoped alerts like "stale PR",
+  "merge conflict") — column accepted, no emitters in this spec.
+- Mute-by-source / mute-by-project — only per-alert mute exists in 031.
+- `team_id` column — phase-1 has no `teams` table; revisit with the
+  multi-tenant migration.
+
+## Plan
+
+1. **Migration.** `create_alerts_table`:
+   ```php
+   Schema::create('alerts', function (Blueprint $table) {
+       $table->id();
+       $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+       $table->string('source', 32);          // AlertSource enum
+       $table->unsignedBigInteger('source_id')->nullable();
+       $table->string('type', 64);            // 'website.down', 'host.offline', ...
+       $table->string('severity', 16);        // AlertSeverity enum
+       $table->string('status', 16)->default('open'); // AlertStatus enum
+       $table->string('title');
+       $table->text('description')->nullable();
+       $table->timestamp('triggered_at');
+       $table->timestamp('acknowledged_at')->nullable();
+       $table->timestamp('resolved_at')->nullable();
+       $table->timestamp('last_seen_at');
+       $table->json('metadata')->nullable();
+       $table->timestamps();
+
+       $table->index(['status', 'source', 'source_id']); // idempotency lookups
+       $table->index(['project_id', 'status']);          // index-page filters
+   });
+   ```
+
+2. **Enums.** Three string-backed enums; `AlertSeverity::badgeTone()`
+   matches `WebsiteStatus::badgeTone()` shape: `critical → 'danger'`,
+   `warning → 'warning'`, `info → 'info'`.
+
+3. **Model.** `Alert` with the seven enum / datetime casts and
+   `belongsTo(Project::class)`. `metadata` cast `array`.
+
+4. **Factory.** `AlertFactory::definition()` returns a sensible default
+   open critical website-down alert; states for `acknowledged()`,
+   `resolved()`, `muted()`, `forHost()`, `forWorkflowRun()`.
+
+5. **Policy.** `AlertPolicy` mirrors `WebsitePolicy` shape: `viewAny`
+   permits any verified user (rows scoped by project ownership at query
+   level); `view` / `update` (the verb used for ack / resolve / mute) /
+   `delete` require `$alert->project->owner_user_id === $user->id`.
+
+6. **`TriggerAlertAction`.** Constructor injects
+   `CreateActivityEventAction`. `execute(array $attrs): Alert`:
+   ```php
+   $existing = Alert::query()
+       ->where('source', $attrs['source'])
+       ->where('source_id', $attrs['source_id'])
+       ->where('type', $attrs['type'])
+       ->whereIn('status', [AlertStatus::Open->value, AlertStatus::Acknowledged->value])
+       ->first();
+
+   if ($existing) {
+       $existing->forceFill(['last_seen_at' => now()])->save();
+       return $existing;
+   }
+
+   $alert = Alert::query()->create([
+       /* …project_id, source, source_id, type, severity, status: open,
+            title, description, triggered_at: now, last_seen_at: now,
+            metadata… */
+   ]);
+
+   $this->createActivity->execute([
+       'event_type' => 'alert.triggered',
+       'severity'   => $alert->severity->toActivitySeverity(),
+       'title'      => $alert->title,
+       'description' => $alert->description,
+       'occurred_at' => $alert->triggered_at,
+       'source'     => 'alerts',
+       'metadata'   => [
+           'alert_id'        => $alert->id,
+           'alert_source'    => $alert->source->value,
+           'alert_source_id' => $alert->source_id,
+           'alert_type'      => $alert->type,
+       ],
+   ]);
+
+   return $alert;
+   ```
+   `AlertSeverity::toActivitySeverity()` returns the matching
+   `ActivitySeverity` case: `critical → Danger`, `warning → Warning`,
+   `info → Info`. Cheap method on the enum.
+
+7. **`ResolveAlertAction`.** `execute(array $criteria): int`:
+   ```php
+   $query = Alert::query()
+       ->where('source', $criteria['source'])
+       ->where('source_id', $criteria['source_id'])
+       ->whereIn('status', [AlertStatus::Open->value, AlertStatus::Acknowledged->value]);
+
+   if (isset($criteria['type'])) {
+       $query->where('type', $criteria['type']);
+   }
+
+   $resolving = $query->get();
+   $now = now();
+
+   foreach ($resolving as $alert) {
+       $alert->forceFill([
+           'status'        => AlertStatus::Resolved->value,
+           'resolved_at'   => $now,
+           'last_seen_at'  => $now,
+       ])->save();
+
+       $this->createActivity->execute([
+           'event_type'  => 'alert.resolved',
+           'severity'    => ActivitySeverity::Success,
+           'title'       => "{$alert->title} resolved",
+           'occurred_at' => $now,
+           'source'      => 'alerts',
+           'metadata'    => [
+               'alert_id'        => $alert->id,
+               'alert_source'    => $alert->source->value,
+               'alert_source_id' => $alert->source_id,
+           ],
+       ]);
+   }
+
+   return $resolving->count();
+   ```
+   No-op when the result set is empty — neither row update nor activity
+   event fires.
+
+8. **`ActivityEventCreated::broadcastOn` extension.** Add a fourth branch:
+   ```php
+   if ($this->activityEvent->source === 'alerts') {
+       $alertId = $metadata['alert_id'] ?? null;
+       if ($alertId === null) return null;
+       $alert = Alert::query()->find($alertId);
+       return $alert?->project?->owner_user_id;
+   }
+   ```
+
+9. **Promotion call sites — extend four existing files.**
+   - `app/Domain/Monitoring/Actions/RecordWebsiteCheckAction.php` — inject
+     `TriggerAlertAction` + `ResolveAlertAction`. In the failed branch
+     (after the existing `website.down` activity event), call
+     `$this->trigger->execute(['source' => 'website', 'source_id' =>
+     $website->id, 'project_id' => $website->project_id, 'type' =>
+     'website.down', 'severity' => AlertSeverity::Critical, …])`. In the
+     recovery branch, `$this->resolve->execute(['source' => 'website',
+     'source_id' => $website->id])`.
+   - `app/Domain/Docker/Actions/DetectOfflineHostsAction.php` — inject
+     `TriggerAlertAction`. After the `host.offline` activity event call,
+     trigger with `source: docker, source_id: host.id`.
+   - `app/Domain/Docker/Actions/IngestHostTelemetryAction.php` — inject
+     `ResolveAlertAction`. In the existing `if ($wasOffline)` branch,
+     after the recovery activity event, call resolve with `source:
+     docker, source_id: host.id`.
+   - `app/Domain/GitHub/WebhookHandlers/WorkflowRunWebhookHandler.php` —
+     inject `TriggerAlertAction`. After persisting the `workflow.failed`
+     row, if `$run->head_branch === $run->repository->default_branch`,
+     trigger with `source: deployment, source_id: run.id`.
+
+10. **Tests.** Files touched + new files listed below. Use the
+    spec-024 / spec-029 conventions: assert on `alerts` table rows
+    directly, use `Event::fake([ActivityEventCreated::class])` only when
+    the test specifically cares about broadcast dispatch (the routing
+    test in `ActivityEventCreatedBroadcastTest`).
+
+## Acceptance criteria
+- [ ] `alerts` migration applies cleanly on a fresh DB and rolls back.
+- [ ] `Alert` factory + policy work in tinker / tests.
+- [ ] A website's healthy → failed transition creates an open `Alert` with
+      `severity: critical`, `source: website`, `source_id: website.id`,
+      `type: website.down`.
+- [ ] The matching failed → healthy transition auto-resolves the open
+      Alert and emits an `alert.resolved` activity event.
+- [ ] A host going offline (`DetectOfflineHostsAction` flip) creates one
+      open Alert with `severity: critical`, `source: docker`.
+- [ ] First telemetry after offline (`IngestHostTelemetryAction` recovery
+      branch) auto-resolves the open host Alert.
+- [ ] A `workflow.failed` webhook for a run on the default branch creates
+      an open Alert with `severity: warning`, `source: deployment`. The
+      same handler does NOT create an Alert for a feature-branch failure.
+- [ ] A second identical `Trigger` call within the open window bumps
+      `last_seen_at` and returns the same row — no duplicate Alert, no
+      second activity event.
+- [ ] `ResolveAlertAction` is a no-op when no matching open Alert exists.
+- [ ] `ActivityEventCreated` routes `source: alerts` rows to the alert's
+      project owner's `users.{id}.activity` channel; unknown alert_id
+      short-circuits to no channels.
+- [ ] Pint clean, `php artisan test` green (new tests added), `npm run
+      build` clean.
+
+## Files touched
+Fill in as work progresses.
+
+- `database/migrations/{ts}_create_alerts_table.php` — new
+- `app/Models/Alert.php` — new
+- `app/Enums/AlertStatus.php` — new
+- `app/Enums/AlertSeverity.php` — new
+- `app/Enums/AlertSource.php` — new
+- `database/factories/AlertFactory.php` — new
+- `app/Policies/AlertPolicy.php` — new
+- `app/Providers/AppServiceProvider.php` — register `AlertPolicy`
+- `app/Domain/Alerts/Actions/TriggerAlertAction.php` — new
+- `app/Domain/Alerts/Actions/ResolveAlertAction.php` — new
+- `app/Events/ActivityEventCreated.php` — `source: alerts` branch
+- `app/Domain/Monitoring/Actions/RecordWebsiteCheckAction.php` — Trigger / Resolve
+- `app/Domain/Docker/Actions/DetectOfflineHostsAction.php` — Trigger
+- `app/Domain/Docker/Actions/IngestHostTelemetryAction.php` — Resolve
+- `app/Domain/GitHub/WebhookHandlers/WorkflowRunWebhookHandler.php` — Trigger (default-branch only)
+- `tests/Unit/Domain/Alerts/TriggerAlertActionTest.php` — new
+- `tests/Unit/Domain/Alerts/ResolveAlertActionTest.php` — new
+- `tests/Feature/Monitoring/RecordWebsiteCheckActionTest.php` — extend
+- `tests/Unit/Domain/Docker/DetectOfflineHostsActionTest.php` — extend
+- `tests/Unit/Domain/Docker/IngestHostTelemetryActionTest.php` — extend
+- `tests/Feature/GitHub/WorkflowRunWebhookHandlerTest.php` — extend (or new file if absent)
+- `tests/Feature/Activity/ActivityEventCreatedBroadcastTest.php` — extend (alerts source)
+
+## Work log
+
+### 2026-05-26
+- Spec drafted for review.
+
+### 2026-05-27
+- Shipping as drafted (all three open-question choices stay: workflow.failed at `warning`, default-branch-only filter, ack→resolve auto-promotion on recovery).
+- Issue [#89](https://github.com/Copxer/nexus/issues/89) opened, branch `spec/030-alerts-scaffolding` cut off `main`. Phase 7 folder created.
+
+## Open questions / blockers
+- **`workflow.failed` severity.** 030 ships `warning`. Some teams treat a
+  broken default branch as `critical` (especially when prod auto-deploys
+  off main). If you'd rather start at `critical`, swap the constant —
+  no schema change. The current call lets the user mark it `resolved` or
+  `muted` from the UI in 031 either way.
+- **Default-branch filter on workflow failures.** 030 only triggers
+  alerts for failed runs whose `head_branch` matches the repo's
+  `default_branch`. Branches like `staging` / `release/*` won't fire.
+  A future polish spec could add a per-repo "monitored branches"
+  allowlist; in MVP the default-branch filter keeps the rail signal-vs-noise
+  ratio reasonable.
+- **Acknowledged ≠ resolved.** `ResolveAlertAction` closes both `open`
+  and `acknowledged` rows (an acknowledged outage that recovers is still
+  resolved). If a user wants ack to "stick" through recovery, they can
+  mute instead. Decision: auto-resolution wins over manual ack — matches
+  the user's mental model of "this is fixed."
+- **`Alert.team_id`.** Roadmap §8.12 lists it; phase-1 has no `teams`
+  table. Column omitted — re-add as part of the eventual multi-tenant
+  migration.

--- a/specs/phase-7-alerts/README.md
+++ b/specs/phase-7-alerts/README.md
@@ -1,0 +1,46 @@
+# Phase 7 — Alerts Engine
+
+Source: [roadmap §Phase 7](../../nexus_control_center_roadmap.md), §8.12 Alerts, §6.8 Specification Pattern for Alerts.
+
+## Phase goal
+Durable, acknowledgeable alerts on top of the activity feed. The existing
+transition events (`website.down`, `host.offline`, `workflow.failed`) get
+promoted into `alerts` rows that the user can acknowledge / resolve / mute
+from a dedicated `/alerts` page. Recovery transitions auto-close the
+matching alert. Overview's Alerts KPI swaps from the long-standing
+`MOCK_KPIS.alerts` placeholder to real counts.
+
+## Tasks
+
+| # | Task | Status |
+|---|------|--------|
+| 030 | Alerts scaffolding + transition-based promotion (events → Alert rows) | ⬜ |
+| 031 | Alerts UI + acknowledge / resolve / mute actions | ⬜ |
+| 032 | Realtime updates + Overview Alerts KPI wiring (closes phase 7) | ⬜ |
+
+## Acceptance criteria (phase-level)
+- [ ] `website.down`, `host.offline`, and `workflow.failed` (on a default
+      branch) each create an Alert row with the right severity and source.
+- [ ] `website.up` / `host.recovered` auto-resolve the matching open alert;
+      workflow failures stay open until the user acts.
+- [ ] Same source + source_id firing twice within an open-alert window
+      bumps `last_seen_at` instead of duplicating (idempotency).
+- [ ] Sidebar `Alerts` entry is enabled and routed; Cmd+K `go-alerts` works.
+- [ ] User can acknowledge / resolve / mute an alert from `/alerts`.
+- [ ] Overview Alerts KPI reflects real active + critical counts (no
+      `MOCK_KPIS`).
+- [ ] Realtime updates land on `/alerts` (dedicated `users.{id}.alerts`
+      channel) and on the right-rail activity feed.
+- [ ] Pint clean, tests green, build clean. CI green for each spec PR.
+
+## Scope notes
+- **Transition-based MVP only.** Alerts in this phase are created by the
+  existing activity transitions. User-defined `AlertRule` rows + an
+  `EvaluateAlertRulesJob` against raw metrics (roadmap §6.8) are deferred
+  to a future polish spec — Phase 7's acceptance is purely event-driven.
+- **Out of scope here:** outbound notifications (email / Slack / webhook —
+  the roadmap's `AlertNotificationService`), mute-by-source / mute-by-project,
+  and alert grouping beyond the per-`(source, source_id, type)` idempotency.
+- The activity-rail vocabulary already includes `alert.triggered` and
+  `alert.resolved` (registered in `Components/Activity/ActivityFeedItem.vue`
+  during spec 026 / 027). Phase 7 fills in the events that emit them.

--- a/specs/phase-7-alerts/README.md
+++ b/specs/phase-7-alerts/README.md
@@ -14,7 +14,7 @@ matching alert. Overview's Alerts KPI swaps from the long-standing
 
 | # | Task | Status |
 |---|------|--------|
-| 030 | Alerts scaffolding + transition-based promotion (events → Alert rows) | ⬜ |
+| 030 | Alerts scaffolding + transition-based promotion (events → Alert rows) | 🟢 |
 | 031 | Alerts UI + acknowledge / resolve / mute actions | ⬜ |
 | 032 | Realtime updates + Overview Alerts KPI wiring (closes phase 7) | ⬜ |
 

--- a/tests/Feature/Activity/ActivityEventCreatedBroadcastTest.php
+++ b/tests/Feature/Activity/ActivityEventCreatedBroadcastTest.php
@@ -6,6 +6,7 @@ use App\Domain\Activity\Actions\CreateActivityEventAction;
 use App\Enums\ActivitySeverity;
 use App\Events\ActivityEventCreated;
 use App\Models\ActivityEvent;
+use App\Models\Alert;
 use App\Models\Host;
 use App\Models\Project;
 use App\Models\Repository;
@@ -141,6 +142,50 @@ class ActivityEventCreatedBroadcastTest extends TestCase
             'source' => 'hosts',
             'event_type' => 'host.offline',
             'metadata' => ['host_id' => 99999],
+        ]);
+
+        $this->assertSame([], (new ActivityEventCreated($row))->broadcastOn());
+    }
+
+    public function test_alerts_source_resolves_to_alert_owners_channel(): void
+    {
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+        $alert = Alert::factory()->create(['project_id' => $project->id]);
+
+        $row = ActivityEvent::factory()->create([
+            'repository_id' => null,
+            'source' => 'alerts',
+            'event_type' => 'alert.triggered',
+            'metadata' => ['alert_id' => $alert->id],
+        ]);
+
+        $channels = (new ActivityEventCreated($row))->broadcastOn();
+
+        $this->assertCount(1, $channels);
+        $this->assertInstanceOf(PrivateChannel::class, $channels[0]);
+        $this->assertSame("private-users.{$owner->id}.activity", $channels[0]->name);
+    }
+
+    public function test_alerts_source_is_silent_when_metadata_alert_id_missing(): void
+    {
+        $row = ActivityEvent::factory()->create([
+            'repository_id' => null,
+            'source' => 'alerts',
+            'event_type' => 'alert.triggered',
+            'metadata' => [],
+        ]);
+
+        $this->assertSame([], (new ActivityEventCreated($row))->broadcastOn());
+    }
+
+    public function test_alerts_source_is_silent_when_alert_id_is_unknown(): void
+    {
+        $row = ActivityEvent::factory()->create([
+            'repository_id' => null,
+            'source' => 'alerts',
+            'event_type' => 'alert.triggered',
+            'metadata' => ['alert_id' => 99999],
         ]);
 
         $this->assertSame([], (new ActivityEventCreated($row))->broadcastOn());

--- a/tests/Feature/GitHub/Webhooks/WorkflowRunWebhookHandlerTest.php
+++ b/tests/Feature/GitHub/Webhooks/WorkflowRunWebhookHandlerTest.php
@@ -2,13 +2,15 @@
 
 namespace Tests\Feature\GitHub\Webhooks;
 
-use App\Domain\Activity\Actions\CreateActivityEventAction;
-use App\Domain\GitHub\Actions\NormalizeGitHubWorkflowRunAction;
 use App\Domain\GitHub\WebhookHandlers\WorkflowRunWebhookHandler;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
 use App\Enums\WebhookDeliveryStatus;
 use App\Events\ActivityEventCreated;
 use App\Events\WorkflowRunUpserted;
 use App\Models\ActivityEvent;
+use App\Models\Alert;
 use App\Models\Project;
 use App\Models\Repository;
 use App\Models\User;
@@ -24,10 +26,7 @@ class WorkflowRunWebhookHandlerTest extends TestCase
 
     private function handler(): WorkflowRunWebhookHandler
     {
-        return new WorkflowRunWebhookHandler(
-            new CreateActivityEventAction,
-            new NormalizeGitHubWorkflowRunAction,
-        );
+        return app(WorkflowRunWebhookHandler::class);
     }
 
     private function deliveryFor(
@@ -135,6 +134,92 @@ class WorkflowRunWebhookHandlerTest extends TestCase
         $this->assertSame(0, ActivityEvent::query()->count());
         // No FK target for the upsert when the repo isn't imported yet.
         $this->assertSame(0, WorkflowRun::query()->count());
+    }
+
+    public function test_default_branch_failure_promotes_to_an_open_warning_alert(): void
+    {
+        Event::fake([ActivityEventCreated::class]);
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        // Pin default_branch so the test isn't a flake against the
+        // factory's random choice across {main, master, develop}.
+        Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+            'default_branch' => 'main',
+        ]);
+
+        $this->handler()->handle($this->deliveryFor('completed', 'failure'));
+
+        $alert = Alert::query()->firstOrFail();
+        $this->assertSame(AlertSource::Deployment, $alert->source);
+        $this->assertSame('workflow.failed', $alert->type);
+        $this->assertSame(AlertSeverity::Warning, $alert->severity);
+        $this->assertSame(AlertStatus::Open, $alert->status);
+        $this->assertSame($project->id, $alert->project_id);
+        $this->assertSame(WorkflowRun::query()->value('id'), $alert->source_id);
+    }
+
+    public function test_non_default_branch_failure_emits_activity_but_no_alert(): void
+    {
+        Event::fake([ActivityEventCreated::class]);
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+            'default_branch' => 'main',
+        ]);
+
+        // Override the default payload (head_branch: main) with a
+        // feature-branch delivery.
+        $delivery = WebhookDelivery::factory()->create([
+            'event' => 'workflow_run',
+            'action' => 'completed',
+            'repository_full_name' => 'octocat/hello-world',
+            'payload_json' => [
+                'action' => 'completed',
+                'repository' => ['full_name' => 'octocat/hello-world'],
+                'workflow_run' => [
+                    'id' => 4321,
+                    'name' => 'CI',
+                    'head_branch' => 'feature/login-form',
+                    'head_sha' => 'b'.str_repeat('2', 39),
+                    'event' => 'pull_request',
+                    'run_number' => 99,
+                    'conclusion' => 'failure',
+                    'status' => 'completed',
+                    'updated_at' => '2026-04-29T12:00:00Z',
+                    'run_started_at' => '2026-04-29T11:55:00Z',
+                    'html_url' => 'https://github.com/octocat/hello-world/actions/runs/4321',
+                    'actor' => ['login' => 'alice'],
+                ],
+                'sender' => ['login' => 'alice'],
+            ],
+        ]);
+
+        $this->handler()->handle($delivery);
+
+        $this->assertDatabaseHas('activity_events', [
+            'event_type' => 'workflow.failed',
+        ]);
+        $this->assertSame(0, Alert::query()->count(), 'feature-branch failures stay rail-only');
+    }
+
+    public function test_default_branch_success_does_not_create_an_alert(): void
+    {
+        Event::fake([ActivityEventCreated::class]);
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+            'default_branch' => 'main',
+        ]);
+
+        $this->handler()->handle($this->deliveryFor('completed', 'success'));
+
+        $this->assertSame(0, Alert::query()->count());
     }
 
     public function test_completed_handled_run_upserts_into_workflow_runs(): void

--- a/tests/Feature/GitHub/Webhooks/WorkflowRunWebhookHandlerTest.php
+++ b/tests/Feature/GitHub/Webhooks/WorkflowRunWebhookHandlerTest.php
@@ -206,6 +206,51 @@ class WorkflowRunWebhookHandlerTest extends TestCase
         $this->assertSame(0, Alert::query()->count(), 'feature-branch failures stay rail-only');
     }
 
+    public function test_malformed_payload_missing_head_branch_does_not_create_an_alert(): void
+    {
+        // The handler's display-fallback ($run['head_branch'] ??
+        // $repository->default_branch ?? 'main') would silently match
+        // the default branch and trigger an alert otherwise; the
+        // raw-payload gate defends against this.
+        Event::fake([ActivityEventCreated::class]);
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'octocat/hello-world',
+            'default_branch' => 'main',
+        ]);
+
+        $delivery = WebhookDelivery::factory()->create([
+            'event' => 'workflow_run',
+            'action' => 'completed',
+            'repository_full_name' => 'octocat/hello-world',
+            'payload_json' => [
+                'action' => 'completed',
+                'repository' => ['full_name' => 'octocat/hello-world'],
+                'workflow_run' => [
+                    'id' => 5555,
+                    'name' => 'CI',
+                    // head_branch intentionally absent
+                    'head_sha' => 'c'.str_repeat('3', 39),
+                    'event' => 'push',
+                    'run_number' => 7,
+                    'conclusion' => 'failure',
+                    'status' => 'completed',
+                    'updated_at' => '2026-04-29T12:00:00Z',
+                    'run_started_at' => '2026-04-29T11:55:00Z',
+                    'html_url' => 'https://github.com/octocat/hello-world/actions/runs/5555',
+                    'actor' => ['login' => 'alice'],
+                ],
+                'sender' => ['login' => 'alice'],
+            ],
+        ]);
+
+        $this->handler()->handle($delivery);
+
+        $this->assertSame(0, Alert::query()->count(), 'missing head_branch must not bypass the default-branch gate');
+    }
+
     public function test_default_branch_success_does_not_create_an_alert(): void
     {
         Event::fake([ActivityEventCreated::class]);

--- a/tests/Feature/Monitoring/RecordWebsiteCheckActionTest.php
+++ b/tests/Feature/Monitoring/RecordWebsiteCheckActionTest.php
@@ -2,15 +2,17 @@
 
 namespace Tests\Feature\Monitoring;
 
-use App\Domain\Activity\Actions\CreateActivityEventAction;
 use App\Domain\Monitoring\Actions\RecordWebsiteCheckAction;
 use App\Domain\Monitoring\Probes\WebsiteProbeResult;
 use App\Enums\ActivitySeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
 use App\Enums\WebsiteCheckStatus;
 use App\Enums\WebsiteStatus;
 use App\Events\ActivityEventCreated;
 use App\Events\WebsiteCheckRecorded;
 use App\Models\ActivityEvent;
+use App\Models\Alert;
 use App\Models\Project;
 use App\Models\User;
 use App\Models\Website;
@@ -25,7 +27,7 @@ class RecordWebsiteCheckActionTest extends TestCase
 
     private function action(): RecordWebsiteCheckAction
     {
-        return new RecordWebsiteCheckAction(new CreateActivityEventAction);
+        return app(RecordWebsiteCheckAction::class);
     }
 
     private function makeWebsite(WebsiteStatus $status = WebsiteStatus::Pending): Website
@@ -189,9 +191,10 @@ class RecordWebsiteCheckActionTest extends TestCase
             new WebsiteProbeResult(WebsiteCheckStatus::Down, 503, 220, 'HTTP 503: Service Unavailable'),
         );
 
-        $this->assertSame(1, ActivityEvent::query()->count());
-        $event = ActivityEvent::query()->first();
-        $this->assertSame('website.down', $event->event_type);
+        // Spec 030 promotes the transition into an alert.triggered
+        // activity event alongside the website.down rail event, so
+        // filter by event_type instead of counting all rows.
+        $event = ActivityEvent::query()->where('event_type', 'website.down')->firstOrFail();
         $this->assertSame(ActivitySeverity::Danger, $event->severity);
         $this->assertSame('monitoring', $event->source);
         $this->assertSame($website->id, $event->metadata['website_id']);
@@ -223,10 +226,46 @@ class RecordWebsiteCheckActionTest extends TestCase
             new WebsiteProbeResult(WebsiteCheckStatus::Up, 200, 95, null),
         );
 
-        $event = ActivityEvent::query()->firstOrFail();
-        $this->assertSame('website.up', $event->event_type);
+        $event = ActivityEvent::query()->where('event_type', 'website.up')->firstOrFail();
         $this->assertSame(ActivitySeverity::Success, $event->severity);
         $this->assertSame('monitoring', $event->source);
+    }
+
+    public function test_healthy_to_failed_promotes_into_an_open_critical_alert(): void
+    {
+        Event::fake([ActivityEventCreated::class]);
+        $website = $this->makeWebsite(WebsiteStatus::Up);
+
+        $this->action()->execute(
+            $website,
+            new WebsiteProbeResult(WebsiteCheckStatus::Down, 502, 200, 'HTTP 502'),
+        );
+
+        $alert = Alert::query()->firstOrFail();
+        $this->assertSame(AlertSource::Website, $alert->source);
+        $this->assertSame($website->id, $alert->source_id);
+        $this->assertSame('website.down', $alert->type);
+        $this->assertSame(AlertStatus::Open, $alert->status);
+        $this->assertSame($website->project_id, $alert->project_id);
+    }
+
+    public function test_failed_to_healthy_auto_resolves_the_open_alert(): void
+    {
+        Event::fake([ActivityEventCreated::class]);
+        $website = $this->makeWebsite(WebsiteStatus::Down);
+        $alert = Alert::factory()->create([
+            'project_id' => $website->project_id,
+            'source' => AlertSource::Website->value,
+            'source_id' => $website->id,
+            'type' => 'website.down',
+        ]);
+
+        $this->action()->execute(
+            $website,
+            new WebsiteProbeResult(WebsiteCheckStatus::Up, 200, 80, null),
+        );
+
+        $this->assertSame(AlertStatus::Resolved, $alert->fresh()->status);
     }
 
     public function test_steady_state_healthy_emits_nothing(): void

--- a/tests/Unit/Domain/Alerts/ResolveAlertActionTest.php
+++ b/tests/Unit/Domain/Alerts/ResolveAlertActionTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Unit\Domain\Alerts;
+
+use App\Domain\Alerts\Actions\ResolveAlertAction;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
+use App\Models\ActivityEvent;
+use App\Models\Alert;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ResolveAlertActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_resolves_an_open_alert_and_emits_an_activity_event(): void
+    {
+        $project = Project::factory()->create();
+        $alert = Alert::factory()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website->value,
+            'source_id' => 11,
+            'type' => 'website.down',
+        ]);
+
+        $resolved = app(ResolveAlertAction::class)->execute([
+            'source' => AlertSource::Website,
+            'source_id' => 11,
+        ]);
+
+        $this->assertSame(1, $resolved);
+        $this->assertSame(AlertStatus::Resolved, $alert->fresh()->status);
+        $this->assertNotNull($alert->fresh()->resolved_at);
+
+        $event = ActivityEvent::query()->firstOrFail();
+        $this->assertSame('alert.resolved', $event->event_type);
+        $this->assertSame('alerts', $event->source);
+        $this->assertSame($alert->id, $event->metadata['alert_id']);
+    }
+
+    public function test_resolves_acknowledged_alerts_too(): void
+    {
+        $project = Project::factory()->create();
+        $alert = Alert::factory()->acknowledged()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Docker->value,
+            'source_id' => 3,
+            'type' => 'host.offline',
+        ]);
+
+        $resolved = app(ResolveAlertAction::class)->execute([
+            'source' => AlertSource::Docker,
+            'source_id' => 3,
+        ]);
+
+        $this->assertSame(1, $resolved);
+        $this->assertSame(AlertStatus::Resolved, $alert->fresh()->status);
+    }
+
+    public function test_is_a_noop_when_no_open_alert_matches(): void
+    {
+        // Already-resolved row should NOT be touched.
+        Alert::factory()->resolved()->create([
+            'source' => AlertSource::Website->value,
+            'source_id' => 1,
+            'type' => 'website.down',
+        ]);
+
+        $resolved = app(ResolveAlertAction::class)->execute([
+            'source' => AlertSource::Website,
+            'source_id' => 1,
+        ]);
+
+        $this->assertSame(0, $resolved);
+        $this->assertSame(0, ActivityEvent::query()->count(), 'no spurious activity event');
+    }
+
+    public function test_does_not_touch_other_sources(): void
+    {
+        Alert::factory()->create([
+            'source' => AlertSource::Website->value,
+            'source_id' => 1,
+            'type' => 'website.down',
+        ]);
+        Alert::factory()->create([
+            'source' => AlertSource::Docker->value,
+            'source_id' => 1, // same id, different source
+            'type' => 'host.offline',
+        ]);
+
+        app(ResolveAlertAction::class)->execute([
+            'source' => AlertSource::Website,
+            'source_id' => 1,
+        ]);
+
+        $this->assertSame(
+            1,
+            Alert::query()->where('status', AlertStatus::Open->value)->count(),
+            'the docker-source alert was untouched',
+        );
+    }
+
+    public function test_type_filter_narrows_the_close_set(): void
+    {
+        $project = Project::factory()->create();
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website->value,
+            'source_id' => 7,
+            'type' => 'website.down',
+        ]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website->value,
+            'source_id' => 7,
+            'type' => 'website.slow',
+        ]);
+
+        $resolved = app(ResolveAlertAction::class)->execute([
+            'source' => AlertSource::Website,
+            'source_id' => 7,
+            'type' => 'website.down',
+        ]);
+
+        $this->assertSame(1, $resolved);
+        $this->assertSame(
+            1,
+            Alert::query()
+                ->where('type', 'website.slow')
+                ->where('status', AlertStatus::Open->value)
+                ->count(),
+            'website.slow stayed open',
+        );
+    }
+}

--- a/tests/Unit/Domain/Alerts/ResolveAlertActionTest.php
+++ b/tests/Unit/Domain/Alerts/ResolveAlertActionTest.php
@@ -102,6 +102,29 @@ class ResolveAlertActionTest extends TestCase
         );
     }
 
+    public function test_muted_alerts_are_left_alone_on_resolve(): void
+    {
+        // The user explicitly muted this alert; auto-resolve must
+        // not undo that decision. (Auto-resolve closes `open` and
+        // `acknowledged` — `muted` and `resolved` stay put.)
+        $project = Project::factory()->create();
+        $muted = Alert::factory()->muted()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website->value,
+            'source_id' => 50,
+            'type' => 'website.down',
+        ]);
+
+        $resolved = app(ResolveAlertAction::class)->execute([
+            'source' => AlertSource::Website,
+            'source_id' => 50,
+        ]);
+
+        $this->assertSame(0, $resolved);
+        $this->assertSame(AlertStatus::Muted, $muted->fresh()->status);
+        $this->assertSame(0, ActivityEvent::query()->count());
+    }
+
     public function test_type_filter_narrows_the_close_set(): void
     {
         $project = Project::factory()->create();

--- a/tests/Unit/Domain/Alerts/TriggerAlertActionTest.php
+++ b/tests/Unit/Domain/Alerts/TriggerAlertActionTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Tests\Unit\Domain\Alerts;
+
+use App\Domain\Alerts\Actions\TriggerAlertAction;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
+use App\Models\ActivityEvent;
+use App\Models\Alert;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TriggerAlertActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function attrs(array $overrides = []): array
+    {
+        $project = Project::factory()->create();
+
+        return array_merge([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website,
+            'source_id' => 42,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical,
+            'title' => 'Site is down',
+            'description' => 'GET / returned 500',
+            'metadata' => ['url' => 'https://example.com'],
+        ], $overrides);
+    }
+
+    public function test_first_trigger_inserts_an_open_alert_and_one_activity_event(): void
+    {
+        $alert = app(TriggerAlertAction::class)->execute($this->attrs());
+
+        $this->assertSame(AlertStatus::Open, $alert->status);
+        $this->assertSame(AlertSource::Website, $alert->source);
+        $this->assertSame('website.down', $alert->type);
+        $this->assertNotNull($alert->triggered_at);
+        $this->assertNotNull($alert->last_seen_at);
+
+        $this->assertSame(1, Alert::query()->count());
+
+        $event = ActivityEvent::query()->firstOrFail();
+        $this->assertSame('alert.triggered', $event->event_type);
+        $this->assertSame('alerts', $event->source);
+        $this->assertSame($alert->id, $event->metadata['alert_id']);
+        $this->assertSame('website', $event->metadata['alert_source']);
+        $this->assertSame(42, $event->metadata['alert_source_id']);
+    }
+
+    public function test_second_identical_trigger_is_idempotent(): void
+    {
+        $action = app(TriggerAlertAction::class);
+        $first = $action->execute($this->attrs());
+
+        // Travel to assert last_seen_at moves on the second call.
+        $this->travel(2)->minutes();
+        $second = $action->execute($this->attrs(['project_id' => $first->project_id]));
+
+        $this->assertSame($first->id, $second->id, 'returns the same row');
+        $this->assertSame(1, Alert::query()->count(), 'no duplicate Alert');
+        $this->assertSame(1, ActivityEvent::query()->count(), 'no second activity event');
+
+        $second->refresh();
+        $this->assertTrue($second->last_seen_at->greaterThan($first->triggered_at));
+    }
+
+    public function test_different_type_with_same_source_id_creates_a_separate_alert(): void
+    {
+        $action = app(TriggerAlertAction::class);
+        $project = Project::factory()->create();
+
+        $action->execute([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website,
+            'source_id' => 7,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical,
+            'title' => 'Down',
+        ]);
+        $action->execute([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website,
+            'source_id' => 7,
+            'type' => 'website.slow', // different type
+            'severity' => AlertSeverity::Warning,
+            'title' => 'Slow',
+        ]);
+
+        $this->assertSame(2, Alert::query()->count());
+    }
+
+    public function test_resolved_alert_does_not_block_a_fresh_trigger(): void
+    {
+        $project = Project::factory()->create();
+        Alert::factory()->resolved()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website->value,
+            'source_id' => 99,
+            'type' => 'website.down',
+        ]);
+
+        $alert = app(TriggerAlertAction::class)->execute([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website,
+            'source_id' => 99,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical,
+            'title' => 'Fresh outage',
+        ]);
+
+        $this->assertSame(AlertStatus::Open, $alert->status);
+        $this->assertSame(2, Alert::query()->count(), 'old resolved row stays; new open row inserted');
+    }
+
+    public function test_acknowledged_alert_blocks_a_duplicate_trigger(): void
+    {
+        $project = Project::factory()->create();
+        $existing = Alert::factory()->acknowledged()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website->value,
+            'source_id' => 5,
+            'type' => 'website.down',
+        ]);
+
+        $alert = app(TriggerAlertAction::class)->execute([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website,
+            'source_id' => 5,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical,
+            'title' => 'Still down',
+        ]);
+
+        $this->assertSame($existing->id, $alert->id);
+        $this->assertSame(AlertStatus::Acknowledged, $alert->fresh()->status);
+        $this->assertSame(1, Alert::query()->count());
+    }
+}

--- a/tests/Unit/Domain/Docker/DetectOfflineHostsActionTest.php
+++ b/tests/Unit/Domain/Docker/DetectOfflineHostsActionTest.php
@@ -4,8 +4,11 @@ namespace Tests\Unit\Domain\Docker;
 
 use App\Domain\Docker\Actions\DetectOfflineHostsAction;
 use App\Enums\ActivitySeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
 use App\Enums\HostStatus;
 use App\Models\ActivityEvent;
+use App\Models\Alert;
 use App\Models\Host;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -95,6 +98,22 @@ class DetectOfflineHostsActionTest extends TestCase
         $this->assertSame(0, $flipped);
         $this->assertSame(HostStatus::Offline, $host->fresh()->status);
         $this->assertSame(0, ActivityEvent::query()->where('event_type', 'host.offline')->count());
+    }
+
+    public function test_flipping_a_host_also_creates_a_critical_alert(): void
+    {
+        $host = Host::factory()->online()->create([
+            'last_seen_at' => now()->subSeconds(self::TIMEOUT + 60),
+        ]);
+
+        app(DetectOfflineHostsAction::class)->execute();
+
+        $alert = Alert::query()->firstOrFail();
+        $this->assertSame(AlertSource::Docker, $alert->source);
+        $this->assertSame($host->id, $alert->source_id);
+        $this->assertSame('host.offline', $alert->type);
+        $this->assertSame(AlertStatus::Open, $alert->status);
+        $this->assertSame($host->project_id, $alert->project_id);
     }
 
     public function test_multiple_stale_hosts_each_produce_one_event(): void

--- a/tests/Unit/Domain/Docker/IngestHostTelemetryActionTest.php
+++ b/tests/Unit/Domain/Docker/IngestHostTelemetryActionTest.php
@@ -4,8 +4,11 @@ namespace Tests\Unit\Domain\Docker;
 
 use App\Domain\Docker\Actions\IngestHostTelemetryAction;
 use App\Enums\ActivitySeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
 use App\Enums\HostStatus;
 use App\Models\ActivityEvent;
+use App\Models\Alert;
 use App\Models\Host;
 use App\Models\HostMetricSnapshot;
 use Carbon\CarbonImmutable;
@@ -152,5 +155,20 @@ class IngestHostTelemetryActionTest extends TestCase
         app(IngestHostTelemetryAction::class)->execute($host, $this->basePayload());
 
         $this->assertSame(0, ActivityEvent::query()->where('event_type', 'host.recovered')->count());
+    }
+
+    public function test_recovery_auto_resolves_the_open_host_alert(): void
+    {
+        $host = Host::factory()->offline()->create();
+        $alert = Alert::factory()->forHost()->create([
+            'project_id' => $host->project_id,
+            'source' => AlertSource::Docker->value,
+            'source_id' => $host->id,
+            'type' => 'host.offline',
+        ]);
+
+        app(IngestHostTelemetryAction::class)->execute($host, $this->basePayload());
+
+        $this->assertSame(AlertStatus::Resolved, $alert->fresh()->status);
     }
 }


### PR DESCRIPTION
Closes #89

Spec: `specs/phase-7-alerts/030-alerts-scaffolding.md`

Opens Phase 7. Lays the alert data layer and wires every existing transition emitter to also promote into durable Alert rows.

## Summary

- **Data layer.** `alerts` table (project_id, source, source_id, type, severity, status, title, description, triggered_at, acknowledged_at, resolved_at, last_seen_at, metadata) with composite indexes on `(status, source, source_id)` and `(project_id, status)`. `Alert` model + factory + `AlertPolicy` (mirrors `HostPolicy`). Three enums: `AlertStatus`, `AlertSeverity` (with `badgeTone()` + `toActivitySeverity()`), `AlertSource`.
- **Actions.** `TriggerAlertAction` is idempotent on `(source, source_id, type, status IN [open, acknowledged])` — second call bumps `last_seen_at`, no duplicate row, no second activity event. `ResolveAlertAction` closes every open + acknowledged Alert matching `(source, source_id[, type])`; muted and already-resolved rows stay put.
- **Activity routing.** `ActivityEventCreated::broadcastOn()` gains a 4th branch resolving `source: alerts` via `metadata.alert_id → alert → project → owner_user_id`.
- **Promotion call sites (×4).**
  - `RecordWebsiteCheckAction` — down transition → critical `website.down` Alert; up transition → auto-resolve.
  - `DetectOfflineHostsAction` — flip → critical `host.offline` Alert (inside the same transaction as the status flip + activity event).
  - `IngestHostTelemetryAction` — recovery → auto-resolve.
  - `WorkflowRunWebhookHandler` — `workflow.failed` on the repo's default branch → warning `workflow.failed` Alert. Feature-branch failures stay rail-only.

## Test plan
- [x] `alerts` migration applies cleanly + rolls back
- [x] `Alert` factory + policy work
- [x] Website healthy → failed creates an open critical Alert; failed → healthy auto-resolves
- [x] `DetectOfflineHostsAction` flip creates an open critical Alert
- [x] First telemetry after offline auto-resolves the open host Alert
- [x] `workflow.failed` on default branch creates a warning Alert; feature-branch failures don't; malformed payloads missing `head_branch` don't
- [x] Second identical Trigger bumps `last_seen_at` and doesn't duplicate / re-emit
- [x] `ResolveAlertAction` is a no-op when nothing matches; muted rows are left alone
- [x] `ActivityEventCreated` routes `source: alerts` rows to the alert's project owner's `users.{id}.activity` channel
- [x] Pint clean, `php artisan test` green (529 tests, +22 new), `npm run build` clean

## Self-review notes
Reviewed via `superpowers:code-reviewer` — assessed ready to PR, no critical/blocking issues. Addressed in the close-out commit:
- `WorkflowRunWebhookHandler` now gates the alert promotion on the **raw** payload `head_branch` (not the existing display-fallback that defaults to `default_branch` when missing). A malformed delivery missing the field no longer accidentally passes the default-branch match. Added a regression test.
- `TriggerAlertAction`'s docblock spells out the no-unique-index idempotency caveat. All 030 call sites serialize, but a future caller with real concurrency would need a partial unique index or an action-layer guard.
- New `muted_alerts_are_left_alone_on_resolve` test pins the load-bearing user-opt-out invariant.

Deferred / conscious choices:
- The `/alerts` page UI, ack/resolve/mute controllers, sidebar wiring, Cmd+K — spec 031.
- Dedicated `AlertTriggered` / `AlertResolved` broadcast events + `users.{id}.alerts` channel — spec 032. Realtime in 030 rides on the existing activity rail via the new `source: alerts` branch.
- Overview `MOCK_KPIS.alerts` placeholder stays in place — spec 032 swaps it.
- Activity-event volume on a promoted transition doubles (the original `website.down`/`host.offline`/`workflow.failed` row + a sibling `alert.triggered` row). Different metadata; both intentionally visible on the rail. Revisit if spec 031's nav consumers want suppression.