### PR TITLE
Spec 035 — Overview risky-projects + heatmap polish (closes Phase 8)

### DIFF
--- a/app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php
+++ b/app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php
@@ -41,9 +41,9 @@ use Illuminate\Support\Collection;
  *     limit 4. `commits` proxies via stars_count until phase 2 syncs
  *     real commit counts from GitHub.
  *   - activityHeatmap — 7 days × 6 four-hour buckets aggregated from
- *     `activity_events.occurred_at` over the last 90 days. Bucketing
- *     happens in PHP so the query stays cross-DB without `DAYOFWEEK()` /
- *     `HOUR()` polyfills.
+ *     `activity_events.occurred_at` over the last 12 weeks (84 days).
+ *     Bucketing happens in PHP so the query stays cross-DB without
+ *     `DAYOFWEEK()` / `HOUR()` polyfills.
  *   - dashboard.uptime.{overall,change,sparkline,status} — Spec 025;
  *     `GetMonitoringUptimeKpiQuery` aggregates `website_checks`
  *     volume-weighted across all of the user's monitors over 24h
@@ -226,22 +226,23 @@ class GetOverviewDashboardQuery
     /**
      * Engineering-rhythm heatmap (7 days × 6 four-hour buckets).
      *
-     * Aggregates `activity_events.occurred_at` over the last 90 days
-     * into a `[day_of_week][bucket]` grid where:
+     * Aggregates `activity_events.occurred_at` over the last 12 weeks
+     * (84 days) into a `[day_of_week][bucket]` grid where:
      *   - day_of_week: 0=Sun, 1=Mon, …, 6=Sat (Carbon's convention,
      *     matches the JS `Date#getDay()` axis on the heatmap component)
      *   - bucket: 0=00:00–04:00, 1=04:00–08:00, …, 5=20:00–24:00
      *
-     * 90-day window is long enough to surface a recurring rhythm but
+     * 12-week window is long enough to surface a recurring rhythm but
      * recent enough to reflect *current* habits — narrower than "all
      * time" (which dilutes signal forever) and wider than "last week"
-     * (which is noisy on quiet accounts).
+     * (which is noisy on quiet accounts). The window was 90 days
+     * pre-spec 035; the shift aligns to the Phase 8 acceptance text.
      *
      * **Why bucket in PHP, not SQL:** `DAYOFWEEK()` (MySQL) and
      * `strftime('%w', …)` (SQLite) disagree on indexing AND on
      * timezone handling, and the test suite runs on SQLite while prod
      * uses MySQL. A single `SELECT occurred_at FROM activity_events
-     * WHERE occurred_at >= ?` is cheap at phase-1 scale (≤90d × low
+     * WHERE occurred_at >= ?` is cheap at phase-1 scale (≤12 weeks × low
      * webhook traffic), and bucketing in PHP keeps the math obvious.
      *
      * **Timezone caveat:** the hour bucket is computed in the app's
@@ -295,6 +296,7 @@ class GetOverviewDashboardQuery
             ->orderByRaw('health_score IS NULL')
             ->orderBy('health_score', 'asc')
             ->orderByDesc('last_activity_at')
+            ->orderBy('id') // deterministic tiebreaker when score + last_activity_at collide
             ->limit(self::RISKY_PROJECTS_LIMIT)
             ->get([
                 'id',

--- a/app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php
+++ b/app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php
@@ -5,6 +5,7 @@ namespace App\Domain\Dashboard\Queries;
 use App\Domain\Monitoring\Queries\GetMonitoringUptimeKpiQuery;
 use App\Enums\AlertSeverity;
 use App\Enums\AlertStatus;
+use App\Enums\HealthScoreBand;
 use App\Enums\HostStatus;
 use App\Models\ActivityEvent;
 use App\Models\Alert;
@@ -12,6 +13,7 @@ use App\Models\Host;
 use App\Models\HostMetricSnapshot;
 use App\Models\Project;
 use App\Models\Repository;
+use App\Models\User;
 use App\Models\WorkflowRun;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
@@ -69,7 +71,10 @@ class GetOverviewDashboardQuery
     /** Default number of repositories returned by the Top Repositories slice. */
     private const TOP_REPOS_LIMIT = 4;
 
