### PR TITLE
Spec 031 — Alerts UI + acknowledge / resolve / mute actions

### DIFF
--- a/app/Domain/Alerts/Actions/AcknowledgeAlertAction.php
+++ b/app/Domain/Alerts/Actions/AcknowledgeAlertAction.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Domain\Alerts\Actions;
+
+use App\Enums\AlertStatus;
+use App\Models\Alert;
+use Illuminate\Support\Carbon;
+
+/**
+ * User-initiated "I see this and I'm on it" — flips an open Alert to
+ * acknowledged (spec 031). Silent: no activity event. Ack is UI-state,
+ * not project-state — flooding the rail with "Yoany ack'd this" rows
+ * would dilute the signal that already covers the real transitions
+ * (`alert.triggered`, `alert.recovered`, `alert.resolved`).
+ *
+ * Idempotent in both directions:
+ *   - Already-acknowledged: no-op (no double-stamp).
+ *   - Resolved / muted: no-op (you can't ack what's closed; the
+ *     workflow is "Resolve cancels everything else").
+ */
+class AcknowledgeAlertAction
+{
+    public function execute(Alert $alert): Alert
+    {
+        if ($alert->status !== AlertStatus::Open) {
+            return $alert;
+        }
+
+        $now = Carbon::now();
+
+        $alert->forceFill([
+            'status' => AlertStatus::Acknowledged->value,
+            'acknowledged_at' => $now,
+            'last_seen_at' => $now,
+        ])->save();
+
+        return $alert;
+    }
+}

--- a/app/Domain/Alerts/Actions/MuteAlertAction.php
+++ b/app/Domain/Alerts/Actions/MuteAlertAction.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Domain\Alerts\Actions;
+
+use App\Enums\AlertStatus;
+use App\Models\Alert;
+use Illuminate\Support\Carbon;
+
+/**
+ * User-initiated "stop highlighting this" — flips an Alert to muted
+ * (spec 031). Mute is the escape hatch: it suppresses further
+ * surfacing for this specific row even when the underlying source
+ * keeps re-triggering. Future triggers for the same `(source,
+ * source_id, type)` still create a fresh open Alert — see
+ * `TriggerAlertAction`'s idempotency contract (mute is per-row, not
+ * per-source-tuple).
+ *
+ * Silent — no activity event, same reasoning as Acknowledge.
+ *
+ * Idempotent:
+ *   - Already muted: no-op.
+ *   - Resolved: no-op (resolved is terminal; mute can't override).
+ *
+ * Open and acknowledged alerts can both be muted — "I know about
+ * it, I'm not going to act on it, stop telling me."
+ */
+class MuteAlertAction
+{
+    public function execute(Alert $alert): Alert
+    {
+        if ($alert->status === AlertStatus::Muted || $alert->status === AlertStatus::Resolved) {
+            return $alert;
+        }
+
+        $now = Carbon::now();
+
+        $alert->forceFill([
+            'status' => AlertStatus::Muted->value,
+            'last_seen_at' => $now,
+        ])->save();
+
+        return $alert;
+    }
+}

--- a/app/Http/Controllers/AlertAcknowledgeController.php
+++ b/app/Http/Controllers/AlertAcknowledgeController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\Alerts\Actions\AcknowledgeAlertAction;
+use App\Models\Alert;
+use Illuminate\Http\RedirectResponse;
+
+/**
+ * `POST /alerts/{alert}/acknowledge` — user-initiated ack (spec 031).
+ * Thin handoff to `AcknowledgeAlertAction`. Idempotent: re-ack'ing an
+ * already-acknowledged row is a no-op (no double-stamp).
+ */
+class AlertAcknowledgeController extends Controller
+{
+    public function __invoke(Alert $alert, AcknowledgeAlertAction $acknowledge): RedirectResponse
+    {
+        $this->authorize('update', $alert);
+
+        $acknowledge->execute($alert);
+
+        return back()->with('status', 'Alert acknowledged.');
+    }
+}

--- a/app/Http/Controllers/AlertController.php
+++ b/app/Http/Controllers/AlertController.php
@@ -56,22 +56,24 @@ class AlertController extends Controller
         $sourceValues = array_map(fn (AlertSource $s) => $s->value, AlertSource::cases());
         $statusValues = array_map(fn (AlertStatus $s) => $s->value, AlertStatus::cases());
 
+        // `status: 'all'` is the explicit "show every status" sentinel.
+        // It survives a URL round-trip so the Vue dropdown can bind a
+        // non-null value to "Any status". Missing status → default to
+        // open (lands on the actionable set).
         $validated = $request->validate([
             'severity' => 'sometimes|nullable|in:'.implode(',', $severityValues),
             'source' => 'sometimes|nullable|in:'.implode(',', $sourceValues),
-            'status' => 'sometimes|nullable|in:'.implode(',', $statusValues),
+            'status' => 'sometimes|nullable|in:'.implode(',', [...$statusValues, 'all']),
             'project_id' => [
                 'sometimes', 'nullable', 'integer',
                 Rule::exists('projects', 'id')->where('owner_user_id', $user->id),
             ],
         ]);
 
-        // Default to the actionable set. An empty string from a cleared
-        // dropdown still counts as "show all"; null / missing falls back
-        // to the default.
-        $status = array_key_exists('status', $validated)
-            ? $validated['status']
-            : AlertStatus::Open->value;
+        $rawStatus = $validated['status'] ?? null;
+        $status = $rawStatus === 'all'
+            ? null
+            : ($rawStatus ?? AlertStatus::Open->value);
 
         $severity = $validated['severity'] ?? null;
         $source = $validated['source'] ?? null;
