### PR TITLE
fix(alerts): guard ResolveAlertAction against concurrent close race

### DIFF
--- a/app/Domain/Alerts/Actions/ResolveAlertAction.php
+++ b/app/Domain/Alerts/Actions/ResolveAlertAction.php
@@ -9,6 +9,7 @@ use App\Enums\AlertStatus;
 use App\Events\AlertResolved;
 use App\Models\Alert;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Close every open or acknowledged Alert matching a recovery
@@ -22,8 +23,28 @@ use Illuminate\Support\Carbon;
  * through recovery they can mute (031).
  *
  * For each closed row the action emits an `alert.resolved` activity
- * event so the rail picks up the recovery in realtime. A no-op call
+ * event and (spec 032) an `AlertResolved` broadcast so the rail + the
+ * `/alerts` page + the TopBar bell react in realtime. A no-op call
  * (nothing matches) emits nothing.
+ *
+ * **Race-guard (post-032 follow-up).** Two callers can hit the same
+ * `(source, source_id, type)` near-simultaneously — e.g. a user
+ * clicking Resolve in the browser while a website-monitor cron's
+ * recovery path is mid-flight. Without a guard, both `query->get()`
+ * SELECTs return the row, both flip + emit, both broadcast — the
+ * rail double-renders the recovery and the TopBar badge churns.
+ *
+ * The guard: re-fetch each candidate inside a per-row transaction
+ * with `lockForUpdate()` and a fresh `whereIn('status', [open,
+ * acknowledged])` filter. The first caller wins the row-level lock,
+ * flips + emits, releases. The second caller's re-fetch returns
+ * `null` (status is now resolved → filter excludes it) and the close
+ * path is silently skipped. The action's return value reports the
+ * rows actually closed, not the rows the initial SELECT returned.
+ *
+ * On SQLite (the dev/test DB) `lockForUpdate` is a no-op — file-level
+ * locks already serialize writes, so the guard is harmless and the
+ * status re-check on its own still catches stale candidates.
  */
 class ResolveAlertAction
 {
@@ -37,7 +58,9 @@ class ResolveAlertAction
      *     source_id: int|null,
      *     type?: string,
      * }  $criteria
-     * @return int Number of Alerts resolved.
+     * @return int Number of Alerts actually closed (may be less than the
+     *             initial SELECT returned if concurrent callers won the
+     *             race for some rows — see the race-guard note above).
      */
     public function execute(array $criteria): int
     {
@@ -57,15 +80,47 @@ class ResolveAlertAction
             $query->where('type', $criteria['type']);
         }
 
-        $resolving = $query->get();
+        $candidates = $query->get();
 
-        if ($resolving->isEmpty()) {
+        if ($candidates->isEmpty()) {
             return 0;
         }
 
         $now = Carbon::now();
+        $closed = 0;
 
-        foreach ($resolving as $alert) {
+        foreach ($candidates as $candidate) {
+            if ($this->closeIfStillActionable($candidate->id, $source, $now)) {
+                $closed++;
+            }
+        }
+
+        return $closed;
+    }
+
+    /**
+     * Close one candidate alert under a row-level lock; returns true
+     * iff this caller actually flipped the row + emitted. A racing
+     * caller that already won the lock returns false here (the
+     * re-fetch finds the row's status outside the `[open,
+     * acknowledged]` set, so nothing to do).
+     */
+    private function closeIfStillActionable(int $candidateId, string $source, Carbon $now): bool
+    {
+        return DB::transaction(function () use ($candidateId, $source, $now): bool {
+            $alert = Alert::query()
+                ->whereKey($candidateId)
+                ->whereIn('status', [
+                    AlertStatus::Open->value,
+                    AlertStatus::Acknowledged->value,
+                ])
+                ->lockForUpdate()
+                ->first();
+
+            if ($alert === null) {
+                return false; // racing caller already closed it
+            }
+
             $alert->forceFill([
                 'status' => AlertStatus::Resolved->value,
                 'resolved_at' => $now,
@@ -86,13 +141,14 @@ class ResolveAlertAction
             ]);
 
             // Spec 032 — dedicated alerts broadcast per closed row.
-            // Trigger's idempotency means the typical resolve closes
-            // a single row, but the per-row dispatch stays correct if
-            // a future caller ever resolves N at once.
+            // Inside the same transaction as the close + activity
+            // event so the broadcast can't race the write (the
+            // `ShouldDispatchAfterCommit` interface defers it until
+            // commit).
             $alert->loadMissing('project:id,owner_user_id');
             AlertResolved::dispatch($alert->id, $alert->project?->owner_user_id);
-        }
 
-        return $resolving->count();
+            return true;
+        });
     }
 }

--- a/tests/Unit/Domain/Alerts/ResolveAlertActionTest.php
+++ b/tests/Unit/Domain/Alerts/ResolveAlertActionTest.php
@@ -11,6 +11,7 @@ use App\Models\Alert;
 use App\Models\Project;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Tests\TestCase;
 
