### PR TITLE
chore(specs): flip 033 to done + Phase 8 tracker

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -43,7 +43,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 5 | Website Monitoring | 🟢 | 3/3 specs done (023–025). Phase complete. |
 | 6 | Docker Host Agent MVP | 🟢 | 4/4 specs done (026–029). Phase complete. |
 | 7 | Alerts Engine | 🟢 | 3/3 specs done (030–032). Phase complete. |
-| 8 | Analytics & Health Scores | ⬜ | — |
+| 8 | Analytics & Health Scores | 🟡 | 1/3 specs done (033). 034 (analytics page) + 035 (heatmap + risky-projects close) pending. |
 | 9 | Polish & Production Readiness | ⬜ | — |
 | 10 | Future Innovation | ⬜ | — |
 

--- a/specs/phase-8-analytics/033-health-score-scaffolding.md
+++ b/specs/phase-8-analytics/033-health-score-scaffolding.md
@@ -1,7 +1,7 @@
 ---
 spec: health-score-scaffolding
 phase: 8
-status: in-progress   # not-started | in-progress | blocked | done
+status: done   # not-started | in-progress | blocked | done
 owner: Yoany
 created: 2026-06-03
 updated: 2026-06-04

--- a/specs/phase-8-analytics/README.md
+++ b/specs/phase-8-analytics/README.md
@@ -19,7 +19,7 @@ matters.
 
 | # | Task | Status |
 |---|------|--------|
-| 033 | Health-score scaffolding (calculation + scheduled & transition-driven recompute + broadcast + Overview & project UI) | ⬜ |
+| 033 | Health-score scaffolding (calculation + scheduled & transition-driven recompute + broadcast + Overview & project UI) | 🟢 |
 | 034 | Analytics dashboard page (`/analytics` route, §8.13 chart set, date-range filter) | ⬜ |
 | 035 | Real-data activity heatmap + Overview risky-project prioritization (closes phase 8) | ⬜ |
 


### PR DESCRIPTION
Spec 033 (#97 / PR #98) merged. This bookkeeping commit flips the spec frontmatter to `done`, the Phase 8 README task row to 🟢, and the master tracker's Phase 8 row from ⬜ → 🟡 with progress notes.