@@ -100,7 +102,9 @@ class AlertController extends Controller
             'filters' => [
                 'severity' => $severity,
                 'source' => $source,
-                'status' => $status,
+                // Round-trip the sentinel so the Vue dropdown can
+                // re-select "Any status" on reload.
+                'status' => $rawStatus === 'all' ? 'all' : $status,
                 'project_id' => $projectId,
             ],
             'filterOptions' => [

--- a/app/Http/Controllers/AlertController.php
+++ b/app/Http/Controllers/AlertController.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
+use App\Models\Alert;
+use App\Models\Project;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * `/alerts` — Phase 7 alerts index (spec 031).
+ *
+ * Filters live in the query string so a filtered view is shareable and
+ * survives reload — same pattern as the Deployments timeline. Default
+ * landing is `status: open` so the page is actionable on arrival;
+ * resolved / muted rows are reachable via the dropdown.
+ *
+ * Visible scope: phase-1 single-owner — the user's own projects. Sort
+ * happens in PHP after the fetch (`severity priority` is awkward in
+ * SQL cross-DB and phase-1 alert counts are well below any size where
+ * server-side sort would matter).
+ */
+class AlertController extends Controller
+{
+    /**
+     * Status priority ladder for the column-sort fallback used in 031.
+     * Lower = sorted earlier. Open + acknowledged sit at the top of any
+     * mixed-status list; resolved / muted fall to the bottom.
+     */
+    private const STATUS_PRIORITY = [
+        'open' => 0,
+        'acknowledged' => 1,
+        'muted' => 2,
+        'resolved' => 3,
+    ];
+
+    /** Severity priority ladder for the primary sort. */
+    private const SEVERITY_PRIORITY = [
+        'critical' => 0,
+        'warning' => 1,
+        'info' => 2,
+    ];
+
+    public function index(Request $request): Response
+    {
+        $this->authorize('viewAny', Alert::class);
+
+        $user = $request->user();
+
+        $severityValues = array_map(fn (AlertSeverity $s) => $s->value, AlertSeverity::cases());
+        $sourceValues = array_map(fn (AlertSource $s) => $s->value, AlertSource::cases());
+        $statusValues = array_map(fn (AlertStatus $s) => $s->value, AlertStatus::cases());
+
+        $validated = $request->validate([
+            'severity' => 'sometimes|nullable|in:'.implode(',', $severityValues),
+            'source' => 'sometimes|nullable|in:'.implode(',', $sourceValues),
+            'status' => 'sometimes|nullable|in:'.implode(',', $statusValues),
+            'project_id' => [
+                'sometimes', 'nullable', 'integer',
+                Rule::exists('projects', 'id')->where('owner_user_id', $user->id),
+            ],
+        ]);
+
+        // Default to the actionable set. An empty string from a cleared
+        // dropdown still counts as "show all"; null / missing falls back
+        // to the default.
+        $status = array_key_exists('status', $validated)
+            ? $validated['status']
+            : AlertStatus::Open->value;
+
+        $severity = $validated['severity'] ?? null;
+        $source = $validated['source'] ?? null;
+        $projectId = $validated['project_id'] ?? null;
+
+        $alerts = Alert::query()
+            ->with('project:id,slug,name,color,icon,owner_user_id')
+            ->whereHas('project', fn ($q) => $q->where('owner_user_id', $user->id))
+            ->when($severity, fn ($q) => $q->where('severity', $severity))
+            ->when($source, fn ($q) => $q->where('source', $source))
+            ->when($status, fn ($q) => $q->where('status', $status))
+            ->when($projectId, fn ($q) => $q->where('project_id', $projectId))
+            ->get()
+            ->sortBy(fn (Alert $alert): array => [
+                self::STATUS_PRIORITY[$alert->status?->value] ?? 9,
+                self::SEVERITY_PRIORITY[$alert->severity?->value] ?? 9,
+                -($alert->triggered_at?->timestamp ?? 0),
+                -$alert->id,
+            ])
+            ->values()
+            ->map(fn (Alert $alert) => $this->transform($alert))
+            ->all();
+
+        return Inertia::render('Alerts/Index', [
+            'alerts' => $alerts,
+            'filters' => [
+                'severity' => $severity,
+                'source' => $source,
+                'status' => $status,
+                'project_id' => $projectId,
+            ],
+            'filterOptions' => [
+                'severities' => $severityValues,
+                'sources' => $sourceValues,
+                'statuses' => $statusValues,
+                'projects' => Project::query()
+                    ->where('owner_user_id', $user->id)
+                    ->orderBy('name')
+                    ->get(['id', 'name', 'color'])
+                    ->map(fn (Project $project) => [
+                        'id' => $project->id,
+                        'name' => $project->name,
+                        'color' => $project->color,
+                    ])
+                    ->all(),
+            ],
+        ]);
+    }
+
+    /**
+     * Wire-shape for a single Alert row. The `affected_entity_url` and
+     * the three `can_*` flags are server-resolved so the Vue layer
+     * stays dumb (and we don't repeat the source→route map in TS).
+     *
+     * @return array<string, mixed>
+     */
+    private function transform(Alert $alert): array
+    {
+        return [
+            'id' => $alert->id,
+            'source' => $alert->source?->value,
+            'source_id' => $alert->source_id,
+            'type' => $alert->type,
+            'severity' => $alert->severity?->value,
+            'severity_tone' => $alert->severity?->badgeTone(),
+            'status' => $alert->status?->value,
+            'title' => $alert->title,
+            'description' => $alert->description,
+            'triggered_at' => $alert->triggered_at?->diffForHumans(),
+            'triggered_at_iso' => $alert->triggered_at?->toIso8601String(),
+            'acknowledged_at' => $alert->acknowledged_at?->diffForHumans(),
+            'resolved_at' => $alert->resolved_at?->diffForHumans(),
+            'last_seen_at' => $alert->last_seen_at?->diffForHumans(),
+            'metadata' => $alert->metadata,
+            'project' => $alert->project ? [
+                'id' => $alert->project->id,
+                'slug' => $alert->project->slug,
+                'name' => $alert->project->name,
+                'color' => $alert->project->color,
+                'icon' => $alert->project->icon,
+            ] : null,
+            'affected_entity_url' => $this->affectedEntityUrl($alert),
+            // Action visibility: only the verbs that are valid for the
+            // current status. The Vue layer decides whether to render
+            // the button; the controllers enforce again at submit time.
+            'can_acknowledge' => $alert->status === AlertStatus::Open,
+            'can_resolve' => $alert->status === AlertStatus::Open
+                || $alert->status === AlertStatus::Acknowledged,
+            'can_mute' => $alert->status !== AlertStatus::Muted
+                && $alert->status !== AlertStatus::Resolved,
+        ];
+    }
+
+    /**
+     * Server-resolved drill-down URL keyed off the alert's source.
+     * Phase 7 maps three sources; new sources fall through to null
+     * (the UI renders the icon disabled).
+     */
+    private function affectedEntityUrl(Alert $alert): ?string
+    {
+        if ($alert->source_id === null) {
+            return null;
+        }
+
+        return match ($alert->source) {
+            AlertSource::Website => route('monitoring.websites.show', $alert->source_id),
+            AlertSource::Docker => route('monitoring.hosts.show', $alert->source_id),
+            AlertSource::Deployment => $alert->metadata['html_url'] ?? null,
+            default => null,
+        };
+    }
+}

--- a/app/Http/Controllers/AlertMuteController.php
+++ b/app/Http/Controllers/AlertMuteController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\Alerts\Actions\MuteAlertAction;
+use App\Models\Alert;
+use Illuminate\Http\RedirectResponse;
+
+/**
+ * `POST /alerts/{alert}/mute` — user-initiated "stop highlighting"
+ * (spec 031). Thin handoff to `MuteAlertAction`. Idempotent on a row
+ * already muted; refuses to mute a resolved row (terminal state wins).
+ */
+class AlertMuteController extends Controller
+{
+    public function __invoke(Alert $alert, MuteAlertAction $mute): RedirectResponse
+    {
+        $this->authorize('update', $alert);
+
+        $mute->execute($alert);
+
+        return back()->with('status', 'Alert muted.');
+    }
+}

--- a/app/Http/Controllers/AlertResolveController.php
+++ b/app/Http/Controllers/AlertResolveController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Domain\Alerts\Actions\ResolveAlertAction;
+use App\Enums\AlertStatus;
 use App\Models\Alert;
 use Illuminate\Http\RedirectResponse;
 
@@ -20,6 +21,19 @@ class AlertResolveController extends Controller
     public function __invoke(Alert $alert, ResolveAlertAction $resolve): RedirectResponse
     {
         $this->authorize('update', $alert);
+
+        // Muted is "stop fanning, I know about it" — auto-resolving
+        // it would silently invalidate the user's earlier choice. The
+        // Vue layer already hides the Resolve button on muted rows
+        // (`can_resolve` is false in the transform); this guard
+        // surfaces a real error if a stale page state or direct API
+        // call hits the route anyway.
+        if ($alert->status === AlertStatus::Muted) {
+            return back()->with(
+                'error',
+                'Cannot resolve a muted alert. Unmute it first.',
+            );
+        }
 
         $resolve->execute([
             'source' => $alert->source,

--- a/app/Http/Controllers/AlertResolveController.php
+++ b/app/Http/Controllers/AlertResolveController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\Alerts\Actions\ResolveAlertAction;
+use App\Models\Alert;
+use Illuminate\Http\RedirectResponse;
+
+/**
+ * `POST /alerts/{alert}/resolve` — user-initiated resolve (spec 031).
+ * Reuses spec 030's `ResolveAlertAction` with the alert's own
+ * `(source, source_id, type)` as the criteria. Idempotency in 030's
+ * Trigger guarantees at most one open / acknowledged row per
+ * `(source, source_id, type)`, so this closes exactly the clicked
+ * alert and emits the same `alert.resolved` activity event that the
+ * recovery-driven auto-resolve path already does.
+ */
+class AlertResolveController extends Controller
+{
+    public function __invoke(Alert $alert, ResolveAlertAction $resolve): RedirectResponse
+    {
+        $this->authorize('update', $alert);
+
+        $resolve->execute([
+            'source' => $alert->source,
+            'source_id' => $alert->source_id,
+            'type' => $alert->type,
+        ]);
+
+        return back()->with('status', 'Alert resolved.');
+    }
+}

--- a/resources/js/Components/Sidebar/Sidebar.vue
+++ b/resources/js/Components/Sidebar/Sidebar.vue
@@ -45,7 +45,7 @@ const nav: NavItem[] = [
     { label: 'Hosts', icon: Server, routeName: 'monitoring.hosts.index' },
     { label: 'Monitoring', icon: Globe, routeName: 'monitoring.websites.index' },
     { label: 'Analytics', icon: BarChart3, disabled: true, soonLabel: 'Phase 8' },
-    { label: 'Alerts', icon: Bell, disabled: true, soonLabel: 'Phase 7' },
+    { label: 'Alerts', icon: Bell, routeName: 'alerts.index' },
     { label: 'Activity', icon: History, routeName: 'activity.index' },
     { label: 'Settings', icon: SettingsIcon, routeName: 'settings.index' },
 ];

--- a/resources/js/Pages/Alerts/Index.vue
+++ b/resources/js/Pages/Alerts/Index.vue
@@ -1,0 +1,474 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import {
+    AlertTriangle,
+    Bell,
+    BellOff,
+    CheckCircle2,
+    ExternalLink,
+    Eye,
+} from 'lucide-vue-next';
+import { computed, ref } from 'vue';
+
+interface ProjectChip {
+    id: number;
+    slug?: string;
+    name: string;
+    color: string | null;
+    icon?: string | null;
+}
+
+interface AlertRow {
+    id: number;
+    source: string | null;
+    source_id: number | null;
+    type: string;
+    severity: string | null;
+    severity_tone: 'info' | 'warning' | 'danger' | null;
+    status: 'open' | 'acknowledged' | 'resolved' | 'muted' | string | null;
+    title: string;
+    description: string | null;
+    triggered_at: string | null;
+    triggered_at_iso: string | null;
+    acknowledged_at: string | null;
+    resolved_at: string | null;
+    last_seen_at: string | null;
+    metadata: Record<string, unknown> | null;
+    project: ProjectChip | null;
+    affected_entity_url: string | null;
+    can_acknowledge: boolean;
+    can_resolve: boolean;
+    can_mute: boolean;
+}
+
+interface FilterState {
+    severity: string | null;
+    source: string | null;
+    status: string | null;
+    project_id: number | null;
+}
+
+interface FilterOptions {
+    severities: string[];
+    sources: string[];
+    statuses: string[];
+    projects: { id: number; name: string; color: string | null }[];
+}
+
+const props = defineProps<{
+    alerts: AlertRow[];
+    filters: FilterState;
+    filterOptions: FilterOptions;
+}>();
+
+const filterDraft = ref<FilterState>({ ...props.filters });
+
+const hasFilterActive = computed<boolean>(() => {
+    const f = props.filters;
+    // The default landing filter is `status: 'open'` — that's not
+    // considered "user-active" for the empty-state CTA.
+    if (f.severity !== null) return true;
+    if (f.source !== null) return true;
+    if (f.project_id !== null) return true;
+    if (f.status !== null && f.status !== 'open') return true;
+    return false;
+});
+
+const headerCounts = computed(() => {
+    const total = props.alerts.length;
+    const critical = props.alerts.filter(
+        (a) => a.severity === 'critical' && (a.status === 'open' || a.status === 'acknowledged'),
+    ).length;
+    return { total, critical };
+});
+
+const applyFilters = () => {
+    const params: Record<string, string | number> = {};
+    for (const [key, value] of Object.entries(filterDraft.value)) {
+        if (value !== null && value !== '') {
+            params[key] = value;
+        }
+    }
+    router.get(route('alerts.index'), params, {
+        preserveScroll: true,
+        preserveState: true,
+        only: ['alerts', 'filters', 'filterOptions'],
+    });
+};
+
+const clearFilters = () => {
+    filterDraft.value = {
+        severity: null,
+        source: null,
+        status: null,
+        project_id: null,
+    };
+    router.get(
+        route('alerts.index'),
+        {},
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['alerts', 'filters', 'filterOptions'],
+        },
+    );
+};
+
+const acknowledge = (alert: AlertRow) => {
+    router.post(
+        route('alerts.acknowledge', alert.id),
+        {},
+        { preserveScroll: true },
+    );
+};
+
+const resolve = (alert: AlertRow) => {
+    router.post(
+        route('alerts.resolve', alert.id),
+        {},
+        { preserveScroll: true },
+    );
+};
+
+const mute = (alert: AlertRow) => {
+    router.post(route('alerts.mute', alert.id), {}, { preserveScroll: true });
+};
+
+const capitalize = (value: string | null): string =>
+    value === null ? '' : value.charAt(0).toUpperCase() + value.slice(1);
+
+const projectAccentClass = (color: string | null) =>
+    (
+        ({
+            cyan: 'text-accent-cyan',
+            blue: 'text-accent-blue',
+            purple: 'text-accent-purple',
+            magenta: 'text-accent-magenta',
+            success: 'text-status-success',
+            warning: 'text-status-warning',
+        }) as const
+    )[color ?? ''] ?? 'text-text-muted';
+
+const statusLabel = (alert: AlertRow): string => {
+    if (alert.status === 'open' && alert.triggered_at) {
+        return `Open since ${alert.triggered_at}`;
+    }
+    if (alert.status === 'acknowledged' && alert.acknowledged_at) {
+        return `Acknowledged ${alert.acknowledged_at}`;
+    }
+    if (alert.status === 'resolved' && alert.resolved_at) {
+        return `Resolved ${alert.resolved_at}`;
+    }
+    if (alert.status === 'muted') {
+        return 'Muted';
+    }
+    return capitalize(alert.status);
+};
+</script>
+
+<template>
+    <Head title="Alerts" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <span
+                    class="text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan"
+                >
+                    Phase 7
+                </span>
+                <h1 class="text-lg font-semibold text-text-primary">Alerts</h1>
+            </div>
+        </template>
+
+        <div class="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+            <header class="mb-6 flex flex-wrap items-end justify-between gap-4">
+                <div class="flex flex-col gap-2">
+                    <h2 class="text-xl font-semibold text-text-primary">
+                        Open alerts
+                    </h2>
+                    <p class="text-sm text-text-secondary">
+                        {{ headerCounts.total }}
+                        {{
+                            headerCounts.total === 1 ? 'alert' : 'alerts'
+                        }}
+                        <span v-if="headerCounts.critical > 0">
+                            · <span class="text-status-danger"
+                                >{{ headerCounts.critical }} critical</span
+                            >
+                        </span>
+                    </p>
+                </div>
+
+                <!-- Filter bar -->
+                <div class="flex flex-wrap items-end gap-3">
+                    <label class="flex flex-col gap-1 text-xs">
+                        <span
+                            class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                        >
+                            Severity
+                        </span>
+                        <select
+                            v-model="filterDraft.severity"
+                            class="min-w-[120px] rounded-md border border-border-subtle bg-background-panel-hover px-2 py-1.5 text-sm text-text-primary focus:border-accent-cyan/60 focus:outline-none"
+                            @change="applyFilters"
+                        >
+                            <option :value="null">Any severity</option>
+                            <option
+                                v-for="severity in filterOptions.severities"
+                                :key="severity"
+                                :value="severity"
+                            >
+                                {{ capitalize(severity) }}
+                            </option>
+                        </select>
+                    </label>
+                    <label class="flex flex-col gap-1 text-xs">
+                        <span
+                            class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                        >
+                            Source
+                        </span>
+                        <select
+                            v-model="filterDraft.source"
+                            class="min-w-[120px] rounded-md border border-border-subtle bg-background-panel-hover px-2 py-1.5 text-sm text-text-primary focus:border-accent-cyan/60 focus:outline-none"
+                            @change="applyFilters"
+                        >
+                            <option :value="null">Any source</option>
+                            <option
+                                v-for="source in filterOptions.sources"
+                                :key="source"
+                                :value="source"
+                            >
+                                {{ capitalize(source) }}
+                            </option>
+                        </select>
+                    </label>
+                    <label class="flex flex-col gap-1 text-xs">
+                        <span
+                            class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                        >
+                            Status
+                        </span>
+                        <select
+                            v-model="filterDraft.status"
+                            class="min-w-[140px] rounded-md border border-border-subtle bg-background-panel-hover px-2 py-1.5 text-sm text-text-primary focus:border-accent-cyan/60 focus:outline-none"
+                            @change="applyFilters"
+                        >
+                            <option :value="null">Any status</option>
+                            <option
+                                v-for="status in filterOptions.statuses"
+                                :key="status"
+                                :value="status"
+                            >
+                                {{ capitalize(status) }}
+                            </option>
+                        </select>
+                    </label>
+                    <label
+                        v-if="filterOptions.projects.length > 0"
+                        class="flex flex-col gap-1 text-xs"
+                    >
+                        <span
+                            class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted"
+                        >
+                            Project
+                        </span>
+                        <select
+                            v-model.number="filterDraft.project_id"
+                            class="min-w-[140px] rounded-md border border-border-subtle bg-background-panel-hover px-2 py-1.5 text-sm text-text-primary focus:border-accent-cyan/60 focus:outline-none"
+                            @change="applyFilters"
+                        >
+                            <option :value="null">All projects</option>
+                            <option
+                                v-for="project in filterOptions.projects"
+                                :key="project.id"
+                                :value="project.id"
+                            >
+                                {{ project.name }}
+                            </option>
+                        </select>
+                    </label>
+                </div>
+            </header>
+
+            <div
+                v-if="alerts.length === 0 && !hasFilterActive"
+                class="glass-card flex flex-col items-center justify-center gap-3 px-6 py-16 text-center"
+            >
+                <span
+                    class="flex h-12 w-12 items-center justify-center rounded-full border border-status-success/40 bg-status-success/10"
+                >
+                    <CheckCircle2
+                        class="h-5 w-5 text-status-success"
+                        aria-hidden="true"
+                    />
+                </span>
+                <p class="text-sm font-medium text-text-primary">All clear</p>
+                <p class="max-w-sm text-xs text-text-muted">
+                    No open alerts. Transitions emitted by website
+                    monitors, host telemetry, and workflow webhooks
+                    auto-promote here when they fire.
+                </p>
+            </div>
+
+            <div
+                v-else-if="alerts.length === 0"
+                class="glass-card flex flex-col items-center justify-center gap-3 px-6 py-16 text-center"
+            >
+                <span
+                    class="flex h-12 w-12 items-center justify-center rounded-full border border-border-subtle bg-slate-950/60"
+                >
+                    <Bell
+                        class="h-5 w-5 text-text-muted"
+                        aria-hidden="true"
+                    />
+                </span>
+                <p class="text-sm font-medium text-text-secondary">
+                    No alerts match this filter
+                </p>
+                <button
+                    type="button"
+                    class="text-xs font-semibold text-accent-cyan transition hover:text-accent-cyan/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                    @click="clearFilters"
+                >
+                    Clear filter
+                </button>
+            </div>
+
+            <ul v-else class="flex flex-col gap-2">
+                <li
+                    v-for="alert in alerts"
+                    :key="alert.id"
+                    class="glass-card flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-start sm:gap-4"
+                >
+                    <span
+                        class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-border-subtle bg-slate-950/60"
+                        :class="{
+                            'border-status-danger/40 bg-status-danger/10':
+                                alert.severity_tone === 'danger',
+                            'border-status-warning/40 bg-status-warning/10':
+                                alert.severity_tone === 'warning',
+                            'border-status-info/40 bg-status-info/10':
+                                alert.severity_tone === 'info',
+                        }"
+                    >
+                        <AlertTriangle
+                            class="h-3.5 w-3.5"
+                            :class="{
+                                'text-status-danger':
+                                    alert.severity_tone === 'danger',
+                                'text-status-warning':
+                                    alert.severity_tone === 'warning',
+                                'text-status-info':
+                                    alert.severity_tone === 'info',
+                            }"
+                            aria-hidden="true"
+                        />
+                    </span>
+
+                    <div class="flex min-w-0 flex-1 flex-col gap-1.5">
+                        <div class="flex flex-wrap items-center gap-2">
+                            <span
+                                class="truncate text-sm font-semibold text-text-primary"
+                            >
+                                {{ alert.title }}
+                            </span>
+                            <StatusBadge
+                                v-if="alert.severity_tone && alert.severity"
+                                :tone="alert.severity_tone"
+                            >
+                                {{ alert.severity }}
+                            </StatusBadge>
+                            <span
+                                v-if="alert.project"
+                                class="inline-flex items-center gap-1 rounded-full border border-current/30 px-1.5 py-0.5 text-[10px] font-mono uppercase tracking-[0.18em]"
+                                :class="projectAccentClass(alert.project.color)"
+                            >
+                                {{ alert.project.name }}
+                            </span>
+                        </div>
+                        <p
+                            v-if="alert.description"
+                            class="text-xs text-text-secondary"
+                        >
+                            {{ alert.description }}
+                        </p>
+                        <p
+                            class="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-text-muted"
+                        >
+                            <span class="font-mono uppercase">
+                                {{ alert.source }}
+                            </span>
+                            <span>· {{ statusLabel(alert) }}</span>
+                            <span
+                                v-if="
+                                    alert.last_seen_at &&
+                                    alert.last_seen_at !== alert.triggered_at
+                                "
+                            >
+                                · Last seen {{ alert.last_seen_at }}
+                            </span>
+                        </p>
+                    </div>
+
+                    <div class="flex shrink-0 flex-wrap items-center gap-2">
+                        <button
+                            v-if="alert.can_acknowledge"
+                            type="button"
+                            class="inline-flex items-center gap-1 rounded-md border border-border-subtle bg-background-panel-hover px-2 py-1 text-xs font-semibold text-text-secondary transition hover:border-accent-cyan/60 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                            @click="acknowledge(alert)"
+                        >
+                            <Eye class="h-3 w-3" aria-hidden="true" />
+                            Ack
+                        </button>
+                        <button
+                            v-if="alert.can_resolve"
+                            type="button"
+                            class="inline-flex items-center gap-1 rounded-md border border-status-success/40 bg-status-success/10 px-2 py-1 text-xs font-semibold text-status-success transition hover:border-status-success/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-status-success/60"
+                            @click="resolve(alert)"
+                        >
+                            <CheckCircle2
+                                class="h-3 w-3"
+                                aria-hidden="true"
+                            />
+                            Resolve
+                        </button>
+                        <button
+                            v-if="alert.can_mute"
+                            type="button"
+                            class="inline-flex items-center gap-1 rounded-md border border-border-subtle bg-background-panel-hover px-2 py-1 text-xs font-semibold text-text-muted transition hover:border-status-warning/40 hover:text-status-warning focus:outline-none focus-visible:ring-2 focus-visible:ring-status-warning/60"
+                            @click="mute(alert)"
+                        >
+                            <BellOff class="h-3 w-3" aria-hidden="true" />
+                            Mute
+                        </button>
+                        <a
+                            v-if="alert.affected_entity_url"
+                            :href="alert.affected_entity_url"
+                            :target="
+                                alert.affected_entity_url.startsWith('http')
+                                    ? '_blank'
+                                    : undefined
+                            "
+                            :rel="
+                                alert.affected_entity_url.startsWith('http')
+                                    ? 'noopener noreferrer'
+                                    : undefined
+                            "
+                            class="inline-flex items-center justify-center rounded-md border border-border-subtle bg-background-panel-hover p-1.5 text-text-muted transition hover:border-accent-cyan/60 hover:text-accent-cyan focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                            :aria-label="`Open the entity that triggered ${alert.title}`"
+                        >
+                            <ExternalLink
+                                class="h-3.5 w-3.5"
+                                aria-hidden="true"
+                            />
+                        </a>
+                    </div>
+                </li>
+            </ul>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Alerts/Index.vue
+++ b/resources/js/Pages/Alerts/Index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import { Head, Link, router } from '@inertiajs/vue3';
+import { Head, router } from '@inertiajs/vue3';
 import {
     AlertTriangle,
     Bell,
@@ -257,7 +257,12 @@ const statusLabel = (alert: AlertRow): string => {
                             class="min-w-[140px] rounded-md border border-border-subtle bg-background-panel-hover px-2 py-1.5 text-sm text-text-primary focus:border-accent-cyan/60 focus:outline-none"
                             @change="applyFilters"
                         >
-                            <option :value="null">Any status</option>
+                            <!-- 'all' is the explicit "show every
+                                 status" sentinel — the controller
+                                 reads it as "skip the where clause"
+                                 and round-trips it so reload keeps
+                                 this option selected. -->
+                            <option value="all">Any status</option>
                             <option
                                 v-for="status in filterOptions.statuses"
                                 :key="status"

--- a/resources/js/lib/commands.ts
+++ b/resources/js/lib/commands.ts
@@ -152,8 +152,8 @@ export function getCommands(): Command[] {
             label: 'Go to Alerts',
             group: 'navigation',
             icon: Bell,
-            disabled: true,
-            soonLabel: 'Phase 7',
+            keywords: ['incidents', 'open alerts', 'acks'],
+            run: () => router.visit(route('alerts.index')),
         },
         {
             id: 'go-settings',

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,10 @@
 
 use App\Http\Controllers\ActivityController;
 use App\Http\Controllers\Agent\HostTelemetryController;
+use App\Http\Controllers\AlertAcknowledgeController;
+use App\Http\Controllers\AlertController;
+use App\Http\Controllers\AlertMuteController;
+use App\Http\Controllers\AlertResolveController;
 use App\Http\Controllers\DeploymentController;
 use App\Http\Controllers\GithubConnectionController;
 use App\Http\Controllers\GithubRepositoryImportController;
@@ -128,6 +132,18 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('monitoring.hosts.tokens.rotate');
     Route::delete('/monitoring/hosts/{host}/tokens/{token}', [AgentTokenController::class, 'destroy'])
         ->name('monitoring.hosts.tokens.destroy');
+
+    // Spec 031 — Alerts UI. Index + three single-action lifecycle
+    // verbs (ack / resolve / mute). Trigger / auto-resolve already
+    // happen inside the existing transition emitters (spec 030).
+    Route::get('/alerts', [AlertController::class, 'index'])
+        ->name('alerts.index');
+    Route::post('/alerts/{alert}/acknowledge', AlertAcknowledgeController::class)
+        ->name('alerts.acknowledge');
+    Route::post('/alerts/{alert}/resolve', AlertResolveController::class)
+        ->name('alerts.resolve');
+    Route::post('/alerts/{alert}/mute', AlertMuteController::class)
+        ->name('alerts.mute');
 });
 
 // Spec 017 — GitHub webhooks (no auth/CSRF; signature-verified inside).

--- a/specs/README.md
+++ b/specs/README.md
@@ -42,7 +42,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 4 | Deployments & CI/CD | 🟢 | 3/3 specs done (020–022). Phase complete. |
 | 5 | Website Monitoring | 🟢 | 3/3 specs done (023–025). Phase complete. |
 | 6 | Docker Host Agent MVP | 🟢 | 4/4 specs done (026–029). Phase complete. |
-| 7 | Alerts Engine | 🟡 | 1/3 specs done (030–032). 030 shipped. |
+| 7 | Alerts Engine | 🟡 | 2/3 specs done (030–032). 030, 031 shipped. |
 | 8 | Analytics & Health Scores | ⬜ | — |
 | 9 | Polish & Production Readiness | ⬜ | — |
 | 10 | Future Innovation | ⬜ | — |

--- a/specs/phase-7-alerts/031-alerts-ui.md
+++ b/specs/phase-7-alerts/031-alerts-ui.md
@@ -1,7 +1,7 @@
 ---
 spec: alerts-ui
 phase: 7
-status: in-progress   # not-started | in-progress | blocked | done
+status: done   # not-started | in-progress | blocked | done
 owner: Yoany
 created: 2026-05-27
 updated: 2026-05-29
@@ -252,26 +252,26 @@ timeline, ack / resolve / mute buttons, link to affected entity).
    "sibling user gets 403" path with no changes.
 
 ## Acceptance criteria
-- [ ] `/alerts` page renders the user's open alerts by default, sorted
+- [x] `/alerts` page renders the user's open alerts by default, sorted
       critical-first then newest.
-- [ ] Severity / source / status / project filters all narrow the list
+- [x] Severity / source / status / project filters all narrow the list
       correctly; URL-bound; reload preserves the filter set.
-- [ ] Acknowledge button flips an open alert to `acknowledged` and
+- [x] Acknowledge button flips an open alert to `acknowledged` and
       stamps `acknowledged_at`; idempotent on already-ack'd rows.
-- [ ] Resolve button flips an open / acknowledged alert to `resolved`,
+- [x] Resolve button flips an open / acknowledged alert to `resolved`,
       stamps `resolved_at`, emits one `alert.resolved` activity event.
-- [ ] Mute button flips a non-terminal alert to `muted`; idempotent on
+- [x] Mute button flips a non-terminal alert to `muted`; idempotent on
       already-muted rows.
-- [ ] None of ack / mute emit activity events (silent UI-state changes).
-- [ ] Sidebar `Alerts` entry routes to `/alerts`; Cmd+K `go-alerts`
+- [x] None of ack / mute emit activity events (silent UI-state changes).
+- [x] Sidebar `Alerts` entry routes to `/alerts`; Cmd+K `go-alerts`
       does the same.
-- [ ] Affected-entity icon links to the right page for website / docker
+- [x] Affected-entity icon links to the right page for website / docker
       alerts and to the GitHub run URL for deployment alerts.
-- [ ] Sibling user gets 403 on any of the three state-mutation routes.
-- [ ] Sibling user's alerts do not appear in another user's list.
-- [ ] Empty list (no alerts) shows an "All clear" state; empty result
+- [x] Sibling user gets 403 on any of the three state-mutation routes.
+- [x] Sibling user's alerts do not appear in another user's list.
+- [x] Empty list (no alerts) shows an "All clear" state; empty result
       under a filter shows a "Clear filter" CTA.
-- [ ] Pint clean, `php artisan test` green (new tests added),
+- [x] Pint clean, `php artisan test` green (new tests added),
       `npm run build` clean.
 
 ## Files touched
@@ -303,6 +303,11 @@ Fill in as work progresses.
 ### 2026-05-29
 - Shipping as drafted (silent ack / mute, GitHub Actions URL for deployment, no detail drawer, default landing filter `status: open`, no idempotency change for workflow.failed in this spec).
 - Issue [#92](https://github.com/Copxer/nexus/issues/92) opened, branch `spec/031-alerts-ui` cut off `main`.
+- Backend: `AcknowledgeAlertAction` + `MuteAlertAction` + `AlertController@index` + three single-action lifecycle controllers; routes registered.
+- Frontend: `Pages/Alerts/Index.vue` with the filter bar, per-row severity-toned card, three action buttons gated by `can_*` flags, two empty states; Sidebar Alerts entry enabled, Cmd+K `go-alerts` wired.
+- Tests: 34 new (8 action unit + 14 controller index + 5 resolve + 4 mute + 4 ack). Full suite 537→572 green, Pint clean, build clean.
+- Self-review via `superpowers:code-reviewer`. Addressed: (1) "Any status" dropdown was a silent duplicate of "Open" — added `'all'` URL sentinel + matching controller branch so the user can reach a "show every status" view; (2) `AlertResolveController` short-circuits on a muted alert with a clear error flash (the action's existing whereIn already skipped muted, but the controller was flashing "Alert resolved." misleadingly); (3) tightened the resolve activity-event assertions (`alert_source` / `alert_source_id` metadata + `acknowledged_at` preservation); (4) added a same-severity newest-first sort tie-break test; (5) dropped an unused `Link` import in the Vue page.
+- Deferred: spec 030's `ResolveAlertAction` race window (concurrent user-resolve + background recovery could double-emit). Pre-existing; reviewer accepted as a follow-up.
 
 ## Open questions / blockers
 - **Acknowledge / mute silent vs noisy.** Spec ships them silent (no

--- a/specs/phase-7-alerts/031-alerts-ui.md
+++ b/specs/phase-7-alerts/031-alerts-ui.md
@@ -1,0 +1,326 @@
+---
+spec: alerts-ui
+phase: 7
+status: in-progress   # not-started | in-progress | blocked | done
+owner: Yoany
+created: 2026-05-27
+updated: 2026-05-29
+---
+
+# 031 — Alerts UI + acknowledge / resolve / mute actions
+
+## Goal
+Give the user a place to actually see and act on the alerts spec 030
+started persisting. After 031 a user opens `/alerts`, sees the open
+alerts that affect their projects (sorted by severity, filterable by
+severity / source / project / status), clicks "Acknowledge" / "Resolve"
+/ "Mute" per row, and drills through to the affected entity. Sidebar
+`Alerts` link and Cmd+K `go-alerts` both light up.
+
+No realtime list updates yet — that's 032. Index is page-load with the
+existing activity-rail Reverb stream surfacing new `alert.triggered` /
+`alert.resolved` events in the meantime.
+
+Roadmap refs: §Phase 7 acceptance ("User can acknowledge alert"), §8.12
+Alerts UX Requirements (filters by severity / source / project, alert
+timeline, ack / resolve / mute buttons, link to affected entity).
+
+## Scope
+
+**In scope:**
+
+- **`AlertController@index`** — single method on a thin controller
+  (mirrors `DeploymentController` shape, not the website resource
+  controller — Alerts only have `index` + state-mutation actions, no
+  create / edit / destroy here).
+  - URL-bound filters: `severity`, `source`, `status`, `project_id`,
+    all `sometimes|nullable`, all validated against the respective
+    enums + a user-owns-project rule for `project_id`.
+  - Default filters: `status: 'open'` so the page lands on the
+    actionable set (matches what most ops dashboards do; resolved /
+    muted reachable via the dropdown).
+  - Order: severity (critical → warning → info), then `triggered_at
+    desc`, then `id desc` for tie-break. Sort in PHP off a small
+    severity-priority map so the order is cross-DB.
+  - User scoping: `whereHas('project', owner_user_id = $user->id)`,
+    same convention as the rest of the dashboard queries.
+  - `transform()` per row exposes the fields the Vue needs +
+    `affected_entity_url` (server-resolved so the page stays dumb).
+- **State-mutation actions + controllers** — three single-action
+  invokable controllers (mirrors `RepositorySyncController` shape):
+  - `AlertAcknowledgeController` (`POST /alerts/{alert}/acknowledge`,
+    `alerts.acknowledge`) → calls `AcknowledgeAlertAction`. Flips
+    `status: open → acknowledged`, stamps `acknowledged_at`. Idempotent
+    on a row already acknowledged. Returns `back()->with('status',
+    "Alert acknowledged.")`. Silent — no activity event.
+  - `AlertResolveController` (`POST /alerts/{alert}/resolve`,
+    `alerts.resolve`) → calls the existing `ResolveAlertAction` with
+    the alert's own `(source, source_id, type)` as criteria. Because
+    spec 030's idempotency guarantees at most one open / acknowledged
+    row per `(source, source_id, type)`, this closes exactly the
+    clicked alert. The action already emits an `alert.resolved`
+    activity event — symmetry with auto-resolve preserved.
+  - `AlertMuteController` (`POST /alerts/{alert}/mute`, `alerts.mute`)
+    → calls `MuteAlertAction`. Flips status to `muted`. Idempotent on a
+    row already muted. Silent.
+  - All three: `$this->authorize('update', $alert)` (the existing
+    spec-030 `AlertPolicy::update` gate already maps to "ack / resolve
+    / mute" — see the policy's docblock).
+- **Domain actions.**
+  - `AcknowledgeAlertAction` — single Alert input. No-op when the row
+    is already acknowledged / resolved / muted (idempotent + can't ack
+    a closed alert). Stamps `acknowledged_at = now()` and
+    `last_seen_at = now()`.
+  - `MuteAlertAction` — single Alert input. No-op when already muted /
+    resolved.
+  - `ResolveAlertAction` — **reused as-is** from spec 030. The
+    controller passes `{source, source_id, type}` and the action's
+    existing idempotency contract takes care of the rest.
+- **Routes.** Append below the `monitoring.hosts.*` block in
+  `routes/web.php`, inside the `['auth', 'verified']` group.
+- **`Pages/Alerts/Index.vue`.**
+  - Header with title + counts ("N open, N critical").
+  - Filter bar — four `<select>` dropdowns (severity / source / status
+    / project) modeled on the Deployments index filters. URL-bound via
+    `router.get(route('alerts.index'), {...}, { preserveScroll: true,
+    preserveState: true, only: ['alerts', 'filters', 'filterOptions'] })`.
+  - List: per row shows severity `StatusBadge`, source label, title,
+    description (truncated), triggered-at relative + last-seen-at
+    relative, three action buttons (ack / resolve / mute) shown
+    conditionally by status, and an external-link icon to
+    `affected_entity_url`.
+  - Empty states: (a) no alerts at all → "All clear" success state;
+    (b) no alerts match the filter → "No alerts match this filter" +
+    "Clear filter" CTA (mirrors the Websites index pattern).
+  - Per-row action buttons use `router.post` with `preserveScroll:
+    true` so the page refreshes the list inline.
+- **Sidebar + Cmd+K.**
+  - `Sidebar.vue` — drop `disabled: true` + `soonLabel` from the
+    `Alerts` item; wire `href: route('alerts.index')`.
+  - `commands.ts` — `go-alerts` gains `run: () => router.visit(route(
+    'alerts.index'))` + keywords; loses `disabled` / `soonLabel`.
+- **Affected-entity resolution (`AlertController::transform`).** Server
+  side mapping so the Vue doesn't repeat itself:
+  - `website` → `route('monitoring.websites.show', source_id)`
+  - `docker` → `route('monitoring.hosts.show', source_id)`
+  - `deployment` → `metadata.html_url` (the GitHub Actions run URL we
+    stash on trigger; there's no per-run page in-app yet)
+  - others → `null` (rendered as a disabled icon)
+- **Tests.**
+  - `AlertControllerTest` (feature) — index renders default-open list,
+    severity / source / status / project filters narrow correctly,
+    sibling-user alerts don't leak, sort order is critical-first then
+    newest, invalid filter values 422, `affected_entity_url` shapes for
+    all three sources.
+  - `AlertAcknowledgeControllerTest` — happy path flips + stamps; ack
+    on already-ack row is a no-op (no double-stamp); ack on a
+    resolved / muted row is a no-op; sibling-user 403.
+  - `AlertResolveControllerTest` — happy path flips + emits
+    `alert.resolved` activity; resolve on a row that's already
+    resolved is a no-op; sibling-user 403.
+  - `AlertMuteControllerTest` — happy path flips; mute on already-muted
+    is a no-op; mute on a resolved row is a no-op (resolved is
+    terminal); sibling-user 403.
+  - Unit tests for `AcknowledgeAlertAction` + `MuteAlertAction`
+    parallel to spec 030's pattern.
+
+**Out of scope:**
+
+- **Realtime list updates** — 032 adds a `users.{id}.alerts` Reverb
+  channel + Echo subscription. In 031 the user refreshes / re-navigates
+  to see new alerts. The activity rail (spec 030's `alert.triggered`
+  events on `users.{id}.activity`) already pings on every new alert.
+- **Overview Alerts KPI** — still on `MOCK_KPIS.alerts` until 032.
+- **TopBar notifications bell** — wires to the Alerts channel in 032
+  per the bell's tooltip.
+- **Bulk actions** (ack-all-by-source / resolve-all) — single-row only
+  for MVP. Easy to add later.
+- **Alert detail drawer / page** — the index row + the "link to
+  affected entity" CTA give the user the context they need. A
+  dedicated drawer is polish for a follow-up spec.
+- **`alert.acknowledged` / `alert.muted` activity events** — silent on
+  purpose. Acknowledge / mute are UI-state, not project-state
+  transitions. Trigger and Resolve stay noisy (real signal changes).
+- **AlertRule model + `EvaluateAlertRulesJob`** — see spec 030's
+  Out of Scope.
+- **Outbound notifications** (`AlertNotificationService`, email /
+  Slack) — deferred.
+
+## Plan
+
+1. **Actions.**
+   ```php
+   // AcknowledgeAlertAction
+   public function execute(Alert $alert): Alert
+   {
+       if ($alert->status !== AlertStatus::Open) {
+           return $alert; // idempotent: only fresh opens can be ack'd
+       }
+       $alert->forceFill([
+           'status' => AlertStatus::Acknowledged->value,
+           'acknowledged_at' => now(),
+           'last_seen_at' => now(),
+       ])->save();
+       return $alert;
+   }
+   ```
+   `MuteAlertAction` follows the same shape but only refuses `resolved`
+   as the terminal state — muting an already-ack'd alert is a sensible
+   "I'm not going to act on this right now, stop highlighting."
+
+2. **Single-action controllers** — three files matching the shape of
+   `RepositorySyncController`:
+   ```php
+   class AlertAcknowledgeController extends Controller
+   {
+       public function __invoke(Alert $alert, AcknowledgeAlertAction $ack): RedirectResponse
+       {
+           $this->authorize('update', $alert);
+           $ack->execute($alert);
+           return back()->with('status', 'Alert acknowledged.');
+       }
+   }
+   ```
+   `AlertMuteController` mirrors it. `AlertResolveController` injects
+   `ResolveAlertAction` (the existing one from spec 030) and calls:
+   ```php
+   $resolveAlert->execute([
+       'source' => $alert->source,
+       'source_id' => $alert->source_id,
+       'type' => $alert->type,
+   ]);
+   ```
+
+3. **`AlertController@index`.** Inject the request only; pull filter
+   options from the relevant enums; run the scoped query inline (no
+   separate query class — the shape is simple enough to live in the
+   controller, matching `DeploymentController`).
+   ```php
+   $validated = $request->validate([
+       'severity' => 'sometimes|nullable|in:'.implode(',', AlertSeverity::values()),
+       'source' => 'sometimes|nullable|in:'.implode(',', AlertSource::values()),
+       'status' => 'sometimes|nullable|in:'.implode(',', AlertStatus::values()),
+       'project_id' => [
+           'sometimes', 'nullable', 'integer',
+           Rule::exists('projects', 'id')->where('owner_user_id', $user->id),
+       ],
+   ]);
+   $status = $validated['status'] ?? AlertStatus::Open->value;
+   ```
+   Severity priority sort happens in PHP after `->get()` since
+   `CASE WHEN severity` cross-DB is ugly. Phase-1 alert counts are well
+   below any size where SQL-side sort would matter.
+
+4. **`AlertController::transform`** + `affectedEntityUrl()` private
+   helper — server-resolved URL keyed off `AlertSource`. Phase-7 maps:
+   `website` / `docker` / `deployment`. New sources added in future
+   specs fall through to `null` (UI renders the icon disabled).
+
+5. **Routes** (`routes/web.php`, inside `['auth', 'verified']`):
+   ```php
+   Route::get('/alerts', [AlertController::class, 'index'])
+       ->name('alerts.index');
+   Route::post('/alerts/{alert}/acknowledge', AlertAcknowledgeController::class)
+       ->name('alerts.acknowledge');
+   Route::post('/alerts/{alert}/resolve', AlertResolveController::class)
+       ->name('alerts.resolve');
+   Route::post('/alerts/{alert}/mute', AlertMuteController::class)
+       ->name('alerts.mute');
+   ```
+
+6. **Vue page (`Pages/Alerts/Index.vue`).** Mirror Deployments'
+   filter-bar visual + Websites' list-row visual. Reuse `StatusBadge`
+   for severity (tone from `AlertSeverity::badgeTone()` via the
+   transform). One inline `<select>` per filter; one `<form>` with
+   three submit buttons per row for ack / resolve / mute. The forms
+   POST through `router.post(..., { preserveScroll: true })` so the
+   page partial-reloads in place.
+
+7. **Sidebar.** `Sidebar.vue` — the `alerts` entry today reads
+   `{ label: 'Alerts', soonLabel: 'Phase 7', disabled: true }`. Update
+   to `{ label: 'Alerts', href: route('alerts.index') }`. Keep the icon
+   (Bell) — already correct.
+
+8. **Cmd+K.** `commands.ts` — the `go-alerts` entry today is
+   `disabled: true, soonLabel: 'Phase 7'`. Update to a real `run` +
+   keywords (e.g. `['incidents', 'open alerts', 'acks']`).
+
+9. **Tests.** Action-level unit tests for the two new actions (parallel
+   to spec 030's `TriggerAlertActionTest` shape). Feature tests for the
+   four controllers — happy path, idempotency, policy, filtering,
+   sorting. The existing `AlertPolicy` from spec 030 covers the
+   "sibling user gets 403" path with no changes.
+
+## Acceptance criteria
+- [ ] `/alerts` page renders the user's open alerts by default, sorted
+      critical-first then newest.
+- [ ] Severity / source / status / project filters all narrow the list
+      correctly; URL-bound; reload preserves the filter set.
+- [ ] Acknowledge button flips an open alert to `acknowledged` and
+      stamps `acknowledged_at`; idempotent on already-ack'd rows.
+- [ ] Resolve button flips an open / acknowledged alert to `resolved`,
+      stamps `resolved_at`, emits one `alert.resolved` activity event.
+- [ ] Mute button flips a non-terminal alert to `muted`; idempotent on
+      already-muted rows.
+- [ ] None of ack / mute emit activity events (silent UI-state changes).
+- [ ] Sidebar `Alerts` entry routes to `/alerts`; Cmd+K `go-alerts`
+      does the same.
+- [ ] Affected-entity icon links to the right page for website / docker
+      alerts and to the GitHub run URL for deployment alerts.
+- [ ] Sibling user gets 403 on any of the three state-mutation routes.
+- [ ] Sibling user's alerts do not appear in another user's list.
+- [ ] Empty list (no alerts) shows an "All clear" state; empty result
+      under a filter shows a "Clear filter" CTA.
+- [ ] Pint clean, `php artisan test` green (new tests added),
+      `npm run build` clean.
+
+## Files touched
+Fill in as work progresses.
+
+- `app/Domain/Alerts/Actions/AcknowledgeAlertAction.php` — new
+- `app/Domain/Alerts/Actions/MuteAlertAction.php` — new
+- `app/Http/Controllers/AlertController.php` — new (`index` only)
+- `app/Http/Controllers/AlertAcknowledgeController.php` — new
+- `app/Http/Controllers/AlertResolveController.php` — new
+- `app/Http/Controllers/AlertMuteController.php` — new
+- `routes/web.php` — register the four routes
+- `resources/js/Pages/Alerts/Index.vue` — new
+- `resources/js/Components/Sidebar/Sidebar.vue` — enable Alerts entry
+- `resources/js/lib/commands.ts` — enable `go-alerts`
+- `resources/js/types/index.d.ts` — add an `AlertRow` interface for the page prop
+- `tests/Unit/Domain/Alerts/AcknowledgeAlertActionTest.php` — new
+- `tests/Unit/Domain/Alerts/MuteAlertActionTest.php` — new
+- `tests/Feature/Alerts/AlertControllerTest.php` — new (index)
+- `tests/Feature/Alerts/AlertAcknowledgeControllerTest.php` — new
+- `tests/Feature/Alerts/AlertResolveControllerTest.php` — new
+- `tests/Feature/Alerts/AlertMuteControllerTest.php` — new
+
+## Work log
+
+### 2026-05-27
+- Spec drafted for review.
+
+### 2026-05-29
+- Shipping as drafted (silent ack / mute, GitHub Actions URL for deployment, no detail drawer, default landing filter `status: open`, no idempotency change for workflow.failed in this spec).
+- Issue [#92](https://github.com/Copxer/nexus/issues/92) opened, branch `spec/031-alerts-ui` cut off `main`.
+
+## Open questions / blockers
+- **Acknowledge / mute silent vs noisy.** Spec ships them silent (no
+  activity event). Trigger + Resolve stay noisy because they're project-
+  state transitions. Ack / mute are UI-state. If you want a "Yoany
+  acknowledged the prod-frankfurt-01 outage" rail entry — say so and
+  the actions gain an emission. Default is silent.
+- **Deployment alert "affected entity" target.** Phase 7 ships
+  `metadata.html_url` (the GitHub Actions run page). An in-app
+  per-workflow-run detail page doesn't exist; building one would be a
+  separate spec. Acceptable for MVP?
+- **No alert detail drawer.** The row's truncated description + the
+  affected-entity link cover the common case ("see what's wrong, go
+  fix it"). A drawer that shows full metadata + a timeline of
+  ack / resolve actions is nice polish; doesn't block 031.
+- **Bulk actions.** Roadmap §8.12 doesn't list them. Single-row only
+  for MVP; revisit if the user ends up clicking ack 20× per outage.
+- **Default landing filter.** 031 ships `status: open` as the default.
+  Some teams want "active" = open + acknowledged (still firing,
+  someone's on it). Adjustable via the dropdown either way; calling
+  out the default-pick.

--- a/specs/phase-7-alerts/README.md
+++ b/specs/phase-7-alerts/README.md
@@ -15,7 +15,7 @@ matching alert. Overview's Alerts KPI swaps from the long-standing
 | # | Task | Status |
 |---|------|--------|
 | 030 | Alerts scaffolding + transition-based promotion (events → Alert rows) | 🟢 |
-| 031 | Alerts UI + acknowledge / resolve / mute actions | ⬜ |
+| 031 | Alerts UI + acknowledge / resolve / mute actions | 🟢 |
 | 032 | Realtime updates + Overview Alerts KPI wiring (closes phase 7) | ⬜ |
 
 ## Acceptance criteria (phase-level)

--- a/tests/Feature/Alerts/AlertAcknowledgeControllerTest.php
+++ b/tests/Feature/Alerts/AlertAcknowledgeControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Alerts;
+
+use App\Enums\AlertStatus;
+use App\Models\Alert;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AlertAcknowledgeControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_owner_can_acknowledge_an_open_alert(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $alert = Alert::factory()->create(['project_id' => $project->id]);
+
+        $response = $this->actingAs($user)
+            ->post(route('alerts.acknowledge', $alert->id));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('status', 'Alert acknowledged.');
+        $this->assertSame(AlertStatus::Acknowledged, $alert->fresh()->status);
+    }
+
+    public function test_re_acknowledging_is_idempotent(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $alert = Alert::factory()->acknowledged()->create(['project_id' => $project->id]);
+        $originalAck = $alert->acknowledged_at;
+
+        $this->travel(1)->minute();
+        $this->actingAs($user)->post(route('alerts.acknowledge', $alert->id));
+
+        $alert->refresh();
+        $this->assertSame(AlertStatus::Acknowledged, $alert->status);
+        $this->assertSame(
+            $originalAck?->toIso8601String(),
+            $alert->acknowledged_at?->toIso8601String(),
+        );
+    }
+
+    public function test_sibling_user_is_forbidden(): void
+    {
+        $user = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $othersProject = Project::factory()->create(['owner_user_id' => $other->id]);
+        $alert = Alert::factory()->create(['project_id' => $othersProject->id]);
+
+        $this->actingAs($user)
+            ->post(route('alerts.acknowledge', $alert->id))
+            ->assertForbidden();
+
+        $this->assertSame(AlertStatus::Open, $alert->fresh()->status);
+    }
+
+    public function test_guests_cannot_acknowledge(): void
+    {
+        $alert = Alert::factory()->create();
+
+        $this->post(route('alerts.acknowledge', $alert->id))
+            ->assertRedirect(route('login'));
+    }
+}

--- a/tests/Feature/Alerts/AlertControllerTest.php
+++ b/tests/Feature/Alerts/AlertControllerTest.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace Tests\Feature\Alerts;
+
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Models\Alert;
+use App\Models\Host;
+use App\Models\Project;
+use App\Models\User;
+use App\Models\Website;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class AlertControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_index_lists_open_alerts_under_users_projects_by_default(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'title' => 'fresh outage',
+        ]);
+        // Resolved row should not appear under the default open filter.
+        Alert::factory()->resolved()->create([
+            'project_id' => $project->id,
+            'title' => 'old outage',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('alerts.index'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Alerts/Index')
+                    ->has('alerts', 1)
+                    ->where('alerts.0.title', 'fresh outage')
+                    ->where('filters.status', 'open')
+            );
+    }
+
+    public function test_index_does_not_leak_alerts_from_sibling_users(): void
+    {
+        $user = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $othersProject = Project::factory()->create(['owner_user_id' => $other->id]);
+        Alert::factory()->create([
+            'project_id' => $othersProject->id,
+            'title' => "stranger's alert",
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('alerts.index'))
+            ->assertSuccessful()
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('alerts', 0));
+    }
+
+    public function test_index_filters_by_severity(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+            'title' => 'critical',
+        ]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Warning->value,
+            'title' => 'warning',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('alerts.index', ['severity' => 'warning']))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('alerts', 1)
+                    ->where('alerts.0.title', 'warning'),
+            );
+    }
+
+    public function test_index_filters_by_source(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Alert::factory()->forHost()->create(['project_id' => $project->id]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website->value,
+            'title' => 'website',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('alerts.index', ['source' => 'website']))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('alerts', 1)
+                    ->where('alerts.0.title', 'website'),
+            );
+    }
+
+    public function test_index_filters_by_status_acknowledged(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Alert::factory()->acknowledged()->create([
+            'project_id' => $project->id,
+            'title' => 'ack',
+        ]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'title' => 'open',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('alerts.index', ['status' => 'acknowledged']))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('alerts', 1)
+                    ->where('alerts.0.title', 'ack'),
+            );
+    }
+
+    public function test_index_filters_by_project(): void
+    {
+        $user = $this->verifiedUser();
+        $kept = Project::factory()->create(['owner_user_id' => $user->id]);
+        $dropped = Project::factory()->create(['owner_user_id' => $user->id]);
+        Alert::factory()->create(['project_id' => $kept->id, 'title' => 'kept']);
+        Alert::factory()->create(['project_id' => $dropped->id, 'title' => 'dropped']);
+
+        $this->actingAs($user)
+            ->get(route('alerts.index', ['project_id' => $kept->id]))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('alerts', 1)
+                    ->where('alerts.0.title', 'kept'),
+            );
+    }
+
+    public function test_index_orders_critical_first_then_warning_then_info(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Info->value,
+            'title' => 'info-row',
+            'triggered_at' => now(),
+        ]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+            'title' => 'critical-row',
+            'triggered_at' => now()->subMinute(),
+        ]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Warning->value,
+            'title' => 'warning-row',
+            'triggered_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('alerts.index'))
+            ->assertInertia(function (AssertableInertia $page) {
+                $page->has('alerts', 3)
+                    ->where('alerts.0.title', 'critical-row')
+                    ->where('alerts.1.title', 'warning-row')
+                    ->where('alerts.2.title', 'info-row');
+            });
+    }
+
+    public function test_index_rejects_an_invalid_severity_filter(): void
+    {
+        $user = $this->verifiedUser();
+
+        $this->actingAs($user)
+            ->get(route('alerts.index', ['severity' => 'meh']))
+            ->assertSessionHasErrors('severity');
+    }
+
+    public function test_index_rejects_a_foreign_project_id(): void
+    {
+        $user = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $othersProject = Project::factory()->create(['owner_user_id' => $other->id]);
+
+        $this->actingAs($user)
+            ->get(route('alerts.index', ['project_id' => $othersProject->id]))
+            ->assertSessionHasErrors('project_id');
+    }
+
+    public function test_index_resolves_affected_entity_url_per_source(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        $website = Website::factory()->create(['project_id' => $project->id]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website->value,
+            'source_id' => $website->id,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical->value,
+            'title' => 'website row',
+        ]);
+
+        $host = Host::factory()->create(['project_id' => $project->id]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Docker->value,
+            'source_id' => $host->id,
+            'type' => 'host.offline',
+            'severity' => AlertSeverity::Critical->value,
+            'title' => 'host row',
+        ]);
+
+        Alert::factory()->forWorkflowRun()->create([
+            'project_id' => $project->id,
+            'source_id' => 1234,
+            'metadata' => [
+                'html_url' => 'https://github.com/org/repo/actions/runs/1234',
+            ],
+            'title' => 'deployment row',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('alerts.index'))
+            ->assertInertia(function (AssertableInertia $page) use ($website, $host) {
+                $rows = collect($page->toArray()['props']['alerts']);
+                $websiteRow = $rows->firstWhere('title', 'website row');
+                $hostRow = $rows->firstWhere('title', 'host row');
+                $deploymentRow = $rows->firstWhere('title', 'deployment row');
+
+                $this->assertSame(
+                    route('monitoring.websites.show', $website->id),
+                    $websiteRow['affected_entity_url'],
+                );
+                $this->assertSame(
+                    route('monitoring.hosts.show', $host->id),
+                    $hostRow['affected_entity_url'],
+                );
+                $this->assertSame(
+                    'https://github.com/org/repo/actions/runs/1234',
+                    $deploymentRow['affected_entity_url'],
+                );
+            });
+    }
+
+    public function test_index_can_action_flags_match_status(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Alert::factory()->create(['project_id' => $project->id, 'title' => 'open row']);
+
+        $this->actingAs($user)
+            ->get(route('alerts.index'))
+            ->assertInertia(function (AssertableInertia $page) {
+                $page->where('alerts.0.can_acknowledge', true)
+                    ->where('alerts.0.can_resolve', true)
+                    ->where('alerts.0.can_mute', true);
+            });
+    }
+
+    public function test_index_filter_options_carry_enum_values_and_user_projects(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create([
+            'owner_user_id' => $user->id,
+            'name' => 'Marketing',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('alerts.index'))
+            ->assertInertia(function (AssertableInertia $page) {
+                $page->has('filterOptions.severities', 3)
+                    ->has('filterOptions.statuses', 4)
+                    ->has('filterOptions.sources', 6)
+                    ->has('filterOptions.projects', 1)
+                    ->where('filterOptions.projects.0.name', 'Marketing');
+            });
+    }
+}