-    public function handle(): array
+    /** Cap for the riskyProjects panel — mirrors the dashboard row rhythm (spec 035). */
+    private const RISKY_PROJECTS_LIMIT = 6;
+
+    public function handle(User $user): array
     {
         return [
             'dashboard' => array_merge(self::MOCK_KPIS, [
@@ -79,6 +84,7 @@ class GetOverviewDashboardQuery
                 'alerts' => $this->alerts(),
                 'uptime' => app(GetMonitoringUptimeKpiQuery::class)->execute(),
                 'topRepositories' => $this->topRepositories(),
+                'riskyProjects' => $this->riskyProjects($user),
             ]),
             'activityHeatmap' => $this->activityHeatmap(),
         ];
@@ -250,8 +256,10 @@ class GetOverviewDashboardQuery
     {
         $grid = array_fill(0, 7, array_fill(0, 6, 0));
 
+        // Spec 035 — 12 weeks (84 days), aligning with the Phase 8
+        // README's literal acceptance text. Was 90 days previously.
         ActivityEvent::query()
-            ->where('occurred_at', '>=', now()->subDays(90))
+            ->where('occurred_at', '>=', now()->subWeeks(12))
             ->select('occurred_at')
             ->get()
             ->each(function (ActivityEvent $event) use (&$grid) {
@@ -265,6 +273,51 @@ class GetOverviewDashboardQuery
             });
 
         return $grid;
+    }
+
+    /**
+     * Spec 035 — owned projects ranked ascending by `health_score`
+     * with nulls placed last so unscored projects don't displace
+     * genuinely-risky ones. Returns up to 6 rows; the Overview
+     * "Risky projects" panel renders the badge + last-activity line.
+     *
+     * Single-tenant ordering note: `ORDER BY health_score IS NULL`
+     * is portable across SQLite + MySQL (both treat it as 0/1 for
+     * the secondary key). Postgres would need explicit `NULLS LAST`
+     * — flag during a future port.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function riskyProjects(User $user): array
+    {
+        return Project::query()
+            ->where('owner_user_id', $user->id)
+            ->orderByRaw('health_score IS NULL')
+            ->orderBy('health_score', 'asc')
+            ->orderByDesc('last_activity_at')
+            ->limit(self::RISKY_PROJECTS_LIMIT)
+            ->get([
+                'id',
+                'slug',
+                'name',
+                'color',
+                'icon',
+                'health_score',
+                'last_activity_at',
+            ])
+            ->map(fn (Project $p): array => [
+                'id' => $p->id,
+                'slug' => $p->slug,
+                'name' => $p->name,
+                'color' => $p->color,
+                'icon' => $p->icon,
+                'health_score' => $p->health_score,
+                'health_band' => $p->health_score === null
+                    ? null
+                    : HealthScoreBand::fromScore($p->health_score)->value,
+                'last_activity_at' => $p->last_activity_at?->diffForHumans(),
+            ])
+            ->all();
     }
 
     /**

--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -32,7 +32,7 @@ class OverviewController extends Controller
         GetOverviewDashboardQuery $query,
         WorkItemsForUserQuery $workItemsQuery,
     ): Response {
-        $payload = $query->handle();
+        $payload = $query->handle($request->user());
 
         // Spec 016 shipped the work-items query; this surfaces the top
         // N open items on the Overview's Issues & PRs widget so the

--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -10,14 +10,15 @@ use Inertia\Response;
 
 /**
  * Overview dashboard. Mostly delegates the read to
- * `GetOverviewDashboardQuery` (roadmap §10.2) — that query handles the
- * single-tenant phase-1 slices that don't need a user (projects,
- * hosts, deployments, top repositories, activity heatmap).
+ * `GetOverviewDashboardQuery` (roadmap §10.2) — that query now accepts
+ * the authenticated user so the riskyProjects slice (spec 035) can
+ * scope to owned projects. The remaining KPI slices (projects /
+ * hosts / deployments / topRepositories / activity heatmap) stay
+ * single-tenant until a dedicated tenancy spec.
  *
- * The Issues & PRs widget is the one user-scoped slice on this page
- * — `WorkItemsForUserQuery` requires a `User` so we run it here and
- * merge the result rather than threading the user into
- * `GetOverviewDashboardQuery`'s no-arg signature.
+ * The Issues & PRs widget is the second user-scoped slice on this
+ * page — `WorkItemsForUserQuery` lives in a different domain so we
+ * run it here and merge the result.
  */
 class OverviewController extends Controller
 {

--- a/resources/js/Components/Dashboard/RiskyProjects.vue
+++ b/resources/js/Components/Dashboard/RiskyProjects.vue
@@ -8,27 +8,36 @@ import { computed } from 'vue';
 
 /**
  * Spec 035 — Overview "Risky projects" panel. The query layer
- * (`GetOverviewDashboardQuery::riskyProjects`) already sorts ascending
- * by `health_score` with nulls last and caps at 6, so this component
- * is pure render: project chip + name + `HealthScoreBadge` + last-
+ * (`GetOverviewDashboardQuery::riskyProjects`) sorts ascending by
+ * `health_score` with nulls last and caps at 6, so this component is
+ * pure render: project chip + name + `HealthScoreBadge` + last-
  * activity line. Each row links to the project's Show page.
  *
- * Empty state triggers when the array is empty (user has no projects)
- * or when every row sits in the "healthy" band (score ≥ 90). The
- * panel hides quietly rather than surfacing a "no risky projects"
- * card — Overview's grid stays tight.
+ * Empty-state placeholder ("All projects healthy") triggers when:
+ *   - the user has no projects, OR
+ *   - every project sits at score ≥ 70 (the §14.2 "good" band floor,
+ *     `healthy` + `good`) or has no score yet (`null`).
+ *
+ * A "good"-banded project at score 75 is intentionally *not* shown:
+ * §14.2 calls it "good", not "needs attention". The panel surfaces
+ * only `degraded` / `warning` / `critical` rows that genuinely warrant
+ * the user's eyes today.
  */
 const props = defineProps<{
     projects: RiskyProjectRow[];
 }>();
 
-const everythingHealthy = computed<boolean>(
-    () =>
-        props.projects.length > 0
-        && props.projects.every(
-            (row) => row.health_band === 'healthy' || row.health_band === null,
-        ),
-);
+const HIDING_BANDS = new Set(['healthy', 'good']);
+
+const shouldShowList = computed<boolean>(() => {
+    if (props.projects.length === 0) {
+        return false;
+    }
+
+    return props.projects.some(
+        (row) => row.health_band !== null && !HIDING_BANDS.has(row.health_band),
+    );
+});
 
 const iconAccentClass = (color: string | null): string => {
     switch (color) {
@@ -64,18 +73,18 @@ const iconAccentClass = (color: string | null): string => {
                 </h3>
             </div>
             <ShieldCheck
-                v-if="everythingHealthy"
+                v-if="!shouldShowList && props.projects.length > 0"
                 class="h-4 w-4 text-status-success"
                 aria-hidden="true"
             />
         </header>
 
         <ul
-            v-if="props.projects.length > 0 && !everythingHealthy"
+            v-if="shouldShowList"
             class="space-y-2"
         >
             <li
-                v-for="project in props.projects"
+                v-for="project in props.projects.filter((p) => p.health_band !== null && !HIDING_BANDS.has(p.health_band))"
                 :key="project.id"
             >
                 <Link

--- a/resources/js/Components/Dashboard/RiskyProjects.vue
+++ b/resources/js/Components/Dashboard/RiskyProjects.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+import HealthScoreBadge from '@/Components/Project/HealthScoreBadge.vue';
+import { projectIcon } from '@/lib/projectIcons';
+import type { RiskyProjectRow } from '@/types';
+import { Link } from '@inertiajs/vue3';
+import { FolderKanban, ShieldCheck } from 'lucide-vue-next';
+import { computed } from 'vue';
+
+/**
+ * Spec 035 — Overview "Risky projects" panel. The query layer
+ * (`GetOverviewDashboardQuery::riskyProjects`) already sorts ascending
+ * by `health_score` with nulls last and caps at 6, so this component
+ * is pure render: project chip + name + `HealthScoreBadge` + last-
+ * activity line. Each row links to the project's Show page.
+ *
+ * Empty state triggers when the array is empty (user has no projects)
+ * or when every row sits in the "healthy" band (score ≥ 90). The
+ * panel hides quietly rather than surfacing a "no risky projects"
+ * card — Overview's grid stays tight.
+ */
+const props = defineProps<{
+    projects: RiskyProjectRow[];
+}>();
+
+const everythingHealthy = computed<boolean>(
+    () =>
+        props.projects.length > 0
+        && props.projects.every(
+            (row) => row.health_band === 'healthy' || row.health_band === null,
+        ),
+);
+
+const iconAccentClass = (color: string | null): string => {
+    switch (color) {
+        case 'cyan':
+            return 'text-accent-cyan';
+        case 'blue':
+            return 'text-accent-blue';
+        case 'purple':
+            return 'text-accent-purple';
+        case 'magenta':
+            return 'text-accent-magenta';
+        case 'success':
+            return 'text-status-success';
+        case 'danger':
+            return 'text-status-danger';
+        default:
+            return 'text-text-secondary';
+    }
+};
+</script>
+
+<template>
+    <section class="glass-card p-5">
+        <header class="mb-4 flex items-center justify-between">
+            <div class="flex flex-col gap-1">
+                <span
+                    class="text-[10px] font-semibold uppercase tracking-[0.32em] text-text-muted"
+                >
+                    Health
+                </span>
+                <h3 class="text-sm font-semibold text-text-primary">
+                    Risky projects
+                </h3>
+            </div>
+            <ShieldCheck
+                v-if="everythingHealthy"
+                class="h-4 w-4 text-status-success"
+                aria-hidden="true"
+            />
+        </header>
+
+        <ul
+            v-if="props.projects.length > 0 && !everythingHealthy"
+            class="space-y-2"
+        >
+            <li
+                v-for="project in props.projects"
+                :key="project.id"
+            >
+                <Link
+                    :href="route('projects.show', project.slug)"
+                    class="group flex items-center justify-between gap-3 rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 transition hover:border-accent-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                >
+                    <div class="flex min-w-0 items-center gap-3">
+                        <span
+                            class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border-subtle bg-background-panel"
+                        >
+                            <component
+                                :is="projectIcon(project.icon) ?? FolderKanban"
+                                class="h-4 w-4"
+                                :class="iconAccentClass(project.color)"
+                                aria-hidden="true"
+                            />
+                        </span>
+                        <div class="flex min-w-0 flex-col">
+                            <span
+                                class="truncate text-sm font-semibold text-text-primary group-hover:text-accent-cyan"
+                            >
+                                {{ project.name }}
+                            </span>
+                            <span
+                                v-if="project.last_activity_at"
+                                class="truncate text-[11px] text-text-muted"
+                            >
+                                {{ project.last_activity_at }}
+                            </span>
+                        </div>
+                    </div>
+                    <HealthScoreBadge
+                        :score="project.health_score"
+                        :band="project.health_band"
+                    />
+                </Link>
+            </li>
+        </ul>
+
+        <div
+            v-else
+            class="flex flex-col items-center gap-2 rounded-lg border border-dashed border-border-subtle bg-background-panel-hover/40 px-3 py-6 text-center"
+        >
+            <ShieldCheck
+                class="h-5 w-5 text-status-success"
+                aria-hidden="true"
+            />
+            <p class="text-sm font-semibold text-text-primary">
+                All projects healthy
+            </p>
+            <p class="text-[11px] text-text-muted">
+                Nothing needs your attention right now.
+            </p>
+        </div>
+    </section>
+</template>

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import ActivityHeatmap from '@/Components/Activity/ActivityHeatmap.vue';
 import KpiCard from '@/Components/Dashboard/KpiCard.vue';
+import RiskyProjects from '@/Components/Dashboard/RiskyProjects.vue';
 import Sparkline from '@/Components/Dashboard/Sparkline.vue';
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
@@ -560,6 +561,15 @@ const visualizationStubs = [
                     </footer>
                 </section>
 
+                <!-- Risky projects (spec 035) — sorts owned projects
+                     ascending by health_score so degraded / critical
+                     surface first. Echo-refreshed via the
+                     `users.{id}.dashboard` subscription wired in
+                     spec 033. -->
+                <div class="lg:col-span-12">
+                    <RiskyProjects :projects="dashboard.riskyProjects" />
+                </div>
+
                 <!-- Activity Heatmap — 7 days × 6 four-hour buckets per §8.11 -->
                 <section
                     aria-label="Activity Heatmap"
@@ -576,7 +586,7 @@ const visualizationStubs = [
                             </h2>
                         </div>
                         <span class="hidden font-mono text-[11px] text-text-muted sm:inline">
-                            7 days · 4-hour buckets · last 90 days
+                            7 days · 4-hour buckets · last 12 weeks
                         </span>
                     </header>
                     <ActivityHeatmap :data="activityHeatmap" />

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -122,6 +122,32 @@ export interface DashboardPayload {
         commits: number;
         share: number;
     }>;
+
+    /**
+     * Spec 035 — owned projects ranked ascending by `health_score`
+     * with nulls last. Empty array triggers the "All projects healthy"
+     * placeholder. Capped at 6 server-side.
+     */
+    riskyProjects: RiskyProjectRow[];
+}
+
+export interface RiskyProjectRow {
+    id: number;
+    slug: string;
+    name: string;
+    color: string | null;
+    icon: string | null;
+    health_score: number | null;
+    /** §14.2 band — null when score is null. */
+    health_band:
+        | 'healthy'
+        | 'good'
+        | 'degraded'
+        | 'warning'
+        | 'critical'
+        | null;
+    /** Humanized via `diffForHumans()`. */
+    last_activity_at: string | null;
 }
 
 /**

--- a/specs/phase-8-analytics/035-overview-risky-projects-and-heatmap.md
+++ b/specs/phase-8-analytics/035-overview-risky-projects-and-heatmap.md
@@ -205,6 +205,21 @@ Dated notes as work progresses.
 - Branch `spec/035-overview-risky-projects-and-heatmap` cut off main.
 - Tracking issue #103.
 - Scope shipped as drafted (no late edits requested).
+- Plan-vs-impl notes:
+  - Controller-level coverage landed in `tests/Feature/SmokeTest.php`
+    (one new payload assertion + extended dashboard shape check)
+    instead of a dedicated `OverviewControllerTest.php` — SmokeTest
+    already owns the Overview render path, and a separate
+    controller test would be 90% overlap.
+  - Two-layer empty-state semantics: server returns every owned
+    project ordered ascending by score (including the "good" band),
+    `RiskyProjects.vue` hides the panel when every row sits at
+    score ≥ 70. Test
+    `test_risky_projects_surfaces_good_band_rows_server_side`
+    pins the server contract; frontend test would need JS infra
+    that doesn't exist yet.
+  - Added `->orderBy('id')` tiebreaker per code-reviewer feedback
+    so collisions on `(score, last_activity_at)` are deterministic.
 
 ## Open questions / blockers
 

--- a/specs/phase-8-analytics/035-overview-risky-projects-and-heatmap.md
+++ b/specs/phase-8-analytics/035-overview-risky-projects-and-heatmap.md
@@ -1,0 +1,223 @@
+---
+spec: overview-risky-projects-and-heatmap
+phase: 8
+status: in-progress   # not-started | in-progress | blocked | done
+owner: Yoany
+created: 2026-06-10
+updated: 2026-06-10
+---
+
+# 035 — Overview risky-projects panel + heatmap polish (closes Phase 8)
+
+## Goal
+Close Phase 8 by surfacing the `health_score` work spec 033 lit up.
+Build a new "Risky projects" panel on Overview that sorts the
+authenticated user's projects ascending by `health_score`, putting
+degraded / warning / critical projects at the top of the page so the
+user opens the app and sees what needs attention.
+
+The Echo subscription on `users.{id}.dashboard` that spec 033 pre-
+wired becomes visible: each `HealthScoreUpdated` pulse partial-
+reloads the `dashboard` prop, the panel re-renders without a manual
+refresh.
+
+Polish item: realign the existing real-data activity heatmap from
+its current 90-day window to the acceptance-criterion's "last 12
+weeks" (84 days). The heatmap is already wired to real
+`activity_events.occurred_at` aggregates — the work `MOCK_HEATMAP`
+language in the Phase 8 README pointed at no longer exists (verified
+during impl research). One-line shift.
+
+Roadmap refs: §Phase 8 acceptance criteria ("Risky projects panel
+sorts by health_score asc", "activity heatmap is driven by real
+activity_events.occurred_at"), §14.2 health-score bands.
+
+## Scope
+
+**In scope:**
+
+- **Backend.**
+  - `app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php` —
+    add a `riskyProjects(User $user)` private method that returns
+    up to 6 projects owned by the user, ordered `health_score ASC`
+    with `health_score IS NULL` placed last (unscored projects
+    shouldn't displace genuinely-risky ones), then
+    `last_activity_at DESC` as a stable tiebreaker. Each row carries
+    the project payload shape that already exists for project Show:
+    `{id, slug, name, color, icon, health_score, health_band,
+    last_activity_at}` — just enough for the panel to render.
+  - Adopt a `User` parameter on the existing `handle()` method
+    surface for the riskyProjects slice (the rest of the dashboard
+    stays single-tenant for now; tenancy migration is a separate
+    spec). The controller passes `$request->user()`.
+  - Window the heatmap to **last 12 weeks** by switching
+    `now()->subDays(90)` → `now()->subWeeks(12)` to match the Phase
+    8 README's literal acceptance text. The grid shape (7×6) and
+    bucketing rule (dayOfWeek × intdiv(hour, 4)) stay unchanged.
+
+- **Frontend.**
+  - `resources/js/Components/Dashboard/RiskyProjects.vue` — new
+    panel component. Renders the (up to 6) project rows: project
+    icon + color chip, name, `HealthScoreBadge` (reuse from spec
+    033), and a small "last activity" line. Empty state: when the
+    user has no projects OR every project sits at score ≥ 70,
+    render a quiet "All projects healthy" placeholder. The panel
+    title is "Risky projects". Each row is a `<Link>` to the
+    project's Show page.
+  - `resources/js/Pages/Overview.vue` — slot the new panel into the
+    page near the top of the right column (above the existing
+    services / activity heatmap card). Pass `dashboard.riskyProjects`
+    down. The existing Echo `router.reload({ only: ['dashboard'] })`
+    already covers the realtime refresh — the panel just becomes
+    visible the moment the payload starts carrying data.
+  - `resources/js/types/index.d.ts` — extend `DashboardPayload`
+    with `riskyProjects: RiskyProjectRow[]` and add the
+    `RiskyProjectRow` type matching the backend shape.
+
+- **Tests.**
+  - `tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php` —
+    extend with riskyProjects cases: returns owned projects only
+    (cross-user isolation); ordering is `health_score ASC, nulls
+    last`; cap at 6; empty when user has no projects; empty when
+    all projects sit at score ≥ 70 (defines the "all healthy"
+    placeholder boundary).
+  - `tests/Feature/OverviewControllerTest.php` — assert the new
+    `dashboard.riskyProjects` key surfaces in the Inertia payload
+    with the expected per-row shape.
+  - Heatmap window check: extend the existing heatmap test to
+    confirm a 91-day-old event does NOT contribute and an 83-day-
+    old event DOES (the 84-day boundary).
+
+**Out of scope:**
+
+- Multi-tenant scoping of the OTHER dashboard slices (services /
+  deployments / alerts / uptime / topRepositories). Those stay
+  single-tenant until a dedicated tenancy spec.
+- `HeatmapUpdated` broadcast (heatmap recomputes per pageload — the
+  12-week window doesn't shift second-by-second).
+- User-tunable "risky" threshold. The default ascending-health-score
+  cut at score < 70 is taken from §14.2's "good" band floor.
+- Per-project drill-down filters on Overview. Project Show already
+  carries the per-project score chip (spec 033).
+- PR cycle time / stale PR count / open issues trend — still
+  deferred to a Phase-4 follow-up per 033 / 034.
+- Sparkline per risky-project (would compound the per-row payload
+  for no UX win; the badge tone + score is enough).
+
+## Plan
+
+1. **Backend — `riskyProjects(User $user)`.**
+   ```php
+   private function riskyProjects(User $user): array
+   {
+       return Project::query()
+           ->where('owner_user_id', $user->id)
+           ->orderByRaw('health_score IS NULL') // nulls last (SQLite + MySQL portable)
+           ->orderBy('health_score', 'asc')
+           ->orderBy('last_activity_at', 'desc')
+           ->limit(6)
+           ->get()
+           ->map(fn (Project $p) => [
+               'id' => $p->id,
+               'slug' => $p->slug,
+               'name' => $p->name,
+               'color' => $p->color,
+               'icon' => $p->icon,
+               'health_score' => $p->health_score,
+               'health_band' => $p->health_score === null
+                   ? null
+                   : HealthScoreBand::fromScore($p->health_score)->value,
+               'last_activity_at' => $p->last_activity_at?->diffForHumans(),
+           ])
+           ->all();
+   }
+   ```
+
+2. **Backend — `handle()` signature.** Accept a `User $user`
+   parameter and forward to `riskyProjects()`. Update the
+   `OverviewController` (or whichever caller exists) to pass
+   `$request->user()`.
+
+3. **Backend — heatmap window.** Change `now()->subDays(90)` to
+   `now()->subWeeks(12)` in the existing `activityHeatmap()`
+   method. Update its inline comment.
+
+4. **Frontend — `RiskyProjects.vue`.** New component under
+   `resources/js/Components/Dashboard/`. Mirrors the existing
+   `KpiCard` glass-card chrome (gradient ring, panel-hover bg).
+   Empty state has a soft `ShieldCheck` icon + "All projects
+   healthy" text.
+
+5. **Frontend — `Overview.vue` slot.** Drop the panel above the
+   activity heatmap card. No new Echo logic needed; the existing
+   `router.reload({ only: ['dashboard'] })` covers the refresh.
+
+6. **Frontend — types.** Add `RiskyProjectRow` and extend
+   `DashboardPayload`.
+
+7. **Tests.** Per the test list under **In scope**. Use existing
+   `Project::factory()->create([...])` patterns.
+
+8. **Pint clean. `php artisan test` green. `npm run build` clean.
+   Self-review with `superpowers:code-reviewer`. PR. Watch CI.
+   Pause for merge.**
+
+## Acceptance criteria
+- [ ] `dashboard.riskyProjects` carries up to 6 owned projects,
+      ordered by `health_score` ascending with nulls last.
+- [ ] Cross-user isolation: user B's projects don't appear in user
+      A's payload.
+- [ ] Overview "Risky projects" panel renders the rows with the
+      `HealthScoreBadge` + last-activity line; empty state shows the
+      "All projects healthy" placeholder.
+- [ ] A `HealthScoreUpdated` pulse moves a project's row position in
+      the panel without a manual refresh (the spec 033 Echo
+      subscription becomes visibly load-bearing).
+- [ ] Activity heatmap window is exactly 12 weeks (84 days) — an
+      83-day-old event contributes; a 91-day-old event does not.
+- [ ] Pint clean. `php artisan test` green. `npm run build` clean.
+
+## Files touched
+
+- `app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php` —
+  `riskyProjects` slice, `handle()` accepts `User`, heatmap window
+  shifted to 12 weeks.
+- `app/Http/Controllers/OverviewController.php` — pass
+  `$request->user()` to the query.
+- `resources/js/Components/Dashboard/RiskyProjects.vue` — created.
+- `resources/js/Pages/Overview.vue` — slot the panel + extend
+  `DashboardPayload` consumption.
+- `resources/js/types/index.d.ts` — `RiskyProjectRow` +
+  `DashboardPayload.riskyProjects`.
+- `tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php` —
+  extended with riskyProjects + heatmap window cases.
+- `tests/Feature/OverviewControllerTest.php` — payload assertion.
+
+## Work log
+Dated notes as work progresses.
+
+### 2026-06-10
+- Drafted from `_template.md`. Research surfaced that the activity
+  heatmap is already real-data wired (no `MOCK_HEATMAP` constant
+  exists) — Phase 8 README's literal text was outdated. 035 trims
+  to the actually-remaining work: riskyProjects panel + 12-week
+  window realignment.
+- Branch `spec/035-overview-risky-projects-and-heatmap` cut off main.
+- Tracking issue #103.
+- Scope shipped as drafted (no late edits requested).
+
+## Open questions / blockers
+
+- **`orderByRaw('health_score IS NULL')` portability.** SQLite
+  evaluates this as 0 / 1, sorting nulls last when ASC. MySQL agrees.
+  Postgres requires `NULLS LAST` syntax. The Nexus production target
+  is currently MySQL-class, so portable. Worth noting if Postgres
+  ever lands.
+- **"All projects healthy" threshold.** Empty-state triggers when
+  every owned project sits at `health_score >= 70` (the §14.2 "good"
+  floor). Tunable in a future polish spec if users complain that the
+  panel disappears too eagerly.
+- **Panel cap of 6.** Chosen to mirror the existing dashboard's
+  6-card row rhythm. If users have more than 6 truly-risky projects
+  the panel doesn't paginate — they'd surface the next batch via
+  `/projects` filtered by score, which is its own future polish.

--- a/tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php
+++ b/tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php
@@ -699,20 +699,6 @@ class GetOverviewDashboardQueryTest extends TestCase
         $this->assertSame(3, $heatmap[1][2]);
     }
 
-    public function test_activity_heatmap_excludes_events_older_than_90_days(): void
-    {
-        $repository = $this->setUpRepository();
-
-        ActivityEvent::factory()->create([
-            'repository_id' => $repository->id,
-            'occurred_at' => now()->subDays(91)->startOfDay()->addHours(10),
-        ]);
-
-        $heatmap = (new GetOverviewDashboardQuery)->handle($this->defaultUser())['activityHeatmap'];
-
-        $this->assertSame(array_fill(0, 7, array_fill(0, 6, 0)), $heatmap);
-    }
-
     public function test_activity_heatmap_includes_events_inside_12_week_window(): void
     {
         // Spec 035 — window is exactly 12 weeks (84 days). An 83-day-
@@ -901,6 +887,35 @@ class GetOverviewDashboardQueryTest extends TestCase
             ->handle($a)['dashboard']['riskyProjects'];
 
         $this->assertSame([], $rows, "A's payload must not include B's projects");
+    }
+
+    public function test_risky_projects_surfaces_good_band_rows_server_side(): void
+    {
+        // The server returns every owned project ordered by score —
+        // including the "good" band (70–89). Spec 035's empty-state
+        // semantics ("All projects healthy" when every score ≥ 70)
+        // are enforced on the *frontend*, not in this query. Locking
+        // the server-side contract here keeps the two layers
+        // intentionally distinct.
+        $owner = User::factory()->create();
+        $good = Project::factory()->create([
+            'owner_user_id' => $owner->id,
+            'name' => 'Goodish',
+            'health_score' => 75,
+        ]);
+        $healthy = Project::factory()->create([
+            'owner_user_id' => $owner->id,
+            'name' => 'Healthier',
+            'health_score' => 95,
+        ]);
+
+        $rows = (new GetOverviewDashboardQuery)
+            ->handle($owner)['dashboard']['riskyProjects'];
+
+        $this->assertCount(2, $rows);
+        $this->assertSame('Goodish', $rows[0]['name']);
+        $this->assertSame('good', $rows[0]['health_band']);
+        $this->assertSame('Healthier', $rows[1]['name']);
     }
 
     public function test_risky_projects_row_carries_expected_shape(): void

--- a/tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php
+++ b/tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php
@@ -20,9 +20,21 @@ class GetOverviewDashboardQueryTest extends TestCase
 {
     use RefreshDatabase;
 
+    private ?User $defaultUser = null;
+
+    /**
+     * Spec 035 — `handle()` accepts a User for the riskyProjects
+     * scope. Tests that don't care about the user-scoped slice can
+     * use this helper to get a stable, no-fuss owner.
+     */
+    private function defaultUser(): User
+    {
+        return $this->defaultUser ??= User::factory()->create();
+    }
+
     public function test_handle_returns_the_expected_top_level_shape(): void
     {
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertArrayHasKey('dashboard', $payload);
         $this->assertArrayHasKey('activityHeatmap', $payload);
@@ -45,7 +57,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'status' => 'archived',
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(2, $payload['dashboard']['projects']['active']);
         $this->assertSame('success', $payload['dashboard']['projects']['status']);
@@ -53,7 +65,7 @@ class GetOverviewDashboardQueryTest extends TestCase
 
     public function test_projects_kpi_status_is_muted_when_no_active_projects(): void
     {
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(0, $payload['dashboard']['projects']['active']);
         $this->assertSame('muted', $payload['dashboard']['projects']['status']);
@@ -61,7 +73,7 @@ class GetOverviewDashboardQueryTest extends TestCase
 
     public function test_hosts_kpi_returns_zero_state_with_no_hosts(): void
     {
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(0, $payload['dashboard']['hosts']['online']);
         $this->assertSame(0, $payload['dashboard']['hosts']['offline']);
@@ -77,7 +89,7 @@ class GetOverviewDashboardQueryTest extends TestCase
         Host::factory()->offline()->create(['project_id' => $project->id]);
         Host::factory()->archived()->create(['project_id' => $project->id]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(3, $payload['dashboard']['hosts']['online']);
         $this->assertSame(1, $payload['dashboard']['hosts']['offline']);
@@ -90,7 +102,7 @@ class GetOverviewDashboardQueryTest extends TestCase
         $project = Project::factory()->create();
         Host::factory()->online()->count(2)->create(['project_id' => $project->id]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame('success', $payload['dashboard']['hosts']['status']);
     }
@@ -100,7 +112,7 @@ class GetOverviewDashboardQueryTest extends TestCase
         $project = Project::factory()->create();
         Host::factory()->offline()->count(2)->create(['project_id' => $project->id]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame('danger', $payload['dashboard']['hosts']['status']);
     }
@@ -113,7 +125,7 @@ class GetOverviewDashboardQueryTest extends TestCase
         Host::factory()->create(['project_id' => $project->id, 'name' => 'a-pending']);
         Host::factory()->online()->create(['project_id' => $project->id, 'name' => 'a-online']);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
         $names = array_column($payload['dashboard']['hosts']['cards'], 'name');
 
         $this->assertSame(
@@ -127,7 +139,7 @@ class GetOverviewDashboardQueryTest extends TestCase
         $project = Project::factory()->create();
         Host::factory()->online()->count(10)->create(['project_id' => $project->id]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertCount(6, $payload['dashboard']['hosts']['cards']);
     }
@@ -138,7 +150,7 @@ class GetOverviewDashboardQueryTest extends TestCase
         Host::factory()->online()->create(['project_id' => $project->id, 'name' => 'live-host']);
         Host::factory()->archived()->create(['project_id' => $project->id, 'name' => 'archived-host']);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
         $names = array_column($payload['dashboard']['hosts']['cards'], 'name');
 
         $this->assertSame(['live-host'], $names);
@@ -163,7 +175,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'recorded_at' => now(),
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
         $card = $payload['dashboard']['hosts']['cards'][0];
 
         // Latest snapshot wins.
@@ -190,14 +202,14 @@ class GetOverviewDashboardQueryTest extends TestCase
             'created_at' => now()->subDays(1),
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(1, $payload['dashboard']['hosts']['new']);
     }
 
     public function test_sparklines_are_zero_padded_to_twelve_entries(): void
     {
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertCount(12, $payload['dashboard']['projects']['sparkline']);
         $this->assertCount(12, $payload['dashboard']['hosts']['sparkline']);
@@ -216,7 +228,7 @@ class GetOverviewDashboardQueryTest extends TestCase
         ]);
 
         $sparkline = (new GetOverviewDashboardQuery)
-            ->handle()['dashboard']['projects']['sparkline'];
+            ->handle($this->defaultUser())['dashboard']['projects']['sparkline'];
 
         // 12 days, oldest at index 0, today at index 11. The newly created
         // project should land in the final bucket and only there.
@@ -233,7 +245,7 @@ class GetOverviewDashboardQueryTest extends TestCase
         ]);
 
         $sparkline = (new GetOverviewDashboardQuery)
-            ->handle()['dashboard']['projects']['sparkline'];
+            ->handle($this->defaultUser())['dashboard']['projects']['sparkline'];
 
         // A row stamped exactly 11 days ago lands at the start of the
         // 12-day window (index 0).
@@ -258,7 +270,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             ]);
         }
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertCount(4, $payload['dashboard']['topRepositories']);
         $this->assertSame('owner/repo-0', $payload['dashboard']['topRepositories'][0]['name']);
@@ -270,7 +282,7 @@ class GetOverviewDashboardQueryTest extends TestCase
 
     public function test_top_repositories_is_empty_with_no_repositories(): void
     {
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame([], $payload['dashboard']['topRepositories']);
     }
@@ -280,7 +292,7 @@ class GetOverviewDashboardQueryTest extends TestCase
         // Deployments graduated to a real query in spec 022, uptime in
         // 025, hosts in 029, alerts in 032. The only mocked slice left
         // is `services` — pin it to the phase-0 fixture value.
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(47, $payload['dashboard']['services']['running']);
 
@@ -290,7 +302,7 @@ class GetOverviewDashboardQueryTest extends TestCase
 
     public function test_alerts_kpi_returns_zero_state_with_no_alerts(): void
     {
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(0, $payload['dashboard']['alerts']['active']);
         $this->assertSame(0, $payload['dashboard']['alerts']['critical']);
@@ -306,7 +318,7 @@ class GetOverviewDashboardQueryTest extends TestCase
         Alert::factory()->resolved()->create(['project_id' => $project->id]);
         Alert::factory()->muted()->create(['project_id' => $project->id]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(2, $payload['dashboard']['alerts']['active']);
     }
@@ -319,7 +331,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'severity' => AlertSeverity::Warning->value,
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(1, $payload['dashboard']['alerts']['active']);
         $this->assertSame(0, $payload['dashboard']['alerts']['critical']);
@@ -334,7 +346,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'severity' => AlertSeverity::Critical->value,
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(1, $payload['dashboard']['alerts']['critical']);
         $this->assertSame('danger', $payload['dashboard']['alerts']['status']);
@@ -351,7 +363,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'created_at' => now(),
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
         $sparkline = $payload['dashboard']['alerts']['sparkline'];
 
         $this->assertCount(12, $sparkline);
@@ -364,7 +376,7 @@ class GetOverviewDashboardQueryTest extends TestCase
     {
         // No checks anywhere → muted + null overall (matches the
         // GetMonitoringUptimeKpiQuery contract verified in its own test).
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertNull($payload['dashboard']['uptime']['overall']);
         $this->assertSame('muted', $payload['dashboard']['uptime']['status']);
@@ -385,7 +397,7 @@ class GetOverviewDashboardQueryTest extends TestCase
 
     public function test_deployments_kpi_returns_zero_state_with_no_runs(): void
     {
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(0, $payload['dashboard']['deployments']['successful_24h']);
         $this->assertNull($payload['dashboard']['deployments']['success_rate_24h']);
@@ -405,7 +417,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'run_completed_at' => now()->subHours(2),
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(3, $payload['dashboard']['deployments']['successful_24h']);
         $this->assertSame(100, $payload['dashboard']['deployments']['success_rate_24h']);
@@ -424,7 +436,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'run_completed_at' => now()->subHours(25),
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(0, $payload['dashboard']['deployments']['successful_24h']);
     }
@@ -448,7 +460,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'run_completed_at' => now()->subHours(2),
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(4, $payload['dashboard']['deployments']['successful_24h']);
         $this->assertSame(100, $payload['dashboard']['deployments']['change_percent']);
@@ -467,7 +479,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'run_completed_at' => now()->subHours(2),
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertLessThanOrEqual(999, $payload['dashboard']['deployments']['change_percent']);
     }
@@ -491,7 +503,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'run_completed_at' => now()->subHours(2),
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(95, $payload['dashboard']['deployments']['success_rate_24h']);
         $this->assertSame('success', $payload['dashboard']['deployments']['status']);
@@ -516,7 +528,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'run_completed_at' => now()->subHours(2),
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(80, $payload['dashboard']['deployments']['success_rate_24h']);
         $this->assertSame('warning', $payload['dashboard']['deployments']['status']);
@@ -536,7 +548,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'run_completed_at' => now()->subHours(36),
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(0, $payload['dashboard']['deployments']['successful_24h']);
         $this->assertSame(-100, $payload['dashboard']['deployments']['change_percent']);
@@ -560,7 +572,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'run_completed_at' => now()->subHours(2),
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(85, $payload['dashboard']['deployments']['success_rate_24h']);
         $this->assertSame('warning', $payload['dashboard']['deployments']['status']);
@@ -584,7 +596,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'run_completed_at' => now()->subHours(2),
         ]);
 
-        $payload = (new GetOverviewDashboardQuery)->handle();
+        $payload = (new GetOverviewDashboardQuery)->handle($this->defaultUser());
 
         $this->assertSame(50, $payload['dashboard']['deployments']['success_rate_24h']);
         $this->assertSame('danger', $payload['dashboard']['deployments']['status']);
@@ -615,7 +627,7 @@ class GetOverviewDashboardQueryTest extends TestCase
         ]);
 
         $sparkline = (new GetOverviewDashboardQuery)
-            ->handle()['dashboard']['deployments']['sparkline'];
+            ->handle($this->defaultUser())['dashboard']['deployments']['sparkline'];
 
         $this->assertCount(12, $sparkline);
         // Oldest at index 0 (11 days ago), today at index 11.
@@ -637,7 +649,7 @@ class GetOverviewDashboardQueryTest extends TestCase
         ]);
 
         $sparkline = (new GetOverviewDashboardQuery)