@@ -201,5 +202,63 @@ class ResolveAlertActionTest extends TestCase
         ]);
 
         Event::assertNotDispatched(AlertResolved::class);
+    }
+
+    public function test_race_guard_skips_an_alert_concurrently_resolved_during_iteration(): void
+    {
+        // Simulates a racing caller (eg. a website-monitor cron's
+        // recovery path) flipping the alert to resolved between the
+        // action's initial SELECT and the per-row `lockForUpdate`
+        // re-fetch. The race guard's whereIn('status', [open, ack'd])
+        // filter on the lock-acquiring SELECT must catch this — the
+        // close + emit + broadcast should all be skipped, not
+        // double-fired.
+        $alert = Alert::factory()->create([
+            'source' => AlertSource::Website->value,
+            'source_id' => 100,
+            'type' => 'website.down',
+            'status' => AlertStatus::Open->value,
+        ]);
+
+        // Listener fires on every Alert retrieval. The first time we
+        // see the still-open candidate row (the action's initial
+        // SELECT), we flip its DB-side status to resolved directly
+        // (bypassing the model so this listener doesn't re-trigger).
+        // The action's per-row `lockForUpdate` re-fetch then sees the
+        // new status and the whereIn filter skips it.
+        $flipped = false;
+        $listener = function (Alert $model) use ($alert, &$flipped): void {
+            if ($flipped) {
+                return;
+            }
+            if ($model->id !== $alert->id) {
+                return;
+            }
+            if ($model->status !== AlertStatus::Open) {
+                return;
+            }
+            DB::table('alerts')
+                ->where('id', $alert->id)
+                ->update(['status' => AlertStatus::Resolved->value]);
+            $flipped = true;
+        };
+        Alert::retrieved($listener);
+
+        $closed = app(ResolveAlertAction::class)->execute([
+            'source' => AlertSource::Website,
+            'source_id' => 100,
+        ]);
+
+        $this->assertSame(0, $closed, 'race guard reported zero closes');
+        $this->assertSame(
+            0,
+            ActivityEvent::query()
+                ->where('event_type', 'alert.resolved')
+                ->count(),
+            'no spurious alert.resolved activity event',
+        );
+        // The row landed resolved via the racing caller's direct
+        // update (simulating the other resolve path winning the lock).
+        $this->assertSame(AlertStatus::Resolved, $alert->fresh()->status);
     }
 }


### PR DESCRIPTION
Follow-up to spec 032 (PR #95) — closes the deferred race window in `ResolveAlertAction`.

## The race
Two callers can hit the same `(source, source_id, type)` near-simultaneously — eg. a user clicking Resolve in the browser while a website-monitor cron's recovery path is mid-flight. Without a guard, both `query->get()` SELECTs return the row, both flip + emit + broadcast — the rail double-renders the recovery, the TopBar bell double-counts, two `alert.resolved` activity rows get written.

## The fix
Re-fetch each candidate inside a per-row `DB::transaction` with `lockForUpdate()` plus a fresh `whereIn('status', [open, acknowledged])` filter. The first caller wins the row-level lock, flips + emits, releases. The second caller's re-fetch returns `null` (status is now `resolved` → filter excludes it) and the close path is silently skipped. The action's return value reports rows actually closed, not the rows the initial SELECT returned.

On SQLite (dev/test DB) `lockForUpdate` is a no-op — file-level locks already serialize writes, so the guard is harmless and the status re-check on its own still catches stale candidates. On MySQL/Postgres the row-level lock is the real serialization point.

The broadcast (`AlertResolved`) stays inside the closure but is `ShouldDispatchAfterCommit`, so it only fires after the row lock is released — no held-lock-during-HTTP issue.

## Test plan
- [x] New regression test `test_race_guard_skips_an_alert_concurrently_resolved_during_iteration` — uses `Alert::retrieved` listener to flip the row to `resolved` between the action's outer SELECT and the inner locked re-fetch; asserts `\$closed === 0` and no spurious activity row.
- [x] Existing 8 `ResolveAlertActionTest` tests still pass.
- [x] Full suite: 597 tests / 2346 assertions pass.
- [x] Pint clean.
- [x] `npm run build` clean.

## Self-review notes
- Reviewed by `superpowers:code-reviewer` agent. Verdict: ship it.
- Confirmed the guard is correct under MySQL InnoDB and Postgres — `SELECT ... FOR UPDATE` is a current read, so the second caller sees the first caller's committed `status='resolved'` after unblocking and the `whereIn` filter excludes the row.
- Confirmed `AlertResolved::dispatch` inside the transaction closure is safe: `ShouldDispatchAfterCommit` defers the broadcast until the outermost transaction commits, and on rollback the broadcast is discarded along with the row write.
- Real call sites (`RecordWebsiteCheckAction`, `IngestHostTelemetryAction`) invoke this action outside any transaction, so no nested-transaction edge case.
- Minor stylistic note from reviewer (redundant `\$source` parameter in helper) deferred — non-blocking nit.