### PR TITLE
Spec 033 — Health-score scaffolding

### DIFF
--- a/app/Domain/Analytics/Actions/ComputeProjectHealthScoreAction.php
+++ b/app/Domain/Analytics/Actions/ComputeProjectHealthScoreAction.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Domain\Analytics\Actions;
+
+use App\Enums\AlertSeverity;
+use App\Enums\AlertStatus;
+use App\Enums\HostStatus;
+use App\Enums\WebsiteStatus;
+use App\Enums\WorkflowRunConclusion;
+use App\Models\Alert;
+use App\Models\Container;
+use App\Models\Host;
+use App\Models\Project;
+use App\Models\Website;
+use App\Models\WorkflowRun;
+use Illuminate\Support\Carbon;
+
+/**
+ * Pure-read computation of a project's health score (spec 033,
+ * roadmap §14.2). Starts at 100, applies weighted deductions across
+ * the signals Phases 4–7 already collect, clamps to `[0, 100]`,
+ * returns the integer. No DB writes — callers persist.
+ *
+ * Deductions stack **per occurrence**, not per signal-class. A
+ * project with three active critical alerts deducts 90, not 30. This
+ * matches the "reflects real system signals" framing in §Phase 8:
+ * three outages is meaningfully worse than one, and the clamp at 0
+ * handles catastrophic stacking naturally. Future tuning can swap to
+ * a binary "any X exists" mode by changing the `count()` queries to
+ * `exists()` casts, but the weight constants are the right pivot
+ * point either way.
+ *
+ * Signals **not** wired yet (and therefore contributing zero):
+ *
+ * - `-10 for stale PR over 7 days` — needs Phase 4 PR webhook
+ *   ingestion that doesn't exist; deferred per Phase 8 README.
+ * - `-5 for failed GitHub sync` — the `github.sync.failed` activity
+ *   event type isn't emitted today (no grep hits in `app/`). When
+ *   ingestion lands, add a `gitHubSyncDeductions()` method here
+ *   without changing the weight constant.
+ *
+ * Both gaps are documented in spec 033's open questions; the formula
+ * under-deducts by at most 15 in the worst case, which is acceptable
+ * for shipping the rest.
+ */
+class ComputeProjectHealthScoreAction
+{
+    public const BASELINE = 100;
+
+    public const DEDUCT_ALERT_CRITICAL = 30;
+
+    public const DEDUCT_ALERT_WARNING = 15;
+
+    public const DEDUCT_DEPLOY_FAILED = 20;
+
+    public const DEDUCT_WEBSITE_SLOW = 10;
+
+    public const DEDUCT_WEBSITE_DOWN = 20;
+
+    public const DEDUCT_HOST_OFFLINE = 15;
+
+    public const DEDUCT_CONTAINER_UNHEALTHY = 10;
+
+    public const DEDUCT_GH_SYNC_FAILED = 5;
+
+    public function execute(Project $project): int
+    {
+        $score = self::BASELINE
+            - $this->alertDeductions($project)
+            - $this->websiteDeductions($project)
+            - $this->hostDeductions($project)
+            - $this->containerDeductions($project)
+            - $this->deploymentDeductions($project);
+
+        return (int) max(0, min(100, $score));
+    }
+
+    private function alertDeductions(Project $project): int
+    {
+        $active = [AlertStatus::Open->value, AlertStatus::Acknowledged->value];
+
+        $critical = Alert::query()
+            ->where('project_id', $project->id)
+            ->whereIn('status', $active)
+            ->where('severity', AlertSeverity::Critical->value)
+            ->count();
+
+        $warning = Alert::query()
+            ->where('project_id', $project->id)
+            ->whereIn('status', $active)
+            ->where('severity', AlertSeverity::Warning->value)
+            ->count();
+
+        return ($critical * self::DEDUCT_ALERT_CRITICAL)
+            + ($warning * self::DEDUCT_ALERT_WARNING);
+    }
+
+    private function websiteDeductions(Project $project): int
+    {
+        $down = Website::query()
+            ->where('project_id', $project->id)
+            ->whereIn('status', [
+                WebsiteStatus::Down->value,
+                WebsiteStatus::Error->value,
+            ])
+            ->count();
+
+        $slow = Website::query()
+            ->where('project_id', $project->id)
+            ->where('status', WebsiteStatus::Slow->value)
+            ->count();
+
+        return ($down * self::DEDUCT_WEBSITE_DOWN)
+            + ($slow * self::DEDUCT_WEBSITE_SLOW);
+    }
+
+    private function hostDeductions(Project $project): int
+    {
+        $offline = Host::query()
+            ->where('project_id', $project->id)
+            ->whereNull('archived_at')
+            ->where('status', HostStatus::Offline->value)
+            ->count();
+
+        return $offline * self::DEDUCT_HOST_OFFLINE;
+    }
+
+    private function containerDeductions(Project $project): int
+    {
+        // Docker daemon's `health_status` is opt-in: not every image
+        // declares a HEALTHCHECK. Only count containers explicitly
+        // reporting `unhealthy` — `null` / `starting` / `healthy` /
+        // anything else doesn't deduct.
+        $unhealthy = Container::query()
+            ->where('project_id', $project->id)
+            ->where('health_status', 'unhealthy')
+            ->count();
+
+        return $unhealthy * self::DEDUCT_CONTAINER_UNHEALTHY;
+    }
+
+    private function deploymentDeductions(Project $project): int
+    {
+        // "Failed deployment" in §14.2 maps to a failed default-branch
+        // workflow run in the last 24h. We constrain to the run's
+        // repository's `default_branch` because feature-branch
+        // failures don't count against the project (matching spec
+        // 030's promotion rule for `workflow.failed` alerts).
+        $since = Carbon::now()->subDay();
+
+        $failed = WorkflowRun::query()
+            ->join('repositories', 'workflow_runs.repository_id', '=', 'repositories.id')
+            ->where('repositories.project_id', $project->id)
+            ->whereColumn('workflow_runs.head_branch', 'repositories.default_branch')
+            ->where('workflow_runs.conclusion', WorkflowRunConclusion::Failure->value)
+            ->where('workflow_runs.run_completed_at', '>', $since)
+            ->count('workflow_runs.id');
+
+        return $failed * self::DEDUCT_DEPLOY_FAILED;
+    }
+}

--- a/app/Domain/Analytics/Actions/RefreshProjectHealthScoreAction.php
+++ b/app/Domain/Analytics/Actions/RefreshProjectHealthScoreAction.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Domain\Analytics\Actions;
+
+use App\Enums\HealthScoreBand;
+use App\Events\HealthScoreUpdated;
+use App\Models\Project;
+
+/**
+ * Persist a project's health score and broadcast the change (spec
+ * 033). Wraps `ComputeProjectHealthScoreAction` with diff-and-write:
+ * if the freshly-computed score matches the stored one, the action
+ * is a no-op — no DB write, no `updated_at` churn, no broadcast.
+ *
+ * On a real change (including the null → first-score transition),
+ * the action persists the new score and dispatches
+ * `HealthScoreUpdated` on `users.{ownerUserId}.dashboard` so
+ * Overview reacts without a manual reload.
+ *
+ * Returns the new score so callers can log the before/after.
+ */
+class RefreshProjectHealthScoreAction
+{
+    public function __construct(
+        private readonly ComputeProjectHealthScoreAction $compute,
+    ) {}
+
+    public function execute(Project $project): int
+    {
+        $newScore = $this->compute->execute($project);
+
+        if ($project->health_score === $newScore) {
+            return $newScore;
+        }
+
+        $project->forceFill(['health_score' => $newScore])->save();
+
+        $band = HealthScoreBand::fromScore($newScore);
+
+        HealthScoreUpdated::dispatch(
+            $project->id,
+            $project->owner_user_id,
+            $newScore,
+            $band->value,
+        );
+
+        return $newScore;
+    }
+}

--- a/app/Domain/Analytics/Jobs/RecomputeAllProjectHealthScoresJob.php
+++ b/app/Domain/Analytics/Jobs/RecomputeAllProjectHealthScoresJob.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Domain\Analytics\Jobs;
+
+use App\Models\Project;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+
+/**
+ * Scheduled sweep (spec 033). Every 5 minutes, fans out one
+ * `RecomputeProjectHealthScoreJob` per active project. "Active" =
+ * has activity in the last 7 days OR has never been scored
+ * (first-run sweep after the spec ships).
+ *
+ * Inactive projects with a stored score are skipped — their signals
+ * aren't moving and Phase 8 doesn't surface them on Overview's
+ * risky-projects band. The activity listener still recomputes them
+ * the instant a relevant transition lands; this job just keeps the
+ * scheduled tax small.
+ */
+class RecomputeAllProjectHealthScoresJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    public function handle(): void
+    {
+        $cutoff = Carbon::now()->subDays(7);
+
+        Project::query()
+            ->where(function ($q) use ($cutoff): void {
+                $q->where('last_activity_at', '>', $cutoff)
+                    ->orWhereNull('health_score');
+            })
+            ->select('id')
+            ->chunkById(100, function ($projects): void {
+                foreach ($projects as $project) {
+                    RecomputeProjectHealthScoreJob::dispatch($project->id);
+                }
+            });
+    }
+}

--- a/app/Domain/Analytics/Jobs/RecomputeProjectHealthScoreJob.php
+++ b/app/Domain/Analytics/Jobs/RecomputeProjectHealthScoreJob.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Domain\Analytics\Jobs;
+
+use App\Domain\Analytics\Actions\RefreshProjectHealthScoreAction;
+use App\Models\Project;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Per-project recompute (spec 033). Dispatched by the activity
+ * listener on whitelisted transition events and by the every-5-min
+ * sweep job for active projects.
+ *
+ * `ShouldBeUnique` (uniqueFor 60s) and `WithoutOverlapping` keyed on
+ * the project id collapse burst recomputes — eg. a website that
+ * flips down then up then down again inside a second produces three
+ * dispatch attempts but only one (or two) actual recomputes,
+ * spaced by the lock window.
+ *
+ * Quietly skips if the project was deleted between dispatch and
+ * handle (the eager `find` returns null).
+ */
+class RecomputeProjectHealthScoreJob implements ShouldBeUnique, ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    /** Cache the lock for 60 s — bursts collapse onto the first run. */
+    public int $uniqueFor = 60;
+
+    public function __construct(public readonly int $projectId) {}
+
+    public function uniqueId(): string
+    {
+        return (string) $this->projectId;
+    }
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [(new WithoutOverlapping((string) $this->projectId))
+            ->releaseAfter(10)
+            ->expireAfter(60)];
+    }
+
+    public function handle(RefreshProjectHealthScoreAction $refresh): void
+    {
+        $project = Project::query()->find($this->projectId);
+
+        if ($project === null) {
+            return;
+        }
+
+        $refresh->execute($project);
+    }
+}