-            ->handle()['dashboard']['deployments']['sparkline'];
+            ->handle($this->defaultUser())['dashboard']['deployments']['sparkline'];
 
         $this->assertSame(array_fill(0, 12, 0), $sparkline);
     }
@@ -648,7 +660,7 @@ class GetOverviewDashboardQueryTest extends TestCase
 
     public function test_activity_heatmap_is_all_zeros_with_no_events(): void
     {
-        $heatmap = (new GetOverviewDashboardQuery)->handle()['activityHeatmap'];
+        $heatmap = (new GetOverviewDashboardQuery)->handle($this->defaultUser())['activityHeatmap'];
 
         $this->assertSame(array_fill(0, 7, array_fill(0, 6, 0)), $heatmap);
     }
@@ -663,7 +675,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             'occurred_at' => Carbon::parse('2026-04-29 14:30:00', 'UTC'), // 2026-04-29 was a Wed
         ]);
 
-        $heatmap = (new GetOverviewDashboardQuery)->handle()['activityHeatmap'];
+        $heatmap = (new GetOverviewDashboardQuery)->handle($this->defaultUser())['activityHeatmap'];
 
         $this->assertSame(1, $heatmap[3][3]);
         // Every other cell is zero.
@@ -682,7 +694,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             ]);
         }
 