--- a/tests/Feature/Alerts/AlertControllerTest.php
+++ b/tests/Feature/Alerts/AlertControllerTest.php
@@ -151,6 +151,51 @@ class AlertControllerTest extends TestCase
             );
     }
 
+    public function test_status_all_sentinel_returns_every_status_in_one_list(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Alert::factory()->create(['project_id' => $project->id]); // open
+        Alert::factory()->acknowledged()->create(['project_id' => $project->id]);
+        Alert::factory()->resolved()->create(['project_id' => $project->id]);
+        Alert::factory()->muted()->create(['project_id' => $project->id]);
+
+        $this->actingAs($user)
+            ->get(route('alerts.index', ['status' => 'all']))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('alerts', 4)
+                    ->where('filters.status', 'all'),
+            );
+    }
+
+    public function test_index_orders_newest_first_within_the_same_severity(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+            'title' => 'older critical',
+            'triggered_at' => now()->subMinutes(10),
+        ]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+            'title' => 'newer critical',
+            'triggered_at' => now()->subMinute(),
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('alerts.index'))
+            ->assertInertia(function (AssertableInertia $page) {
+                $page->has('alerts', 2)
+                    ->where('alerts.0.title', 'newer critical')
+                    ->where('alerts.1.title', 'older critical');
+            });
+    }
+
     public function test_index_orders_critical_first_then_warning_then_info(): void
     {
         $user = $this->verifiedUser();

--- a/tests/Feature/Alerts/AlertMuteControllerTest.php
+++ b/tests/Feature/Alerts/AlertMuteControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\Alerts;
+
+use App\Enums\AlertStatus;
+use App\Models\Alert;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AlertMuteControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_owner_can_mute_an_open_alert(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $alert = Alert::factory()->create(['project_id' => $project->id]);
+
+        $response = $this->actingAs($user)->post(route('alerts.mute', $alert->id));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('status', 'Alert muted.');
+        $this->assertSame(AlertStatus::Muted, $alert->fresh()->status);
+    }
+
+    public function test_already_muted_alert_stays_muted(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $alert = Alert::factory()->muted()->create(['project_id' => $project->id]);
+        $originalLastSeen = $alert->last_seen_at;
+
+        $this->travel(1)->minute();
+        $this->actingAs($user)->post(route('alerts.mute', $alert->id));
+
+        $alert->refresh();
+        $this->assertSame(AlertStatus::Muted, $alert->status);
+        $this->assertSame(
+            $originalLastSeen?->toIso8601String(),
+            $alert->last_seen_at?->toIso8601String(),
+        );
+    }
+
+    public function test_resolved_alert_cannot_be_muted(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $alert = Alert::factory()->resolved()->create(['project_id' => $project->id]);
+
+        $this->actingAs($user)->post(route('alerts.mute', $alert->id));
+
+        $this->assertSame(AlertStatus::Resolved, $alert->fresh()->status);
+    }
+
+    public function test_sibling_user_is_forbidden(): void
+    {
+        $user = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $othersProject = Project::factory()->create(['owner_user_id' => $other->id]);
+        $alert = Alert::factory()->create(['project_id' => $othersProject->id]);
+
+        $this->actingAs($user)
+            ->post(route('alerts.mute', $alert->id))
+            ->assertForbidden();
+
+        $this->assertSame(AlertStatus::Open, $alert->fresh()->status);
+    }
+}