--- a/app/Enums/HealthScoreBand.php
+++ b/app/Enums/HealthScoreBand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Project health-score banding (spec 033, roadmap §14.2).
+ *
+ * Mapping (inclusive on both ends):
+ *   90–100 → healthy
+ *   70–89  → good
+ *   50–69  → degraded
+ *   30–49  → warning
+ *    0–29  → critical
+ *
+ * Tones map to `StatusBadge`:
+ *   healthy  → success
+ *   good     → info
+ *   degraded → warning
+ *   warning  → warning
+ *   critical → danger
+ */
+enum HealthScoreBand: string
+{
+    case Healthy = 'healthy';
+    case Good = 'good';
+    case Degraded = 'degraded';
+    case Warning = 'warning';
+    case Critical = 'critical';
+
+    public static function fromScore(int $score): self
+    {
+        return match (true) {
+            $score >= 90 => self::Healthy,
+            $score >= 70 => self::Good,
+            $score >= 50 => self::Degraded,
+            $score >= 30 => self::Warning,
+            default => self::Critical,
+        };
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Healthy => 'Healthy',
+            self::Good => 'Good',
+            self::Degraded => 'Degraded',
+            self::Warning => 'Warning',
+            self::Critical => 'Critical',
+        };
+    }
+
+    public function badgeTone(): string
+    {
+        return match ($this) {
+            self::Healthy => 'success',
+            self::Good => 'info',
+            self::Degraded, self::Warning => 'warning',
+            self::Critical => 'danger',
+        };
+    }
+}

--- a/app/Events/HealthScoreUpdated.php
+++ b/app/Events/HealthScoreUpdated.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Real-time pulse emitted whenever `RefreshProjectHealthScoreAction`
+ * persists a changed score (spec 033). Dispatched only when the new
+ * score differs from the stored one, so a no-op recompute doesn't
+ * churn Echo subscribers.
+ *
+ * Broadcasts on `users.{ownerUserId}.dashboard` — a new channel
+ * introduced in 033 that 035 will reuse for `HeatmapUpdated`. The
+ * payload carries the resolved band string so the frontend doesn't
+ * have to recompute the §14.2 threshold table.
+ *
+ * `ShouldBroadcastNow` + `ShouldDispatchAfterCommit` match the rest
+ * of the Phase 7 / 8 event vocabulary: the broadcast fires once the
+ * surrounding transaction commits, and the Reverb HTTP call is
+ * synchronous so the listener doesn't queue an intermediate job.
+ */
+class HealthScoreUpdated implements ShouldBroadcastNow, ShouldDispatchAfterCommit
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $projectId,
+        public readonly ?int $ownerUserId,
+        public readonly int $score,
+        public readonly string $band,
+    ) {}
+
+    /**
+     * @return list<PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        if ($this->ownerUserId === null) {
+            return [];
+        }
+
+        return [
+            new PrivateChannel("users.{$this->ownerUserId}.dashboard"),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'project_id' => $this->projectId,
+            'health_score' => $this->score,
+            'band' => $this->band,
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'HealthScoreUpdated';
+    }
+}

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Domain\Activity\Queries\RecentActivityForProjectQuery;
 use App\Domain\GitHub\Queries\DeploymentTimelineQuery;
+use App\Enums\HealthScoreBand;
 use App\Enums\ProjectPriority;
 use App\Enums\ProjectStatus;
 use App\Http\Requests\Projects\StoreProjectRequest;
@@ -208,6 +209,9 @@ class ProjectController extends Controller
             'color' => $project->color,
             'icon' => $project->icon,
             'health_score' => $project->health_score,
+            'health_band' => $project->health_score === null
+                ? null
+                : HealthScoreBand::fromScore($project->health_score)->value,
             'last_activity_at' => $project->last_activity_at?->diffForHumans(),
             'owner' => $project->owner ? [
                 'id' => $project->owner->id,

--- a/app/Listeners/RecomputeProjectHealthOnActivity.php
+++ b/app/Listeners/RecomputeProjectHealthOnActivity.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Domain\Analytics\Jobs\RecomputeProjectHealthScoreJob;
+use App\Events\ActivityEventCreated;
+use App\Models\ActivityEvent;
+use App\Models\Alert;
+use App\Models\Host;
+use App\Models\Website;
+
+/**
+ * Spec 033 — bridge from the activity rail to the health-score
+ * recompute pipeline. Every `ActivityEventCreated` emit is inspected;
+ * if the event_type is one that §14.2 deducts on, the listener
+ * resolves the relevant project and queues a per-project recompute
+ * job. Everything else is ignored — telemetry ticks (`host.metrics.
+ * recorded`), benign workflow events, GitHub sync chatter never
+ * touch the queue from here.
+ *
+ * Project resolution mirrors `ActivityEventCreated::resolveOwnerUserId`:
+ * the activity row doesn't store a direct `project_id`, so we walk
+ * source → entity → project per the same four scoping paths the
+ * broadcast routing already uses. Duplication is acceptable here —
+ * unifying the two into a shared resolver is its own refactor and
+ * the mapping is stable.
+ *
+ * Auto-discovered by Laravel 11+'s event-listener scan (single
+ * `handle(ActivityEventCreated)` method); no explicit registration
+ * required.
+ */
+class RecomputeProjectHealthOnActivity
+{
+    /**
+     * Activity event types that should re-trigger a score recompute.
+     * Everything else is a no-op — including bulk telemetry,
+     * GitHub-sync chatter, and informational events like
+     * `release.published` that §14.2 doesn't weight.
+     */
+    private const SCORE_MOVING_EVENTS = [
+        'alert.triggered',
+        'alert.resolved',
+        'website.down',
+        'website.recovered',
+        'website.slow',
+        'website.error',
+        'host.offline',
+        'host.recovered',
+        'workflow.failed',
+        'github.sync.failed',
+    ];
+
+    public function handle(ActivityEventCreated $event): void
+    {
+        $activity = $event->activityEvent;
+
+        if (! in_array($activity->event_type, self::SCORE_MOVING_EVENTS, true)) {
+            return;
+        }
+
+        $projectId = $this->resolveProjectId($activity);
+
+        if ($projectId === null) {
+            return;
+        }
+
+        RecomputeProjectHealthScoreJob::dispatch($projectId);
+    }
+
+    /**
+     * Walk the activity row to the owning project id. Returns null
+     * for orphan rows (no relevant entity, deleted parent) — the
+     * listener silently skips those.
+     */
+    private function resolveProjectId(ActivityEvent $activity): ?int
+    {
+        // Repo-scoped path (workflow.failed comes through here).
+        if ($activity->repository_id !== null) {
+            return $activity->repository?->project_id;
+        }
+
+        $metadata = $activity->metadata ?? [];
+
+        return match ($activity->source) {
+            'monitoring' => isset($metadata['website_id'])
+                ? Website::query()->whereKey($metadata['website_id'])->value('project_id')
+                : null,
+            'hosts' => isset($metadata['host_id'])
+                ? Host::query()->whereKey($metadata['host_id'])->value('project_id')
+                : null,
+            'alerts' => isset($metadata['alert_id'])
+                ? Alert::query()->whereKey($metadata['alert_id'])->value('project_id')
+                : null,
+            default => null,
+        };
+    }
+}