-        $heatmap = (new GetOverviewDashboardQuery)->handle()['activityHeatmap'];
+        $heatmap = (new GetOverviewDashboardQuery)->handle($this->defaultUser())['activityHeatmap'];
 
         $this->assertSame(3, $heatmap[1][2]);
     }
@@ -696,28 +708,47 @@ class GetOverviewDashboardQueryTest extends TestCase
             'occurred_at' => now()->subDays(91)->startOfDay()->addHours(10),
         ]);
 
-        $heatmap = (new GetOverviewDashboardQuery)->handle()['activityHeatmap'];
+        $heatmap = (new GetOverviewDashboardQuery)->handle($this->defaultUser())['activityHeatmap'];
 
         $this->assertSame(array_fill(0, 7, array_fill(0, 6, 0)), $heatmap);
     }
 
-    public function test_activity_heatmap_includes_events_inside_90_day_window(): void
+    public function test_activity_heatmap_includes_events_inside_12_week_window(): void
     {
+        // Spec 035 — window is exactly 12 weeks (84 days). An 83-day-
+        // old event should land inside; the 91-day-outside boundary
+        // is covered by its sibling test below.
         $repository = $this->setUpRepository();
 
         ActivityEvent::factory()->create([
             'repository_id' => $repository->id,
-            'occurred_at' => now()->subDays(89)->startOfDay()->addHours(10),
+            'occurred_at' => now()->subDays(83)->startOfDay()->addHours(10),
         ]);
 
-        $heatmap = (new GetOverviewDashboardQuery)->handle()['activityHeatmap'];
+        $heatmap = (new GetOverviewDashboardQuery)->handle($this->defaultUser())['activityHeatmap'];
 
         $this->assertSame(1, array_sum(array_map('array_sum', $heatmap)));
     }
 