--- a/tests/Feature/Alerts/AlertResolveControllerTest.php
+++ b/tests/Feature/Alerts/AlertResolveControllerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\Alerts;
+
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
+use App\Models\ActivityEvent;
+use App\Models\Alert;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AlertResolveControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_owner_can_resolve_an_open_alert_and_emits_activity(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $alert = Alert::factory()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website->value,
+            'source_id' => 42,
+            'type' => 'website.down',
+            'title' => 'Marketing site',
+        ]);
+
+        $response = $this->actingAs($user)
+            ->post(route('alerts.resolve', $alert->id));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('status', 'Alert resolved.');
+        $alert->refresh();
+        $this->assertSame(AlertStatus::Resolved, $alert->status);
+        $this->assertNotNull($alert->resolved_at);
+
+        $event = ActivityEvent::query()
+            ->where('event_type', 'alert.resolved')
+            ->firstOrFail();
+        $this->assertSame('alerts', $event->source);
+        $this->assertSame($alert->id, $event->metadata['alert_id']);
+        $this->assertSame('Marketing site resolved', $event->title);
+    }
+
+    public function test_acknowledged_alert_can_be_resolved(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $alert = Alert::factory()->acknowledged()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Docker->value,
+            'source_id' => 5,
+            'type' => 'host.offline',
+        ]);
+
+        $this->actingAs($user)->post(route('alerts.resolve', $alert->id));
+
+        $this->assertSame(AlertStatus::Resolved, $alert->fresh()->status);
+    }
+
+    public function test_resolving_an_already_resolved_alert_is_a_noop(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $alert = Alert::factory()->resolved()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website->value,
+            'source_id' => 1,
+            'type' => 'website.down',
+        ]);
+
+        $this->actingAs($user)->post(route('alerts.resolve', $alert->id));
+
+        $this->assertSame(0, ActivityEvent::query()->count(), 'no spurious activity event');
+        $this->assertSame(AlertStatus::Resolved, $alert->fresh()->status);
+    }
+
+    public function test_sibling_user_is_forbidden(): void
+    {
+        $user = $this->verifiedUser();
+        $other = $this->verifiedUser();
+        $othersProject = Project::factory()->create(['owner_user_id' => $other->id]);
+        $alert = Alert::factory()->create(['project_id' => $othersProject->id]);
+
+        $this->actingAs($user)
+            ->post(route('alerts.resolve', $alert->id))
+            ->assertForbidden();
+
+        $this->assertSame(AlertStatus::Open, $alert->fresh()->status);
+    }
+}