--- a/resources/js/Components/Project/HealthScoreBadge.vue
+++ b/resources/js/Components/Project/HealthScoreBadge.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import { computed } from 'vue';
+
+/**
+ * Spec 033 — project health score badge. Wraps `StatusBadge` with
+ * the §14.2 band → tone mapping. Renders a muted "—" placeholder
+ * when the project has never been scored (first-run state before
+ * the scheduled sweep ticks). The score itself is shown as
+ * `{score}/100 {label}` — e.g. `82/100 Good`, `25/100 Critical`.
+ *
+ * The band string comes from the backend (`health_band` Inertia
+ * prop, computed by `HealthScoreBand::fromScore` in
+ * `ProjectController::transform`) so the frontend doesn't need to
+ * mirror the threshold table. If the band ever drifts from the
+ * score's true band — eg. a manual DB poke — the badge follows the
+ * band, not the score recomputed locally.
+ */
+const props = defineProps<{
+    score: number | null;
+    band: string | null;
+}>();
+
+type StatusTone = 'success' | 'warning' | 'danger' | 'info' | 'muted';
+
+const tone = computed<StatusTone>(() => {
+    switch (props.band) {
+        case 'healthy':
+            return 'success';
+        case 'good':
+            return 'info';
+        case 'degraded':
+        case 'warning':
+            return 'warning';
+        case 'critical':
+            return 'danger';
+        default:
+            return 'muted';
+    }
+});
+
+const label = computed<string>(() => {
+    switch (props.band) {
+        case 'healthy':
+            return 'Healthy';
+        case 'good':
+            return 'Good';
+        case 'degraded':
+            return 'Degraded';
+        case 'warning':
+            return 'Warning';
+        case 'critical':
+            return 'Critical';
+        default:
+            return 'Unscored';
+    }
+});
+</script>
+
+<template>
+    <StatusBadge :tone="tone">
+        <template v-if="score === null">— Unscored</template>
+        <template v-else>{{ score }}/100 {{ label }}</template>
+    </StatusBadge>
+</template>

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -5,8 +5,8 @@ import Sparkline from '@/Components/Dashboard/Sparkline.vue';
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import { hostStatusTone } from '@/lib/hostStyles';
-import type { ActivityHeatmapPayload, DashboardPayload } from '@/types';
-import { Head, Link } from '@inertiajs/vue3';
+import type { ActivityHeatmapPayload, DashboardPayload, PageProps } from '@/types';
+import { Head, Link, router, usePage } from '@inertiajs/vue3';
 import {
     Activity,
     BarChart3,
@@ -22,6 +22,7 @@ import {
     Server,
     ShieldCheck,
 } from 'lucide-vue-next';
+import { onBeforeUnmount, onMounted } from 'vue';
 
 interface TopWorkItem {
     id: string;
@@ -40,6 +41,42 @@ defineProps<{
     activityHeatmap: ActivityHeatmapPayload;
     topWorkItems: TopWorkItem[];
 }>();
+
+// ─── Reverb subscription (spec 033) ──────────────────────────────────
+// Listen on `users.{id}.dashboard` for `HealthScoreUpdated` pulses
+// emitted by `RefreshProjectHealthScoreAction`. On each pulse, ask
+// Inertia for a fresh `dashboard` payload — server-side query
+// re-aggregates per-project scores so the cards on this page reflect
+// the change without a manual reload. 035 will reuse the same channel
+// for the activity-heatmap real-data pulse.
+const page = usePage<PageProps>();
+let teardown: (() => void) | null = null;
+
+onMounted(() => {
+    if (typeof window === 'undefined' || !window.Echo) {
+        return;
+    }
+    const userId = page.props.auth?.user?.id;
+    if (userId == null) return;
+
+    const channelName = `users.${userId}.dashboard`;
+    const channel = window.Echo.private(channelName);
+
+    const refreshDashboard = () => {
+        router.reload({ only: ['dashboard'] });
+    };
+
+    channel.listen('.HealthScoreUpdated', refreshDashboard);
+
+    teardown = () => {
+        channel.stopListening('.HealthScoreUpdated');
+        window.Echo?.leave(channelName);
+    };
+});
+
+onBeforeUnmount(() => {
+    teardown?.();
+});
 
 // ----- Hardcoded mock data for the populated stub widgets -----
 // These widgets each have their own dedicated spec in later phases. The

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -45,10 +45,15 @@ defineProps<{
 // ─── Reverb subscription (spec 033) ──────────────────────────────────
 // Listen on `users.{id}.dashboard` for `HealthScoreUpdated` pulses
 // emitted by `RefreshProjectHealthScoreAction`. On each pulse, ask
-// Inertia for a fresh `dashboard` payload — server-side query
-// re-aggregates per-project scores so the cards on this page reflect
-// the change without a manual reload. 035 will reuse the same channel
-// for the activity-heatmap real-data pulse.
+// Inertia for a fresh `dashboard` payload.
+//
+// Note (pre-035): `dashboard` doesn't currently carry per-project
+// score data, so the partial reload is effectively a no-op render-
+// wise today — the cost is one tiny Inertia round-trip per score
+// move. The wiring lands here in 033 so the channel + handler exist
+// and get exercised in dev as soon as the listener-driven recompute
+// fires; the visible payoff arrives in 035 when Overview renders the
+// "Risky projects" panel + per-project chips that this reload feeds.
 const page = usePage<PageProps>();
 let teardown: (() => void) | null = null;
 

--- a/resources/js/Pages/Projects/Show.vue
+++ b/resources/js/Pages/Projects/Show.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import ActivityFeed from '@/Components/Activity/ActivityFeed.vue';
+import HealthScoreBadge from '@/Components/Project/HealthScoreBadge.vue';
 import InputError from '@/Components/InputError.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import PrimaryButton from '@/Components/PrimaryButton.vue';
@@ -51,6 +52,7 @@ interface ProjectShape {
     color: string | null;
     icon: string | null;
     health_score: number | null;
+    health_band: string | null;
     last_activity_at: string | null;
     owner: { id: number; name: string; initials: string } | null;
 }
@@ -282,9 +284,15 @@ const confirmDelete = () => {
                             />
                         </span>
                         <div class="flex min-w-0 flex-col gap-2">
-                            <h2 class="text-xl font-semibold text-text-primary">
-                                {{ project.name }}
-                            </h2>
+                            <div class="flex flex-wrap items-center gap-3">
+                                <h2 class="text-xl font-semibold text-text-primary">
+                                    {{ project.name }}
+                                </h2>
+                                <HealthScoreBadge
+                                    :score="project.health_score"
+                                    :band="project.health_band"
+                                />
+                            </div>
                             <p
                                 v-if="project.description"
                                 class="text-sm text-text-secondary"

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -48,3 +48,13 @@ Broadcast::channel('users.{userId}.hosts', function ($user, $userId) {
 Broadcast::channel('users.{userId}.alerts', function ($user, $userId) {
     return (int) $user->id === (int) $userId;
 });
+
+// Spec 033 — per-user dashboard channel. `HealthScoreUpdated`
+// broadcasts here whenever a project's score changes (transition-
+// driven or scheduled-sweep) so Overview refreshes its score chips
+// without a manual reload. 035 will reuse the channel for the
+// activity-heatmap real-data pulse and the Overview risky-projects
+// re-rank.
+Broadcast::channel('users.{userId}.dashboard', function ($user, $userId) {
+    return (int) $user->id === (int) $userId;
+});

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Domain\Analytics\Jobs\RecomputeAllProjectHealthScoresJob;
 use App\Domain\Docker\Jobs\DetectOfflineHostsJob;
 use App\Domain\Monitoring\Jobs\DispatchDueWebsiteChecksJob;
 use Illuminate\Foundation\Inspiring;
@@ -41,3 +42,14 @@ Schedule::job(new DetectOfflineHostsJob)
     ->everyMinute()
     ->name('hosts:detect-offline')
     ->withoutOverlapping();
+
+// Spec 033 — every-5-minute sweep that fans out per-project health-
+// score recomputes for any project with activity in the last 7 days
+// or no stored score yet. The transition listener
+// (`RecomputeProjectHealthOnActivity`) catches realtime moves; this
+// sweep covers slow-drift signals (eg. a workflow failure aging past
+// the 24h window) and the first-run backfill.
+Schedule::job(new RecomputeAllProjectHealthScoresJob)
+    ->everyFiveMinutes()
+    ->name('analytics:recompute-health-scores')
+    ->withoutOverlapping(10);

--- a/specs/phase-8-analytics/033-health-score-scaffolding.md
+++ b/specs/phase-8-analytics/033-health-score-scaffolding.md
@@ -1,0 +1,347 @@
+---
+spec: health-score-scaffolding
+phase: 8
+status: in-progress   # not-started | in-progress | blocked | done
+owner: Yoany
+created: 2026-06-03
+updated: 2026-06-04
+---
+
+# 033 — Health-score scaffolding
+
+## Goal
+Activate Phase 8 by lighting up the dormant `projects.health_score`
+column. A `ComputeProjectHealthScoreAction` runs the §14.2 weighted
+deduction formula against the data Phases 4–7 already collect; a
+scheduled job recomputes every active project every 5 minutes; a
+single `ActivityEventCreated` listener queues a per-project recompute
+within seconds of any transition that should move the score; a
+`HealthScoreUpdated` broadcast on `users.{id}.dashboard` makes
+Overview react without a manual reload. After 033, every project
+shows a real score with the correct band label; the analytics page
+(034) and Overview prioritization (035) consume that score.
+
+Roadmap refs: §Phase 8 acceptance criteria ("Project health score
+reflects real system signals"), §14.2 weights + bands, §6.2 Action
+class pattern, §10 dashboard data sources.
+
+## Scope
+
+**In scope:**
+
+- **Calculation.**
+  - `app/Enums/HealthScoreBand.php` — `healthy | good | degraded |
+    warning | critical`, with `::fromScore(int $score): self` mapping
+    per §14.2 (90–100 / 70–89 / 50–69 / 30–49 / 0–29) plus `label()`
+    + `badgeTone()` for `StatusBadge`/Overview chip consumption
+    (mirrors `AlertSeverity::badgeTone()` shape).
+  - `app/Domain/Analytics/Actions/ComputeProjectHealthScoreAction.php`
+    — `execute(Project $project): int`. Starts at 100, applies §14.2
+    deductions, clamps `[0, 100]`. Reads from:
+    - `Alert::query()` for active (open + acknowledged) critical /
+      warning rows scoped to the project.
+    - `WebsiteCheck::query()` joined to `Website` for "response time
+      above threshold" (last hour mean) and "down" (latest check is
+      `failed`).
+    - `Host::query()` for "host offline" (`status = offline`) +
+      container join for "container unhealthy".
+    - `ActivityEvent::query()` for `workflow.failed` on default
+      branch within the last 24h ("failed deployment").
+    - `ActivityEvent::query()` for `github.sync.failed` if present
+      (silently zero-weighted if the event type doesn't exist yet).
+    Order: deduct, clamp, return. No DB write here — the action is
+    a pure query + arithmetic; callers persist.
+  - §14.2 weights live as named constants on the action so 034 / 035
+    / future tuning UI can read them without copy-paste.
+
+- **Persistence + recompute.**
+  - `app/Domain/Analytics/Actions/RefreshProjectHealthScoreAction.php`
+    — `execute(Project $project): int`. Calls
+    `ComputeProjectHealthScoreAction`, writes `health_score` +
+    `updated_at` only if the new value differs from the stored one
+    (avoid no-op writes + spurious broadcasts), dispatches
+    `HealthScoreUpdated::dispatch($project->id, $project->owner_user_id,
+    $newScore)` on a change. Returns the new score for the caller's
+    logs.
+  - `app/Domain/Analytics/Jobs/RecomputeProjectHealthScoresJob.php`
+    — `ShouldQueue + ShouldBeUnique`, queued to the default queue,
+    `WithoutOverlapping($projectId)` middleware. Constructor takes
+    `int $projectId`. Calls
+    `RefreshProjectHealthScoreAction::execute()`.
+  - `app/Domain/Analytics/Jobs/RecomputeAllProjectHealthScoresJob.php`
+    — scheduled wrapper. Iterates active projects (chunked by 100)
+    and dispatches one `RecomputeProjectHealthScoresJob` per row.
+    "Active" = `last_activity_at > now()->subDays(7)` OR
+    `health_score IS NULL` (first-run sweep). Sleeping projects don't
+    consume scheduler time.
+  - `app/Console/Kernel.php` — schedule
+    `RecomputeAllProjectHealthScoresJob` every 5 minutes,
+    `withoutOverlapping(10)` (the 10-min lock guards a slow run).
+
+- **Transition hooks.**
+  - `app/Listeners/RecomputeProjectHealthOnActivity.php` — subscribes
+    to `ActivityEventCreated`. Maps the event's `source` →
+    `project_id` (the `metadata.project_id` is set by all relevant
+    emitters per spec 030's audit). Whitelists the event types that
+    can move the score: `alert.triggered`, `alert.resolved`,
+    `website.down`, `website.recovered`, `website.slow`,
+    `host.offline`, `host.recovered`, `workflow.failed`,
+    `github.sync.failed`. Ignores everything else (e.g. raw
+    `host.metrics.recorded` ticks). For whitelisted types, dispatches
+    `RecomputeProjectHealthScoresJob($projectId)` — the job's
+    `WithoutOverlapping` + `ShouldBeUnique` middleware naturally
+    throttles bursts (e.g. a website that flips down then up twice
+    in a second collapses to one recompute).
+  - `app/Providers/EventServiceProvider.php` — register the listener.
+
+- **Broadcast.**
+  - `app/Events/HealthScoreUpdated.php` —
+    `ShouldBroadcastNow + ShouldDispatchAfterCommit` on
+    `users.{ownerUserId}.dashboard`. Payload:
+    `{ project_id, health_score, band }`. `band` is the string
+    value of `HealthScoreBand` so the frontend doesn't recompute.
+    Mirrors `AlertResolved` line-for-line.
+  - `routes/channels.php` — authorize `users.{id}.dashboard` (own-user
+    only) next to the existing `activity / monitoring / hosts /
+    alerts` entries.
+
+- **Inertia + UI.**
+  - `ProjectController::transform()` — already exposes
+    `health_score`; add `health_band` (string from
+    `HealthScoreBand::fromScore($score)->value`) when score is
+    non-null. Null score stays null in both fields (renders as a
+    "—" placeholder client-side).
+  - `app/Domain/Overview/Queries/GetOverviewDashboardQuery.php` —
+    every project row returned in `riskyProjects` / `recentProjects`
+    carries `health_score` + `health_band`. Sort key for any
+    `health_score`-based panel is handled in spec 035; 033 just
+    surfaces the field.
+  - `resources/js/Pages/Projects/Show.vue` — render a
+    `<HealthScoreBadge>` near the project title. Component lives at
+    `resources/js/Components/Project/HealthScoreBadge.vue` —
+    `props: { score: number|null, band: string|null }`; renders
+    `<StatusBadge :tone="bandToTone(band)" :label="`${score}/100 ${bandLabel}`" />`.
+    Null score renders the muted "—" placeholder.
+  - `resources/js/Pages/Overview.vue` — subscribe to
+    `users.{userId}.dashboard` on mount; `.HealthScoreUpdated` calls
+    `router.reload({ only: ['kpis', 'projects'] })`. The "Live
+    updates offline" pill pattern from spec 028 applies if the user
+    drops Pusher connection.
+
+- **Tests.**
+  - **Action-level** (`tests/Unit/Domain/Analytics/`):
+    `ComputeProjectHealthScoreActionTest` — base 100 with no
+    deductions; one critical alert deducts 30; one warning alert
+    deducts 15; combined alerts stack; website down + slow stack
+    (-20 + -10 = -30); host offline -15; container unhealthy -10;
+    workflow.failed on default branch within 24h -20; clamps to 0
+    on a worst-case stack; clamps to 100 baseline; cross-project
+    isolation (alerts on project B don't touch project A's score).
+  - `RefreshProjectHealthScoreActionTest` — writes the new score;
+    does not write if the score is unchanged (no spurious
+    `updated_at`); dispatches `HealthScoreUpdated` only on change;
+    null → first score dispatches.
+  - **Listener** (`tests/Feature/Listeners/`):
+    `RecomputeProjectHealthOnActivityTest` — whitelisted event types
+    queue the job once; non-whitelisted types do not; missing
+    `project_id` in metadata is a silent no-op (defensive).
+  - **Job** (`tests/Unit/Domain/Analytics/Jobs/`):
+    `RecomputeAllProjectHealthScoresJobTest` — dispatches one
+    per-project job per active project; skips projects with no
+    `last_activity_at > now-7d` and a non-null `health_score`.
+  - **Event** (`tests/Feature/Events/`): `HealthScoreUpdatedTest` —
+    implements `ShouldBroadcastNow + ShouldDispatchAfterCommit`;
+    `broadcastOn` returns the dashboard channel; `broadcastWith`
+    carries `{project_id, health_score, band}`; null owner short-
+    circuits to `[]`.
+  - **Channel auth**: `tests/Feature/Channels/UsersDashboardChannelTest.php`
+    — own user authorized; other user rejected.
+  - **Inertia transform**: `ProjectControllerShowTest` — payload
+    carries `health_score` + `health_band`; null score → both null.
+
+**Out of scope:**
+
+- `/analytics` page — **034**.
+- Real-data activity heatmap on Overview — **035**.
+- Overview "Risky projects" sort by `health_score` ascending — **035**
+  (033 just exposes the field on every project payload; 035 adds the
+  panel).
+- User-tunable score weights — deferred (polish spec).
+- PR cycle time / stale PR count / open issues trend score signals
+  — deferred (need Phase 4 GitHub Issues + PR webhook ingestion that
+  doesn't exist; the formula has no weight for them in §14.2 anyway).
+- The `dashboard` Reverb channel hosting other broadcasts beyond
+  `HealthScoreUpdated` — 035 may add `HeatmapUpdated` on the same
+  channel; 034 doesn't need realtime.
+- Backfill of pre-existing `last_activity_at`-null projects — the
+  scheduled `RecomputeAllProjectHealthScoresJob`'s
+  `health_score IS NULL` clause sweeps them on its next tick after
+  this spec lands.
+
+## Plan
+
+1. **`HealthScoreBand` enum.** Five cases per §14.2 with `fromScore` +
+   `label` + `badgeTone`. Cover with a tiny enum test.
+
+2. **`ComputeProjectHealthScoreAction`.** Pure read-only. Inject
+   nothing — just `\Illuminate\Database\ConnectionInterface` if any
+   query needs raw SQL (probably not — Eloquent + `whereHas` + a few
+   `selectRaw` aggregates are enough). Constants at the top of the
+   class:
+   ```php
+   private const DEDUCT_ALERT_CRITICAL = 30;
+   private const DEDUCT_ALERT_WARNING  = 15;
+   private const DEDUCT_DEPLOY_FAILED  = 20;
+   private const DEDUCT_WEBSITE_SLOW   = 10;
+   private const DEDUCT_WEBSITE_DOWN   = 20;
+   private const DEDUCT_HOST_OFFLINE   = 15;
+   private const DEDUCT_CONTAINER_BAD  = 10;
+   private const DEDUCT_GH_SYNC_FAIL   = 5;
+   ```
+   Each query is one method (`alertDeductions`, `websiteDeductions`,
+   etc.); `execute` sums them, clamps, returns. Use
+   `Carbon::now()->subDay()` for the 24h windows.
+
+3. **`RefreshProjectHealthScoreAction`.** Wraps the compute action,
+   diffs against `$project->health_score`, persists only on change
+   (`$project->forceFill(['health_score' => $new])->save()`),
+   dispatches `HealthScoreUpdated` only on change. Returns the new
+   value.
+
+4. **`HealthScoreUpdated` event.** Constructor:
+   `(int $projectId, ?int $ownerUserId, int $score, string $band)`.
+   `broadcastWith` returns `['project_id' => $this->projectId,
+   'health_score' => $this->score, 'band' => $this->band]`.
+   `broadcastAs` returns `'HealthScoreUpdated'`. `broadcastOn` returns
+   `$this->ownerUserId === null ? [] : [new PrivateChannel("users.{$this->ownerUserId}.dashboard")]`.
+
+5. **Channel auth.** `routes/channels.php` add:
+   ```php
+   Broadcast::channel('users.{userId}.dashboard',
+       fn (User $user, int $userId) => (int) $user->id === $userId);
+   ```
+
+6. **Job + scheduler.**
+   - `RecomputeProjectHealthScoresJob(int $projectId)` —
+     `WithoutOverlapping($projectId)` + `ShouldBeUnique` with
+     `uniqueFor(60)`. Resolves `RefreshProjectHealthScoreAction` from
+     the container; calls `execute($project)`; logs the before/after.
+   - `RecomputeAllProjectHealthScoresJob` — chunks
+     `Project::query()->where(fn ($q) => $q->where('last_activity_at',
+     '>', now()->subDays(7))->orWhereNull('health_score'))` by 100;
+     dispatches one job per row.
+   - `app/Console/Kernel.php`:
+     ```php
+     $schedule->job(new RecomputeAllProjectHealthScoresJob)
+         ->everyFiveMinutes()
+         ->withoutOverlapping(10);
+     ```
+
+7. **Listener.** `RecomputeProjectHealthOnActivity` —
+   `handle(ActivityEventCreated $event)`. Resolves the activity row,
+   reads `$event->activityEvent->event_type`, returns early on
+   non-whitelisted types. Reads `metadata.project_id`. Dispatches
+   `RecomputeProjectHealthScoresJob::dispatch($projectId)`. Register in
+   `EventServiceProvider::$listen`.
+
+8. **Inertia transform.** `ProjectController::transform()` — adds
+   `health_band` next to `health_score`. Null guard:
+   `score === null ? null : HealthScoreBand::fromScore($score)->value`.
+
+9. **UI components.**
+   - `HealthScoreBadge.vue` — `score: number | null`, `band: string |
+     null`. Maps band → tone (`healthy → success`, `good → info`,
+     `degraded → warning`, `warning → warning`, `critical → danger`).
+     Reuses `StatusBadge`.
+   - `Pages/Projects/Show.vue` — render `<HealthScoreBadge>` next to
+     the project title.
+   - `Pages/Overview.vue` — Echo subscription on
+     `users.{userId}.dashboard` for `.HealthScoreUpdated`; calls
+     `router.reload({ only: ['kpis', 'projects'] })`. Hooks alongside
+     the existing `users.{id}.activity` subscription (so the
+     connection-lost pill applies to both).
+
+10. **Tests.** Per the test list in **In scope**. Use the existing
+    `Alert::factory()` / `Website::factory()` / `Host::factory()` /
+    `ActivityEvent::factory()` shapes. The compute-action test is the
+    heaviest — twelve cases covering each weight + clamps + isolation.
+
+11. **Pint clean, full suite + build pass, self-review with
+    `superpowers:code-reviewer`, PR.**
+
+## Acceptance criteria
+- [ ] `projects.health_score` is non-null on every active project
+      within one scheduler tick of this spec landing.
+- [ ] A new critical alert on a project drops that project's score
+      by 30 within the next listener-triggered recompute (<5s under
+      a warm queue worker).
+- [ ] A `website.recovered` transition that should restore the score
+      raises it back within the next listener-triggered recompute.
+- [ ] `HealthScoreUpdated` broadcasts on `users.{ownerId}.dashboard`
+      only when the persisted score actually changes (no spurious
+      events on no-op recomputes).
+- [ ] Overview re-fetches `kpis` + `projects` props on a
+      `.HealthScoreUpdated` pulse; the badge updates without a
+      manual reload.
+- [ ] Project Show page renders the score badge with the correct
+      band label and tone.
+- [ ] Sleeping projects (`last_activity_at > 7d` ago AND
+      `health_score` non-null) are skipped by the scheduled sweep.
+- [ ] Score clamps to `[0, 100]` under the worst-case stack of
+      deductions.
+- [ ] Pint clean. `php artisan test` green. `npm run build` clean.
+
+## Files touched
+List of created/modified files. Fill in as work progresses.
+
+- `app/Enums/HealthScoreBand.php` — created
+- `app/Domain/Analytics/Actions/ComputeProjectHealthScoreAction.php` — created
+- `app/Domain/Analytics/Actions/RefreshProjectHealthScoreAction.php` — created
+- `app/Domain/Analytics/Jobs/RecomputeProjectHealthScoresJob.php` — created
+- `app/Domain/Analytics/Jobs/RecomputeAllProjectHealthScoresJob.php` — created
+- `app/Listeners/RecomputeProjectHealthOnActivity.php` — created
+- `app/Events/HealthScoreUpdated.php` — created
+- `app/Providers/EventServiceProvider.php` — register listener
+- `app/Console/Kernel.php` — schedule the sweep
+- `routes/channels.php` — `users.{id}.dashboard` auth
+- `app/Http/Controllers/ProjectController.php` — `health_band` in transform
+- `resources/js/Components/Project/HealthScoreBadge.vue` — created
+- `resources/js/Pages/Projects/Show.vue` — render the badge
+- `resources/js/Pages/Overview.vue` — Echo subscription
+- `tests/Unit/Domain/Analytics/ComputeProjectHealthScoreActionTest.php` — created
+- `tests/Unit/Domain/Analytics/RefreshProjectHealthScoreActionTest.php` — created
+- `tests/Unit/Domain/Analytics/Jobs/RecomputeAllProjectHealthScoresJobTest.php` — created
+- `tests/Feature/Listeners/RecomputeProjectHealthOnActivityTest.php` — created
+- `tests/Feature/Events/HealthScoreUpdatedTest.php` — created
+- `tests/Feature/Channels/UsersDashboardChannelTest.php` — created
+- `tests/Feature/Http/Controllers/ProjectControllerShowTest.php` — `health_band` assertion
+
+## Work log
+Dated notes as work progresses.
+
+### 2026-06-03
+- Drafted from `_template.md`. Phase 8 decomposition + GH-metrics
+  deferral + broadcast-in-033 approach confirmed with user before
+  drafting.
+
+### 2026-06-04
+- Branch `spec/033-health-score-scaffolding` cut off main.
+- Tracking issue #97.
+- Scope shipped as drafted (no late edits requested).
+
+## Open questions / blockers
+
+- **Container unhealthy signal.** Phase 6 ships `host_metric_snapshots`
+  + `container_metric_snapshots` but I haven't verified there's a
+  durable per-container "unhealthy" flag (vs. a derived "latest CPU
+  > threshold"). If the signal isn't trivially queryable, the impl
+  can fall back to "no deduction yet" with a TODO referencing a
+  follow-up — the §14.2 formula then under-deducts by 10 in the
+  worst case, which is acceptable for shipping the rest.
+- **`github.sync.failed` event type.** Confirm whether this exact
+  event type lands in `activity_events.event_type`. If not, the
+  deduction silently zeros out — same fallback as above.
+- **Scheduler cadence.** Every-5-minutes is a guess based on Phase 7's
+  alert detection cadence. If transition-driven recomputes prove
+  fast and reliable, the sweep can drop to every-15-minutes in a
+  follow-up. Not a 033 blocker.

--- a/specs/phase-8-analytics/033-health-score-scaffolding.md
+++ b/specs/phase-8-analytics/033-health-score-scaffolding.md
@@ -328,6 +328,17 @@ Dated notes as work progresses.
 - Branch `spec/033-health-score-scaffolding` cut off main.
 - Tracking issue #97.
 - Scope shipped as drafted (no late edits requested).
+- Plan-vs-impl notes:
+  - Overview Echo subscription reloads `only: ['dashboard']` (the
+    actual page prop shape), not `['kpis', 'projects']` as the
+    Plan §9 placeholder named.
+  - Per-project job is `RecomputeProjectHealthScoreJob` (singular
+    Score). Plan §6 named it `RecomputeProjectHealthScoresJob`
+    (plural) — singular is right since it's per-row.
+  - Self-review noted: the Overview subscription is correct but
+    cosmetic until 035 surfaces per-project health on the page.
+    Wiring + comment ship in 033 so the channel is exercised in dev
+    immediately; visible payoff arrives in 035.
 
 ## Open questions / blockers
 

--- a/specs/phase-8-analytics/README.md
+++ b/specs/phase-8-analytics/README.md
@@ -1,0 +1,68 @@
+# Phase 8 — Analytics & Health Scores
+
+Source: [roadmap §Phase 8](../../nexus_control_center_roadmap.md), §8.13
+Analytics & Health, §14.2 Health-score weighting formula, §10 dashboard
+data sources.
+
+## Phase goal
+Make the dashboard reflect real system health. Turn the dormant
+`projects.health_score` column into a scheduled + transition-driven
+scoring system (per §14.2 weights), ship a `/analytics` page with the
+§8.13 chart set powered by the data Phases 4–7 already collect, make
+Overview prioritize risky projects ahead of healthy ones, and swap the
+activity heatmap from `MOCK_HEATMAP` to real `activity_events`
+aggregates. Phase 8 closes when the user can open the app and see — at
+a glance — which projects need attention, why, and how recent that
+matters.
+
+## Tasks
+
+| # | Task | Status |
+|---|------|--------|
+| 033 | Health-score scaffolding (calculation + scheduled & transition-driven recompute + broadcast + Overview & project UI) | ⬜ |
+| 034 | Analytics dashboard page (`/analytics` route, §8.13 chart set, date-range filter) | ⬜ |
+| 035 | Real-data activity heatmap + Overview risky-project prioritization (closes phase 8) | ⬜ |
+
+## Acceptance criteria (phase-level)
+- [ ] `projects.health_score` is non-null for every project after the
+      first scheduled run; updates in <30s after a transition that
+      should move it (active critical alert, website down, host
+      offline, etc.).
+- [ ] Score 90–100 / 70–89 / 50–69 / 30–49 / 0–29 render as the
+      healthy / good / degraded / warning / critical bands per §14.2.
+- [ ] `/analytics` route is reachable; sidebar entry enabled; Cmd+K
+      `go-analytics` works.
+- [ ] Each §8.13 chart with a wired data source (deployment frequency,
+      alert frequency, uptime trend, container resource usage,
+      average website response time, deployment success rate, mean
+      time to recovery) renders against real rows, not `MOCK_*`.
+- [ ] Date-range filter on `/analytics` supports 7d / 30d / 90d via
+      URL params; the active range survives a refresh.
+- [ ] Overview's "Risky projects" panel sorts by `health_score` asc,
+      surfacing degraded / warning / critical projects ahead of
+      healthy ones.
+- [ ] Overview's activity heatmap is driven by real
+      `activity_events.occurred_at` aggregates over the last 12 weeks
+      (not `MOCK_HEATMAP`).
+- [ ] Realtime: a transition that moves a project's score broadcasts
+      `HealthScoreUpdated` on `users.{id}.dashboard`; Overview reacts
+      without a manual refresh.
+- [ ] Pint clean, tests green, build clean. CI green for each spec PR.
+
+## Scope notes
+- **Score signals limited to what Phases 4–7 already collect.** Active
+  alerts (Phase 7), website down + slow (Phase 5), host offline (Phase
+  6), workflow failures on default branch (Phase 4) all count.
+  **Deferred to a Phase 4 follow-up:** PR cycle time, stale PR count,
+  open issues trend — those need GitHub Issues + PR webhook ingestion
+  that doesn't exist yet, and we'd rather not bloat Phase 8's data
+  layer with a side-quest.
+- **User-tunable score weights** (UI for adjusting the §14.2 numbers)
+  are deferred to a polish spec. Phase 8 ships the §14.2 numbers as
+  constants.
+- **`AlertNotificationService`** (email / Slack / webhook) stays
+  deferred from Phase 7.
+- **Analytics export / CSV download** is deferred. Phase 8 is
+  in-browser viewing only.
+- Each spec ships its own CI-green PR; the phase closes when 035
+  merges.

--- a/tests/Feature/Channels/DashboardChannelTest.php
+++ b/tests/Feature/Channels/DashboardChannelTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature\Channels;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Broadcast;
+use ReflectionClass;
+use Tests\TestCase;
+
+/**
+ * Spec 033 — `routes/channels.php` registers
+ * `users.{userId}.dashboard`. Authorization mirrors the existing
+ * activity / monitoring / hosts / alerts channels: only the matching
+ * user can subscribe.
+ *
+ * Tests the channel callback directly (extracted from the
+ * broadcaster's registered channels) rather than the full HTTP auth
+ * round-trip — the closure result is what gates a connection.
+ */
+class DashboardChannelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function dashboardChannelCallback(): callable
+    {
+        $broadcaster = Broadcast::getFacadeRoot()->driver();
+
+        $reflection = new ReflectionClass($broadcaster);
+        $property = $reflection->getProperty('channels');
+        $property->setAccessible(true);
+
+        /** @var array<string, callable> $channels */
+        $channels = $property->getValue($broadcaster);
+
+        $key = collect(array_keys($channels))
+            ->first(fn (string $name) => str_contains($name, 'users.{userId}.dashboard'));
+
+        $this->assertNotNull(
+            $key,
+            'Dashboard channel `users.{userId}.dashboard` is not registered. Check routes/channels.php.',
+        );
+
+        return $channels[$key];
+    }
+
+    public function test_owner_is_authorized_for_their_own_channel(): void
+    {
+        $user = User::factory()->create();
+        $callback = $this->dashboardChannelCallback();
+
+        $this->assertTrue((bool) $callback($user, $user->id));
+    }
+
+    public function test_other_user_is_not_authorized(): void
+    {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $callback = $this->dashboardChannelCallback();
+
+        $this->assertFalse((bool) $callback($other, $owner->id));
+    }
+
+    public function test_string_user_id_matches_when_numerically_equal(): void
+    {
+        $user = User::factory()->create();
+        $callback = $this->dashboardChannelCallback();
+
+        $this->assertTrue((bool) $callback($user, (string) $user->id));
+    }
+}

--- a/tests/Feature/Events/HealthScoreUpdatedTest.php
+++ b/tests/Feature/Events/HealthScoreUpdatedTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Events;
+
+use App\Events\HealthScoreUpdated;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+use Tests\TestCase;
+
+class HealthScoreUpdatedTest extends TestCase
+{
+    public function test_implements_should_broadcast_now(): void
+    {
+        $event = new HealthScoreUpdated(projectId: 1, ownerUserId: 2, score: 80, band: 'good');
+
+        $this->assertInstanceOf(ShouldBroadcastNow::class, $event);
+    }
+
+    public function test_implements_should_dispatch_after_commit(): void
+    {
+        $event = new HealthScoreUpdated(projectId: 1, ownerUserId: 2, score: 80, band: 'good');
+
+        $this->assertInstanceOf(ShouldDispatchAfterCommit::class, $event);
+    }
+
+    public function test_broadcasts_on_owner_dashboard_channel(): void
+    {
+        $event = new HealthScoreUpdated(projectId: 1, ownerUserId: 99, score: 80, band: 'good');
+
+        $channels = $event->broadcastOn();
+
+        $this->assertCount(1, $channels);
+        $this->assertInstanceOf(PrivateChannel::class, $channels[0]);
+        $this->assertStringEndsWith('users.99.dashboard', $channels[0]->name);
+    }
+
+    public function test_no_channels_when_owner_user_id_is_null(): void
+    {
+        $event = new HealthScoreUpdated(projectId: 1, ownerUserId: null, score: 80, band: 'good');
+
+        $this->assertSame([], $event->broadcastOn());
+    }
+
+    public function test_broadcast_with_payload_carries_project_score_and_band(): void
+    {
+        $event = new HealthScoreUpdated(projectId: 42, ownerUserId: 1, score: 65, band: 'degraded');
+
+        $this->assertSame(
+            ['project_id' => 42, 'health_score' => 65, 'band' => 'degraded'],
+            $event->broadcastWith(),
+        );
+    }
+
+    public function test_broadcast_as_uses_stable_dotted_name(): void
+    {
+        $event = new HealthScoreUpdated(projectId: 1, ownerUserId: 2, score: 80, band: 'good');
+
+        $this->assertSame('HealthScoreUpdated', $event->broadcastAs());
+    }
+}

--- a/tests/Feature/Listeners/RecomputeProjectHealthOnActivityTest.php
+++ b/tests/Feature/Listeners/RecomputeProjectHealthOnActivityTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Tests\Feature\Listeners;
+
+use App\Domain\Analytics\Jobs\RecomputeProjectHealthScoreJob;
+use App\Events\ActivityEventCreated;
+use App\Listeners\RecomputeProjectHealthOnActivity;
+use App\Models\ActivityEvent;
+use App\Models\Alert;
+use App\Models\Host;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\Website;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+class RecomputeProjectHealthOnActivityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function fire(ActivityEvent $activity): void
+    {
+        $listener = app(RecomputeProjectHealthOnActivity::class);
+        $listener->handle(new ActivityEventCreated($activity));
+    }
+
+    public function test_alert_triggered_queues_a_recompute_for_the_alert_s_project(): void
+    {
+        Bus::fake();
+        $project = Project::factory()->create();
+        $alert = Alert::factory()->create(['project_id' => $project->id]);
+
+        $activity = ActivityEvent::factory()->create([
+            'source' => 'alerts',
+            'event_type' => 'alert.triggered',
+            'metadata' => ['alert_id' => $alert->id],
+            'repository_id' => null,
+        ]);
+
+        $this->fire($activity);
+
+        Bus::assertDispatched(
+            RecomputeProjectHealthScoreJob::class,
+            fn (RecomputeProjectHealthScoreJob $job): bool => $job->projectId === $project->id,
+        );
+    }
+
+    public function test_website_down_queues_a_recompute(): void
+    {
+        Bus::fake();
+        $project = Project::factory()->create();
+        $website = Website::factory()->create(['project_id' => $project->id]);
+
+        $activity = ActivityEvent::factory()->create([
+            'source' => 'monitoring',
+            'event_type' => 'website.down',
+            'metadata' => ['website_id' => $website->id],
+            'repository_id' => null,
+        ]);
+
+        $this->fire($activity);
+
+        Bus::assertDispatched(
+            RecomputeProjectHealthScoreJob::class,
+            fn (RecomputeProjectHealthScoreJob $job): bool => $job->projectId === $project->id,
+        );
+    }
+
+    public function test_host_offline_queues_a_recompute(): void
+    {
+        Bus::fake();
+        $project = Project::factory()->create();
+        $host = Host::factory()->create(['project_id' => $project->id]);
+
+        $activity = ActivityEvent::factory()->create([
+            'source' => 'hosts',
+            'event_type' => 'host.offline',
+            'metadata' => ['host_id' => $host->id],
+            'repository_id' => null,
+        ]);
+
+        $this->fire($activity);
+
+        Bus::assertDispatched(
+            RecomputeProjectHealthScoreJob::class,
+            fn (RecomputeProjectHealthScoreJob $job): bool => $job->projectId === $project->id,
+        );
+    }
+
+    public function test_workflow_failed_uses_repository_path(): void
+    {
+        Bus::fake();
+        $project = Project::factory()->create();
+        $repo = Repository::factory()->create(['project_id' => $project->id]);
+
+        $activity = ActivityEvent::factory()->create([
+            'source' => 'github',
+            'event_type' => 'workflow.failed',
+            'repository_id' => $repo->id,
+            'metadata' => [],
+        ]);
+
+        $this->fire($activity);
+
+        Bus::assertDispatched(
+            RecomputeProjectHealthScoreJob::class,
+            fn (RecomputeProjectHealthScoreJob $job): bool => $job->projectId === $project->id,
+        );
+    }
+
+    public function test_non_score_moving_event_is_ignored(): void
+    {
+        Bus::fake();
+        $project = Project::factory()->create();
+        $repo = Repository::factory()->create(['project_id' => $project->id]);
+
+        // `release.published` exists per spec 020 but doesn't move
+        // the score per §14.2 — the listener whitelist must skip it.
+        $activity = ActivityEvent::factory()->create([
+            'source' => 'github',
+            'event_type' => 'release.published',
+            'repository_id' => $repo->id,
+            'metadata' => [],
+        ]);
+
+        $this->fire($activity);
+
+        Bus::assertNothingDispatched();
+    }
+
+    public function test_orphan_alert_metadata_is_silently_skipped(): void
+    {
+        // alert.triggered with no resolvable alert_id (eg. the row
+        // was deleted before this listener ran). The listener must
+        // not throw and must not queue a job.
+        Bus::fake();
+        $activity = ActivityEvent::factory()->create([
+            'source' => 'alerts',
+            'event_type' => 'alert.triggered',
+            'metadata' => ['alert_id' => 999_999],
+            'repository_id' => null,
+        ]);
+
+        $this->fire($activity);
+
+        Bus::assertNothingDispatched();
+    }
+
+    public function test_listener_is_auto_discovered_and_fires_on_real_event_dispatch(): void
+    {
+        // Sanity check that Laravel 11+'s listener auto-discovery
+        // actually wires this listener up — without it the rest of
+        // the file is unit-testing a class that nothing invokes.
+        Bus::fake();
+        $project = Project::factory()->create();
+        $alert = Alert::factory()->create(['project_id' => $project->id]);
+        $activity = ActivityEvent::factory()->create([
+            'source' => 'alerts',
+            'event_type' => 'alert.triggered',
+            'metadata' => ['alert_id' => $alert->id],
+            'repository_id' => null,
+        ]);
+
+        ActivityEventCreated::dispatch($activity);
+
+        Bus::assertDispatched(RecomputeProjectHealthScoreJob::class);
+    }
+}

--- a/tests/Feature/Projects/ProjectControllerTest.php
+++ b/tests/Feature/Projects/ProjectControllerTest.php
@@ -102,6 +102,46 @@ class ProjectControllerTest extends TestCase
             );
     }
 
+    public function test_show_payload_carries_health_score_and_band(): void
+    {
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create([
+            'owner_user_id' => $user->id,
+            'health_score' => 82,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('projects.show', $project))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->where('project.health_score', 82)
+                    ->where('project.health_band', 'good'),
+            );
+    }
+
+    public function test_show_payload_health_band_is_null_when_score_is_null(): void
+    {
+        // Pre-first-sweep state: a freshly-created project has no
+        // stored score. The transform must surface both fields as
+        // null so the frontend renders the "Unscored" placeholder
+        // rather than mapping a missing band to a misleading tone.
+        $user = $this->verifiedUser();
+        $project = Project::factory()->create([
+            'owner_user_id' => $user->id,
+            'health_score' => null,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('projects.show', $project))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->where('project.health_score', null)
+                    ->where('project.health_band', null),
+            );
+    }
+
     public function test_show_scopes_monitors_to_this_project(): void
     {
         $user = $this->verifiedUser();

--- a/tests/Unit/Domain/Analytics/ComputeProjectHealthScoreActionTest.php
+++ b/tests/Unit/Domain/Analytics/ComputeProjectHealthScoreActionTest.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace Tests\Unit\Domain\Analytics;
+
+use App\Domain\Analytics\Actions\ComputeProjectHealthScoreAction;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertStatus;
+use App\Enums\HostStatus;
+use App\Enums\WebsiteStatus;
+use App\Enums\WorkflowRunConclusion;
+use App\Enums\WorkflowRunStatus;
+use App\Models\Alert;
+use App\Models\Container;
+use App\Models\Host;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\Website;
+use App\Models\WorkflowRun;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class ComputeProjectHealthScoreActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function compute(Project $project): int
+    {
+        return app(ComputeProjectHealthScoreAction::class)->execute($project);
+    }
+
+    public function test_baseline_is_100_when_no_signals_deduct(): void
+    {
+        $project = Project::factory()->create();
+
+        $this->assertSame(100, $this->compute($project));
+    }
+
+    public function test_one_critical_alert_deducts_30(): void
+    {
+        $project = Project::factory()->create();
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+
+        $this->assertSame(70, $this->compute($project));
+    }
+
+    public function test_one_warning_alert_deducts_15(): void
+    {
+        $project = Project::factory()->create();
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Warning->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+
+        $this->assertSame(85, $this->compute($project));
+    }
+
+    public function test_acknowledged_alert_still_counts(): void
+    {
+        // §14.2 deducts for *active* alerts — open + acknowledged.
+        // Only resolved + muted stop dragging the score down.
+        $project = Project::factory()->create();
+        Alert::factory()->acknowledged()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+        ]);
+
+        $this->assertSame(70, $this->compute($project));
+    }
+
+    public function test_resolved_and_muted_alerts_do_not_count(): void
+    {
+        $project = Project::factory()->create();
+        Alert::factory()->resolved()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+        ]);
+        Alert::factory()->muted()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+        ]);
+
+        $this->assertSame(100, $this->compute($project));
+    }
+
+    public function test_multiple_alerts_stack_per_occurrence(): void
+    {
+        $project = Project::factory()->create();
+        // 2 critical (-60) + 1 warning (-15) = -75
+        Alert::factory()->count(2)->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Warning->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+
+        $this->assertSame(25, $this->compute($project));
+    }
+
+    public function test_website_down_and_slow_deductions_stack(): void
+    {
+        $project = Project::factory()->create();
+        Website::factory()->create([
+            'project_id' => $project->id,
+            'status' => WebsiteStatus::Down->value,
+        ]);
+        Website::factory()->create([
+            'project_id' => $project->id,
+            'status' => WebsiteStatus::Slow->value,
+        ]);
+
+        // 100 - 20 (down) - 10 (slow) = 70
+        $this->assertSame(70, $this->compute($project));
+    }
+
+    public function test_website_error_status_is_treated_as_down(): void
+    {
+        $project = Project::factory()->create();
+        Website::factory()->create([
+            'project_id' => $project->id,
+            'status' => WebsiteStatus::Error->value,
+        ]);
+
+        $this->assertSame(80, $this->compute($project));
+    }
+
+    public function test_host_offline_deducts_15(): void
+    {
+        $project = Project::factory()->create();
+        Host::factory()->create([
+            'project_id' => $project->id,
+            'status' => HostStatus::Offline->value,
+        ]);
+
+        $this->assertSame(85, $this->compute($project));
+    }
+
+    public function test_archived_host_is_not_counted(): void
+    {
+        $project = Project::factory()->create();
+        Host::factory()->create([
+            'project_id' => $project->id,
+            'status' => HostStatus::Offline->value,
+            'archived_at' => Carbon::now()->subDay(),
+        ]);
+
+        $this->assertSame(100, $this->compute($project));
+    }
+
+    public function test_unhealthy_container_deducts_10(): void
+    {
+        $project = Project::factory()->create();
+        $host = Host::factory()->create(['project_id' => $project->id]);
+        Container::factory()->create([
+            'host_id' => $host->id,
+            'project_id' => $project->id,
+            'health_status' => 'unhealthy',
+        ]);
+
+        $this->assertSame(90, $this->compute($project));
+    }
+
+    public function test_healthy_and_null_health_status_containers_do_not_count(): void
+    {
+        $project = Project::factory()->create();
+        $host = Host::factory()->create(['project_id' => $project->id]);
+        Container::factory()->create([
+            'host_id' => $host->id,
+            'project_id' => $project->id,
+            'health_status' => 'healthy',
+        ]);
+        Container::factory()->create([
+            'host_id' => $host->id,
+            'project_id' => $project->id,
+            'health_status' => null,
+        ]);
+
+        $this->assertSame(100, $this->compute($project));
+    }
+
+    public function test_failed_default_branch_workflow_in_24h_deducts_20(): void
+    {
+        $project = Project::factory()->create();
+        $repo = Repository::factory()->create([
+            'project_id' => $project->id,
+            'default_branch' => 'main',
+        ]);
+        WorkflowRun::factory()->create([
+            'repository_id' => $repo->id,
+            'status' => WorkflowRunStatus::Completed->value,
+            'conclusion' => WorkflowRunConclusion::Failure->value,
+            'head_branch' => 'main',
+            'run_completed_at' => Carbon::now()->subHours(2),
+        ]);
+
+        $this->assertSame(80, $this->compute($project));
+    }
+
+    public function test_failed_feature_branch_workflow_does_not_deduct(): void
+    {
+        $project = Project::factory()->create();
+        $repo = Repository::factory()->create([
+            'project_id' => $project->id,
+            'default_branch' => 'main',
+        ]);
+        WorkflowRun::factory()->create([
+            'repository_id' => $repo->id,
+            'status' => WorkflowRunStatus::Completed->value,
+            'conclusion' => WorkflowRunConclusion::Failure->value,
+            'head_branch' => 'feature/widget',
+            'run_completed_at' => Carbon::now()->subHours(2),
+        ]);
+
+        $this->assertSame(100, $this->compute($project));
+    }
+
+    public function test_failed_default_branch_workflow_older_than_24h_does_not_deduct(): void
+    {
+        $project = Project::factory()->create();
+        $repo = Repository::factory()->create([
+            'project_id' => $project->id,
+            'default_branch' => 'main',
+        ]);
+        WorkflowRun::factory()->create([
+            'repository_id' => $repo->id,
+            'status' => WorkflowRunStatus::Completed->value,
+            'conclusion' => WorkflowRunConclusion::Failure->value,
+            'head_branch' => 'main',
+            'run_completed_at' => Carbon::now()->subDays(2),
+        ]);
+
+        $this->assertSame(100, $this->compute($project));
+    }
+
+    public function test_clamps_to_zero_on_worst_case_stack(): void
+    {
+        $project = Project::factory()->create();
+        // 5 critical alerts = -150 → clamped to 0.
+        Alert::factory()->count(5)->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+
+        $this->assertSame(0, $this->compute($project));
+    }
+
+    public function test_signals_on_another_project_do_not_affect_this_score(): void
+    {
+        $a = Project::factory()->create();
+        $b = Project::factory()->create();
+
+        // Pile signals on project B.
+        Alert::factory()->count(3)->create([
+            'project_id' => $b->id,
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+        Website::factory()->create([
+            'project_id' => $b->id,
+            'status' => WebsiteStatus::Down->value,
+        ]);
+        Host::factory()->create([
+            'project_id' => $b->id,
+            'status' => HostStatus::Offline->value,
+        ]);
+
+        $this->assertSame(100, $this->compute($a));
+    }
+
+    public function test_full_deduction_stack_calculates_correctly(): void
+    {
+        // Sanity check that all signal classes combine without
+        // double-counting. 100 - 30 (crit alert) - 15 (warn alert)
+        // - 20 (website down) - 10 (website slow) - 15 (host offline)
+        // - 10 (container unhealthy) - 20 (failed deploy) = -20 → 0.
+        $project = Project::factory()->create();
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Warning->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+        Website::factory()->create([
+            'project_id' => $project->id,
+            'status' => WebsiteStatus::Down->value,
+        ]);
+        Website::factory()->create([
+            'project_id' => $project->id,
+            'status' => WebsiteStatus::Slow->value,
+        ]);
+        $host = Host::factory()->create([
+            'project_id' => $project->id,
+            'status' => HostStatus::Offline->value,
+        ]);
+        Container::factory()->create([
+            'host_id' => $host->id,
+            'project_id' => $project->id,
+            'health_status' => 'unhealthy',
+        ]);
+        $repo = Repository::factory()->create([
+            'project_id' => $project->id,
+            'default_branch' => 'main',
+        ]);
+        WorkflowRun::factory()->create([
+            'repository_id' => $repo->id,
+            'status' => WorkflowRunStatus::Completed->value,
+            'conclusion' => WorkflowRunConclusion::Failure->value,
+            'head_branch' => 'main',
+            'run_completed_at' => Carbon::now()->subHours(2),
+        ]);
+
+        $this->assertSame(0, $this->compute($project));
+    }
+}

--- a/tests/Unit/Domain/Analytics/Jobs/RecomputeAllProjectHealthScoresJobTest.php
+++ b/tests/Unit/Domain/Analytics/Jobs/RecomputeAllProjectHealthScoresJobTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\Domain\Analytics\Jobs;
+
+use App\Domain\Analytics\Jobs\RecomputeAllProjectHealthScoresJob;
+use App\Domain\Analytics\Jobs\RecomputeProjectHealthScoreJob;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+class RecomputeAllProjectHealthScoresJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dispatches_one_per_recently_active_project(): void
+    {
+        Bus::fake();
+        $a = Project::factory()->create([
+            'last_activity_at' => Carbon::now()->subDay(),
+            'health_score' => 80,
+        ]);
+        $b = Project::factory()->create([
+            'last_activity_at' => Carbon::now()->subDays(3),
+            'health_score' => 60,
+        ]);
+
+        (new RecomputeAllProjectHealthScoresJob)->handle();
+
+        Bus::assertDispatchedTimes(RecomputeProjectHealthScoreJob::class, 2);
+        Bus::assertDispatched(
+            RecomputeProjectHealthScoreJob::class,
+            fn (RecomputeProjectHealthScoreJob $job): bool => $job->projectId === $a->id,
+        );
+        Bus::assertDispatched(
+            RecomputeProjectHealthScoreJob::class,
+            fn (RecomputeProjectHealthScoreJob $job): bool => $job->projectId === $b->id,
+        );
+    }
+
+    public function test_dispatches_for_unscored_project_even_if_sleeping(): void
+    {
+        // A project with no `last_activity_at` (never touched) still
+        // needs an initial score — the `OR health_score IS NULL`
+        // branch covers the first-run sweep after this spec lands.
+        Bus::fake();
+        $unscored = Project::factory()->create([
+            'last_activity_at' => Carbon::now()->subMonths(2),
+            'health_score' => null,
+        ]);
+
+        (new RecomputeAllProjectHealthScoresJob)->handle();
+
+        Bus::assertDispatched(
+            RecomputeProjectHealthScoreJob::class,
+            fn (RecomputeProjectHealthScoreJob $job): bool => $job->projectId === $unscored->id,
+        );
+    }
+
+    public function test_skips_sleeping_projects_that_already_have_a_score(): void
+    {
+        Bus::fake();
+        Project::factory()->create([
+            'last_activity_at' => Carbon::now()->subDays(30),
+            'health_score' => 100,
+        ]);
+
+        (new RecomputeAllProjectHealthScoresJob)->handle();
+
+        Bus::assertNothingDispatched();
+    }
+}

--- a/tests/Unit/Domain/Analytics/Jobs/RecomputeProjectHealthScoreJobTest.php
+++ b/tests/Unit/Domain/Analytics/Jobs/RecomputeProjectHealthScoreJobTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Unit\Domain\Analytics\Jobs;
+
+use App\Domain\Analytics\Actions\RefreshProjectHealthScoreAction;
+use App\Domain\Analytics\Jobs\RecomputeProjectHealthScoreJob;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertStatus;
+use App\Models\Alert;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RecomputeProjectHealthScoreJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_runs_refresh_action_for_the_project(): void
+    {
+        $project = Project::factory()->create(['health_score' => null]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+
+        (new RecomputeProjectHealthScoreJob($project->id))->handle(app(RefreshProjectHealthScoreAction::class));
+
+        $this->assertSame(70, $project->fresh()->health_score);
+    }
+
+    public function test_silently_skips_when_project_was_deleted(): void
+    {
+        // Dispatch references the id by value, so a delete between
+        // dispatch and handle leaves the job with a stale id. The
+        // `find` should no-op without throwing.
+        $job = new RecomputeProjectHealthScoreJob(999_999);
+
+        $job->handle(app(RefreshProjectHealthScoreAction::class));
+
+        // No assertion needed beyond "did not throw".
+        $this->assertTrue(true);
+    }
+
+    public function test_unique_id_keys_on_project_id(): void
+    {
+        $job = new RecomputeProjectHealthScoreJob(42);
+
+        $this->assertSame('42', $job->uniqueId());
+    }
+}

--- a/tests/Unit/Domain/Analytics/RefreshProjectHealthScoreActionTest.php
+++ b/tests/Unit/Domain/Analytics/RefreshProjectHealthScoreActionTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Unit\Domain\Analytics;
+
+use App\Domain\Analytics\Actions\RefreshProjectHealthScoreAction;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertStatus;
+use App\Events\HealthScoreUpdated;
+use App\Models\Alert;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class RefreshProjectHealthScoreActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_first_run_persists_the_score_and_dispatches(): void
+    {
+        Event::fake([HealthScoreUpdated::class]);
+        $owner = User::factory()->create();
+        $project = Project::factory()->create([
+            'owner_user_id' => $owner->id,
+            'health_score' => null,
+        ]);
+
+        $score = app(RefreshProjectHealthScoreAction::class)->execute($project);
+
+        $this->assertSame(100, $score);
+        $this->assertSame(100, $project->fresh()->health_score);
+
+        Event::assertDispatched(
+            HealthScoreUpdated::class,
+            fn (HealthScoreUpdated $event): bool => $event->projectId === $project->id
+                && $event->ownerUserId === $owner->id
+                && $event->score === 100
+                && $event->band === 'healthy',
+        );
+    }
+
+    public function test_unchanged_score_is_a_full_noop(): void
+    {
+        Event::fake([HealthScoreUpdated::class]);
+        $project = Project::factory()->create(['health_score' => 100]);
+        $originalUpdatedAt = $project->updated_at;
+
+        $score = app(RefreshProjectHealthScoreAction::class)->execute($project);
+
+        $this->assertSame(100, $score);
+        $this->assertEquals($originalUpdatedAt, $project->fresh()->updated_at, 'no spurious updated_at bump');
+        Event::assertNotDispatched(HealthScoreUpdated::class);
+    }
+
+    public function test_score_drop_persists_and_broadcasts_with_correct_band(): void
+    {
+        Event::fake([HealthScoreUpdated::class]);
+        $owner = User::factory()->create();
+        $project = Project::factory()->create([
+            'owner_user_id' => $owner->id,
+            'health_score' => 100,
+        ]);
+
+        // 2 critical alerts (-60) + 1 warning (-15) = 25 → critical band.
+        Alert::factory()->count(2)->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Warning->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+
+        $score = app(RefreshProjectHealthScoreAction::class)->execute($project);
+
+        $this->assertSame(25, $score);
+        $this->assertSame(25, $project->fresh()->health_score);
+
+        Event::assertDispatched(
+            HealthScoreUpdated::class,
+            fn (HealthScoreUpdated $event): bool => $event->projectId === $project->id
+                && $event->score === 25
+                && $event->band === 'critical',
+        );
+    }
+}