+    public function test_activity_heatmap_excludes_events_outside_12_week_window(): void
+    {
+        // Spec 035 — events older than 84 days must not contribute.
+        // 91 days is well past the boundary.
+        $repository = $this->setUpRepository();
+
+        ActivityEvent::factory()->create([
+            'repository_id' => $repository->id,
+            'occurred_at' => now()->subDays(91)->startOfDay()->addHours(10),
+        ]);
+
+        $heatmap = (new GetOverviewDashboardQuery)->handle($this->defaultUser())['activityHeatmap'];
+
+        $this->assertSame(0, array_sum(array_map('array_sum', $heatmap)));
+    }
+
     public function test_activity_heatmap_returns_seven_by_six_grid(): void
     {
-        $heatmap = (new GetOverviewDashboardQuery)->handle()['activityHeatmap'];
+        $heatmap = (new GetOverviewDashboardQuery)->handle($this->defaultUser())['activityHeatmap'];
 
         $this->assertCount(7, $heatmap);
         foreach ($heatmap as $day) {
@@ -754,7 +785,7 @@ class GetOverviewDashboardQueryTest extends TestCase
             ]);
         }
 
-        $heatmap = (new GetOverviewDashboardQuery)->handle()['activityHeatmap'];
+        $heatmap = (new GetOverviewDashboardQuery)->handle($this->defaultUser())['activityHeatmap'];
 
         // Aggregate the expected counts per bucket from the case map.
         $expected = array_fill(0, 6, 0);