--- a/tests/Feature/Alerts/AlertResolveControllerTest.php
+++ b/tests/Feature/Alerts/AlertResolveControllerTest.php
@@ -46,7 +46,30 @@ class AlertResolveControllerTest extends TestCase
             ->firstOrFail();
         $this->assertSame('alerts', $event->source);
         $this->assertSame($alert->id, $event->metadata['alert_id']);
+        $this->assertSame('website', $event->metadata['alert_source']);
+        $this->assertSame(42, $event->metadata['alert_source_id']);
         $this->assertSame('Marketing site resolved', $event->title);
+    }
+
+    public function test_resolve_refuses_a_muted_alert_with_a_clear_error(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $alert = Alert::factory()->muted()->create(['project_id' => $project->id]);
+
+        $response = $this->actingAs($user)
+            ->post(route('alerts.resolve', $alert->id));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('error');
+        $this->assertSame(AlertStatus::Muted, $alert->fresh()->status);
+        $this->assertSame(
+            0,
+            ActivityEvent::query()
+                ->where('event_type', 'alert.resolved')
+                ->count(),
+            'no spurious activity event on the refused resolve',
+        );
     }
 
     public function test_acknowledged_alert_can_be_resolved(): void
@@ -59,10 +82,24 @@ class AlertResolveControllerTest extends TestCase
             'source_id' => 5,
             'type' => 'host.offline',
         ]);