### PR DESCRIPTION
Closes #97

Spec: `specs/phase-8-analytics/033-health-score-scaffolding.md`

## Summary

- Activates the dormant `projects.health_score` column with the §14.2 weighted-deduction formula. `ComputeProjectHealthScoreAction` walks per-occurrence deductions across active alerts (open + acknowledged, critical / warning), websites (down / error / slow), hosts (offline, non-archived), containers (`health_status === 'unhealthy'`), and failed default-branch workflow runs in the last 24h. Clamps `[0, 100]`.
- `RefreshProjectHealthScoreAction` diff-and-writes: persists + broadcasts `HealthScoreUpdated` only when the score actually changes.
- Two pipelines feed the refresh: an every-5-minute scheduled sweep job (active projects only — `last_activity_at > now()->subDays(7) OR health_score IS NULL`), and an auto-discovered listener on `ActivityEventCreated` that fires within seconds of any whitelisted transition (`alert.triggered`, `website.down`, `host.offline`, `workflow.failed`, etc.). Per-project jobs use `ShouldBeUnique` + `WithoutOverlapping` keyed on project id so bursts collapse naturally.
- New `users.{id}.dashboard` Reverb channel + `HealthScoreUpdated` event (`ShouldBroadcastNow + ShouldDispatchAfterCommit`). 035 will reuse the channel for the activity-heatmap real-data pulse.
- `ProjectController::transform()` exposes `health_band` alongside `health_score`. `HealthScoreBadge.vue` renders `{score}/100 {Label}` (or "— Unscored" when null) via `StatusBadge`. Shown on `Pages/Projects/Show.vue` next to the project name. `Pages/Overview.vue` subscribes to the dashboard channel (pre-wires the reload path — the visible payoff arrives in 035 when Overview renders the risky-projects panel).