@@ -765,5 +796,134 @@ class GetOverviewDashboardQueryTest extends TestCase
         $this->assertSame($expected, $heatmap[0]);
         // Other day rows are untouched.
         $this->assertSame(count($cases), array_sum(array_map('array_sum', $heatmap)));
+    }
+
+    // ─── Spec 035 — riskyProjects slice ─────────────────────────────
+
+    public function test_risky_projects_orders_by_health_score_ascending(): void
+    {
+        $owner = User::factory()->create();
+        $healthy = Project::factory()->create([
+            'owner_user_id' => $owner->id,
+            'name' => 'Healthy',
+            'health_score' => 95,
+        ]);
+        $degraded = Project::factory()->create([
+            'owner_user_id' => $owner->id,
+            'name' => 'Degraded',
+            'health_score' => 55,
+        ]);
+        $critical = Project::factory()->create([
+            'owner_user_id' => $owner->id,
+            'name' => 'Critical',
+            'health_score' => 15,
+        ]);
+
+        $payload = (new GetOverviewDashboardQuery)->handle($owner);
+        $rows = $payload['dashboard']['riskyProjects'];
+
+        $this->assertCount(3, $rows);
+        $this->assertSame('Critical', $rows[0]['name']);
+        $this->assertSame('Degraded', $rows[1]['name']);
+        $this->assertSame('Healthy', $rows[2]['name']);
+    }
+
+    public function test_risky_projects_places_unscored_projects_last(): void
+    {
+        $owner = User::factory()->create();
+        // An unscored project must NOT displace a critically-scored
+        // one — that would defeat the panel's purpose. The
+        // `health_score IS NULL` raw clause is the guard.
+        Project::factory()->create([
+            'owner_user_id' => $owner->id,
+            'name' => 'Unscored',
+            'health_score' => null,
+        ]);
+        Project::factory()->create([
+            'owner_user_id' => $owner->id,
+            'name' => 'Critical',
+            'health_score' => 20,
+        ]);
+
+        $rows = (new GetOverviewDashboardQuery)
+            ->handle($owner)['dashboard']['riskyProjects'];
+
+        $this->assertSame('Critical', $rows[0]['name']);
+        $this->assertSame('Unscored', $rows[1]['name']);
+    }
+
+    public function test_risky_projects_caps_at_six_rows(): void
+    {
+        // ProjectFactory uses `fake()->unique()` over an 8-name pool,
+        // which can't satisfy 10 unique creates even when we override
+        // `name` because the unique generator is consumed inside
+        // `definition()` before the override applies. Reset the
+        // faker unique state per-iteration so each call gets a fresh
+        // pool — keeps the test honest about the cap boundary.
+        $owner = User::factory()->create();
+        for ($i = 1; $i <= 10; $i++) {
+            fake()->unique(reset: true);
+            Project::factory()->create([
+                'owner_user_id' => $owner->id,
+                'health_score' => 30,
+            ]);
+        }
+
+        $rows = (new GetOverviewDashboardQuery)
+            ->handle($owner)['dashboard']['riskyProjects'];
+
+        $this->assertCount(6, $rows);
+    }
+
+    public function test_risky_projects_is_empty_when_user_has_no_projects(): void
+    {
+        $owner = User::factory()->create();
+
+        $rows = (new GetOverviewDashboardQuery)
+            ->handle($owner)['dashboard']['riskyProjects'];
+
+        $this->assertSame([], $rows);
+    }
+
+    public function test_risky_projects_is_cross_user_isolated(): void
+    {
+        $a = User::factory()->create();
+        $b = User::factory()->create();
+        for ($i = 1; $i <= 3; $i++) {
+            Project::factory()->create([
+                'owner_user_id' => $b->id,
+                'name' => "Bee {$i}",
+                'health_score' => 20,
+            ]);
+        }
+
+        $rows = (new GetOverviewDashboardQuery)
+            ->handle($a)['dashboard']['riskyProjects'];
+
+        $this->assertSame([], $rows, "A's payload must not include B's projects");
+    }
+
+    public function test_risky_projects_row_carries_expected_shape(): void
+    {
+        $owner = User::factory()->create();
+        $project = Project::factory()->create([
+            'owner_user_id' => $owner->id,
+            'name' => 'Edge Cache',
+            'health_score' => 45,
+            'color' => 'cyan',
+            'icon' => 'HeartPulse',
+        ]);
+
+        $row = (new GetOverviewDashboardQuery)
+            ->handle($owner)['dashboard']['riskyProjects'][0];
+
+        $this->assertSame($project->id, $row['id']);
+        $this->assertSame($project->slug, $row['slug']);
+        $this->assertSame('Edge Cache', $row['name']);
+        $this->assertSame('cyan', $row['color']);
+        $this->assertSame('HeartPulse', $row['icon']);
+        $this->assertSame(45, $row['health_score']);
+        $this->assertSame('warning', $row['health_band']);
+        $this->assertArrayHasKey('last_activity_at', $row);
     }
 }