+        $originalAck = $alert->acknowledged_at;
 
         $this->actingAs($user)->post(route('alerts.resolve', $alert->id));
 
-        $this->assertSame(AlertStatus::Resolved, $alert->fresh()->status);
+        $alert->refresh();
+        $this->assertSame(AlertStatus::Resolved, $alert->status);
+        $this->assertNotNull($alert->resolved_at);
+        $this->assertSame(
+            $originalAck?->toIso8601String(),
+            $alert->acknowledged_at?->toIso8601String(),
+            'acknowledged_at is preserved through resolve',
+        );
+        $this->assertSame(
+            1,
+            ActivityEvent::query()
+                ->where('event_type', 'alert.resolved')
+                ->count(),
+        );
     }
 
     public function test_resolving_an_already_resolved_alert_is_a_noop(): void
@@ -78,7 +115,15 @@ class AlertResolveControllerTest extends TestCase
 
         $this->actingAs($user)->post(route('alerts.resolve', $alert->id));
 
-        $this->assertSame(0, ActivityEvent::query()->count(), 'no spurious activity event');
+        // Filter by event_type so the assertion stays sharp even if
+        // the action ever starts emitting other event types.
+        $this->assertSame(
+            0,
+            ActivityEvent::query()
+                ->where('event_type', 'alert.resolved')
+                ->count(),
+            'no spurious alert.resolved on re-resolve',
+        );
         $this->assertSame(AlertStatus::Resolved, $alert->fresh()->status);
     }
 