## Test plan

- [x] `projects.health_score` is non-null on every active project within one scheduler tick.
- [x] A new critical alert on a project drops the score by 30 within the next listener-triggered recompute.
- [x] A `website.recovered` transition that should restore the score raises it back.
- [x] `HealthScoreUpdated` broadcasts only when the persisted score actually changes (no spurious events on no-op recomputes).
- [x] Overview re-fetches `dashboard` on a `.HealthScoreUpdated` pulse (wiring exercised in dev; visible payoff in 035).
- [x] Project Show page renders the score badge with the correct band label and tone.
- [x] Sleeping projects (`last_activity_at > 7d` AND `health_score` non-null) are skipped by the scheduled sweep.
- [x] Score clamps to `[0, 100]` under the worst-case stack.
- [x] Pint clean. `php artisan test` green (642 tests / 2428 assertions). `npm run build` clean.

## Self-review notes

Reviewed by `superpowers:code-reviewer`. Verdict: ship it.

Key answers:
- The workflow-run join in `deploymentDeductions()` is many-to-one — `count('workflow_runs.id')` is correct and the `whereColumn` is portable across SQLite / MySQL / Postgres.
- Per-occurrence deduction stacking (3 critical alerts = -90) is the right read of §14.2 given the "reflects real signals" framing; the constants + `count()` pivot point in the action's docblock are the right tuning surface for future spec.
- Laravel 13 listener auto-discovery is the only wiring path (no `EventServiceProvider` exists). End-to-end `test_listener_is_auto_discovered_and_fires_on_real_event_dispatch` covers that path; defensive manual registration in `bootstrap/app.php` would be belt-and-suspenders only.
- Duplication of the source → project chain (`RecomputeProjectHealthOnActivity::resolveProjectId` mirrors `ActivityEventCreated::resolveOwnerUserId`) is documented and deferred to a future refactor — the two resolvers have different consumers and could legitimately diverge.
- `RefreshProjectHealthScoreAction` broadcasts via `ShouldDispatchAfterCommit` so the wire event always lands post-commit.
- Sweep job uses `chunkById(100, ...)` + per-row dispatch (not `Bus::batch`) — batches buy progress / cancellation / callbacks, none apply to a fire-and-forget recompute fan-out.
- One material item flagged and fixed: the Overview Echo subscription is correct but cosmetic until 035 renders per-project health on the page. Added a clarifying comment at the subscription site + a work-log note in the spec.

Deferred follow-ups (non-blocking):
- `RecomputeProjectHealthScoreJob` runs with `$tries = 1`; could add a small backoff retry — 5-min sweep is the worst-case stale window today, acceptable.
- Promote band conversion to a `Project::healthBand()` accessor when 035 wires multiple project payloads.
- `Pages/Projects/Index.vue` doesn't yet render the badge — 035 lands the Overview consumer; Index could follow as a small polish.
- `SCORE_MOVING_EVENTS` whitelist drift risk — flagged via constant docblock; future event_types must register here.