--- a/tests/Feature/SmokeTest.php
+++ b/tests/Feature/SmokeTest.php
@@ -49,8 +49,33 @@ class SmokeTest extends TestCase
                         ->where('alerts.status', 'success')
                         ->has('uptime.overall')
                         ->has('topRepositories')
+                        // Spec 035 — `riskyProjects` always present
+                        // in the payload; empty when the user has no
+                        // projects.
+                        ->where('riskyProjects', [])
                     )
                     ->has('topWorkItems')
+            );
+    }
+
+    public function test_overview_payload_carries_risky_projects_for_owner(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create([
+            'owner_user_id' => $user->id,
+            'name' => 'Risky Service',
+            'health_score' => 25,
+        ]);
+
+        $this->actingAs($user)
+            ->get('/overview')
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('dashboard.riskyProjects', 1)
+                    ->where('dashboard.riskyProjects.0.id', $project->id)
+                    ->where('dashboard.riskyProjects.0.name', 'Risky Service')
+                    ->where('dashboard.riskyProjects.0.health_score', 25)
+                    ->where('dashboard.riskyProjects.0.health_band', 'critical'),
             );
     }
 


### PR DESCRIPTION
Closes #103

Spec: \`specs/phase-8-analytics/035-overview-risky-projects-and-heatmap.md\`

**Phase 8 closer.**

## Summary

- **\`GetOverviewDashboardQuery::handle()\`** now accepts a \`User\`. New \`riskyProjects(User)\` slice returns up to 6 owned projects ordered ascending by \`health_score\` with nulls last (via \`orderByRaw('health_score IS NULL')\` + \`asc\` + tiebreakers on \`last_activity_at desc\`, then \`id\` for determinism). Row shape: id/slug/name/color/icon/health_score/health_band/last_activity_at.
- **Heatmap window** shifted from \`now()->subDays(90)\` → \`now()->subWeeks(12)\` to match the Phase 8 README's literal acceptance text. Docblocks + Vue subtitle updated accordingly.
- **\`RiskyProjects.vue\`** (new) — renders the panel with \`HealthScoreBadge\` per row + "All projects healthy" empty state. Two-layer semantics: server returns every owned project ordered by score, frontend hides the panel when every row sits at score ≥ 70 (the §14.2 "good" floor). \`good\`-banded projects don't surface — §14.2 calls them "good", not "needs attention".
- **\`DashboardPayload\`** extended with \`riskyProjects: RiskyProjectRow[]\`. Panel slotted into \`Overview.vue\` above the activity heatmap.
- Spec 033's pre-wired Echo subscription on \`users.{id}.dashboard\` is now **load-bearing** — each \`HealthScoreUpdated\` pulse partial-reloads the \`dashboard\` prop and the panel re-renders.

## Test plan

- [x] \`dashboard.riskyProjects\` carries up to 6 owned projects, ordered by \`health_score\` ascending with nulls last (6 new \`risky_projects_*\` test cases).
- [x] Cross-user isolation: user B's projects don't appear in user A's payload.
- [x] Panel renders rows + empty state correctly (validated in dev; no JS test infra to assert visually).
- [x] Server returns "good"-banded rows; frontend hides the panel when all are good/healthy (test \`test_risky_projects_surfaces_good_band_rows_server_side\` locks server contract).
- [x] Activity heatmap window: 83-day-old event contributes, 91-day-old does not.
- [x] Pint clean. \`php artisan test\` green (675 tests / 2595 assertions). \`npm run build\` clean.

## Self-review notes

Reviewed by \`superpowers:code-reviewer\`. Verdict: solid with 5 fixable items — all addressed:
1. **Spec-vs-impl threshold mismatch (the real one):** empty-state was implemented at score ≥ 90 (healthy only); spec said ≥ 70 (good floor). Fixed — panel now hides when every project is good or healthy.
2. **Stale docblocks** in \`GetOverviewDashboardQuery\` (line 44 class doc, line 229 method doc, line 235 design rationale) — all updated from "90 days" → "12 weeks (84 days)".
3. **Stale \`OverviewController\` docblock** that called the query "single-tenant / no-arg" — updated to reflect the new User parameter.
4. **Duplicate heatmap test** (\`test_activity_heatmap_excludes_events_older_than_90_days\` at line 702 and my new \`_outside_12_week_window\` did the same thing) — old one deleted.
5. **Tiebreaker** on riskyProjects ordering — added \`->orderBy('id')\` so collisions on \`(health_score, last_activity_at)\` resolve deterministically.

Key reviewer answers:
- \`orderByRaw('health_score IS NULL')\` portable across SQLite + MySQL; Postgres NULLS LAST is a future-port concern.
- Two-layer empty-state semantics deliberate: server contract is "return everything ranked ascending", frontend decides what's visible.
- Echo subscription tested by construction (event broadcast contract pinned by \`HealthScoreUpdatedTest\`; Pusher mock would need Playwright infra that doesn't exist).
- Shared-user test helper (\`\$this->defaultUser()\`) safe across the 43 GetOverviewDashboardQueryTest cases — PHPUnit fresh-constructs per test, \`RefreshDatabase\` clears state.

Deferred follow-ups (non-blocking):
- \`ProjectFactory\` uses gratuitous \`fake()->unique()\` on \`name\` despite no DB unique constraint — cleanup pass would simplify the test workaround.
- \`iconAccentClass()\` in \`RiskyProjects.vue\` duplicates the color → token map that already lives in other components — extract to \`projectColors.ts\` next time.