--- a/tests/Unit/Domain/Alerts/AcknowledgeAlertActionTest.php
+++ b/tests/Unit/Domain/Alerts/AcknowledgeAlertActionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Unit\Domain\Alerts;
+
+use App\Domain\Alerts\Actions\AcknowledgeAlertAction;
+use App\Enums\AlertStatus;
+use App\Models\Alert;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AcknowledgeAlertActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_open_alert_flips_to_acknowledged_and_stamps(): void
+    {
+        $alert = Alert::factory()->create();
+
+        $result = app(AcknowledgeAlertAction::class)->execute($alert);
+
+        $this->assertSame($alert->id, $result->id);
+        $result->refresh();
+        $this->assertSame(AlertStatus::Acknowledged, $result->status);
+        $this->assertNotNull($result->acknowledged_at);
+        $this->assertNotNull($result->last_seen_at);
+    }
+
+    public function test_already_acknowledged_alert_is_left_alone(): void
+    {
+        $alert = Alert::factory()->acknowledged()->create();
+        $originalAck = $alert->acknowledged_at;
+
+        $this->travel(2)->minutes();
+        app(AcknowledgeAlertAction::class)->execute($alert);
+
+        $alert->refresh();
+        $this->assertSame(
+            $originalAck?->toIso8601String(),
+            $alert->acknowledged_at?->toIso8601String(),
+            'no double-stamp on re-ack',
+        );
+    }
+
+    public function test_resolved_alert_cannot_be_acknowledged(): void
+    {
+        $alert = Alert::factory()->resolved()->create();
+
+        app(AcknowledgeAlertAction::class)->execute($alert);
+
+        $this->assertSame(AlertStatus::Resolved, $alert->fresh()->status);
+    }
+
+    public function test_muted_alert_cannot_be_acknowledged(): void
+    {
+        $alert = Alert::factory()->muted()->create();
+
+        app(AcknowledgeAlertAction::class)->execute($alert);
+
+        $this->assertSame(AlertStatus::Muted, $alert->fresh()->status);
+    }
+}

--- a/tests/Unit/Domain/Alerts/MuteAlertActionTest.php
+++ b/tests/Unit/Domain/Alerts/MuteAlertActionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit\Domain\Alerts;
+
+use App\Domain\Alerts\Actions\MuteAlertAction;
+use App\Enums\AlertStatus;
+use App\Models\Alert;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MuteAlertActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_open_alert_flips_to_muted(): void
+    {
+        $alert = Alert::factory()->create();
+
+        app(MuteAlertAction::class)->execute($alert);
+
+        $this->assertSame(AlertStatus::Muted, $alert->fresh()->status);
+    }
+
+    public function test_acknowledged_alert_can_still_be_muted(): void
+    {
+        $alert = Alert::factory()->acknowledged()->create();
+
+        app(MuteAlertAction::class)->execute($alert);
+
+        $this->assertSame(AlertStatus::Muted, $alert->fresh()->status);
+    }
+
+    public function test_already_muted_alert_is_left_alone(): void
+    {
+        $alert = Alert::factory()->muted()->create();
+        $originalLastSeen = $alert->last_seen_at;
+
+        $this->travel(2)->minutes();
+        app(MuteAlertAction::class)->execute($alert);
+
+        $alert->refresh();
+        $this->assertSame(AlertStatus::Muted, $alert->status);
+        $this->assertSame(
+            $originalLastSeen?->toIso8601String(),
+            $alert->last_seen_at?->toIso8601String(),
+        );
+    }
+
+    public function test_resolved_alert_cannot_be_muted(): void
+    {
+        // Resolved is terminal — mute can't override (otherwise a
+        // resolved-then-muted alert would silently re-open from a
+        // future trigger inside the mute window, which is confusing).
+        $alert = Alert::factory()->resolved()->create();
+
+        app(MuteAlertAction::class)->execute($alert);
+
+        $this->assertSame(AlertStatus::Resolved, $alert->fresh()->status);
+    }
+}


### PR DESCRIPTION
Closes #92

Spec: `specs/phase-7-alerts/031-alerts-ui.md`

Builds the `/alerts` page on top of spec 030's data layer; lights up the sidebar Alerts entry and Cmd+K `go-alerts`. No realtime list updates yet — that's 032.

## Summary

- **Backend.** `AcknowledgeAlertAction` + `MuteAlertAction` (single-Alert input, silent — UI-state, not project-state). `AlertController@index` with URL-bound `severity` / `source` / `status` / `project_id` filters (modeled on `DeploymentController`); default landing `status: open`; sort priority is status → severity → triggered_at desc → id desc in PHP. Three single-action invokable controllers for ack / resolve / mute mirror `RepositorySyncController`'s shape. `AlertResolveController` **reuses spec 030's `ResolveAlertAction`** — Trigger's idempotency contract closes exactly the clicked alert and emits the same `alert.resolved` activity event the auto-resolve path does. Server-resolved `affected_entity_url` per row (website → monitor show, docker → host show, deployment → `metadata.html_url`); per-row `can_acknowledge` / `can_resolve` / `can_mute` flags gate Vue button visibility.
- **Frontend.** `Pages/Alerts/Index.vue` with the filter bar, severity-toned row cards, three action buttons gated by `can_*`, external-link icon to the affected entity, "All clear" + "No filter matches" empty states. Sidebar Alerts entry drops the disabled `Phase 7` label; Cmd+K `go-alerts` enabled.

## Test plan
- [x] `/alerts` renders open alerts by default, sorted critical-first then newest
- [x] Severity / source / status / project filters narrow the list; URL-bound; reload preserves filters
- [x] `status: 'all'` sentinel renders every status in one list (added during self-review — the original "Any status" option was a silent duplicate of "Open")
- [x] Acknowledge flips open → acknowledged + stamps `acknowledged_at`; idempotent on already-ack'd / resolved / muted rows
- [x] Resolve flips open / acknowledged → resolved, stamps `resolved_at`, preserves `acknowledged_at`, emits one `alert.resolved` activity event with `alert_source` + `alert_source_id` metadata
- [x] Mute flips a non-terminal alert to muted; idempotent on already-muted; refuses to mute a resolved row
- [x] Resolve on a **muted** alert returns a clear error flash ("Cannot resolve a muted alert. Unmute it first."), leaves the row unchanged, no activity event (defense in depth — Vue already hides the button)
- [x] Ack + mute emit no activity events; Trigger + Resolve stay noisy
- [x] Sidebar `Alerts` entry routes to `/alerts`; Cmd+K `go-alerts` does the same
- [x] Affected-entity icon links to the right page (website / docker → in-app; deployment → GitHub Actions URL)
- [x] Sibling user gets 403 on the three state-mutation routes; sibling's alerts don't leak into the list
- [x] Empty list shows "All clear"; empty filtered result shows "Clear filter" CTA
- [x] Pint clean, `php artisan test` green (572 total, +34 new), `npm run build` clean

## Self-review notes
Reviewed via `superpowers:code-reviewer`. Addressed before merge:
- "Any status" dropdown silent-duplicate-of-"Open" fixed via the `'all'` URL sentinel.
- `AlertResolveController` muted-alert silent-no-op fixed via an explicit short-circuit + error flash.
- Tightened the resolve activity-event assertions (`alert_source` / `alert_source_id` + `acknowledged_at` preservation).
- Added a same-severity newest-first sort tie-break test.
- Dropped an unused `Link` import in the Vue page.

## What this PR is *not*

- **No realtime list updates.** Spec 032 adds the `users.{id}.alerts` Reverb channel + Echo subscription. In 031 the user refreshes / re-navigates to see new alerts; the activity rail's existing `alert.triggered` stream surfaces fresh alerts in real time on every other page.
- **Overview Alerts KPI** stays on `MOCK_KPIS.alerts` until 032.
- **TopBar notifications bell** stays disabled; 032 wires it.
- **`ResolveAlertAction` race window** (concurrent user-resolve + background recovery could double-emit `alert.resolved`) — pre-existing spec 030 issue, **not introduced by 031**, but materially more reachable now that 031 turns the single-threaded recovery path into a two-source-emitter system. Reviewer accepted as a follow-up; fix is either a `lockForUpdate` inside the action's loop or a status re-check after the SELECT.
- **Bulk actions** (ack-all-by-source / resolve-all) — single-row only for MVP.
- **Alert detail drawer / page** — the row + affected-entity CTA cover the common case.