### PR TITLE
chore(specs): close Phase 8 (035 done, all 3 specs shipped)

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -43,7 +43,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 5 | Website Monitoring | 🟢 | 3/3 specs done (023–025). Phase complete. |
 | 6 | Docker Host Agent MVP | 🟢 | 4/4 specs done (026–029). Phase complete. |
 | 7 | Alerts Engine | 🟢 | 3/3 specs done (030–032). Phase complete. |
-| 8 | Analytics & Health Scores | 🟡 | 2/3 specs done (033, 034). 035 (heatmap + risky-projects close) pending. |
+| 8 | Analytics & Health Scores | 🟢 | 3/3 specs done (033–035). Phase complete. |
 | 9 | Polish & Production Readiness | ⬜ | — |
 | 10 | Future Innovation | ⬜ | — |
 

--- a/specs/phase-8-analytics/035-overview-risky-projects-and-heatmap.md
+++ b/specs/phase-8-analytics/035-overview-risky-projects-and-heatmap.md
@@ -1,7 +1,7 @@
 ---
 spec: overview-risky-projects-and-heatmap
 phase: 8
-status: in-progress   # not-started | in-progress | blocked | done
+status: done   # not-started | in-progress | blocked | done
 owner: Yoany
 created: 2026-06-10
 updated: 2026-06-10

--- a/specs/phase-8-analytics/README.md
+++ b/specs/phase-8-analytics/README.md
@@ -21,7 +21,7 @@ matters.
 |---|------|--------|
 | 033 | Health-score scaffolding (calculation + scheduled & transition-driven recompute + broadcast + Overview & project UI) | 🟢 |
 | 034 | Analytics dashboard page (`/analytics` route, §8.13 chart set, date-range filter) | 🟢 |
-| 035 | Real-data activity heatmap + Overview risky-project prioritization (closes phase 8) | ⬜ |
+| 035 | Real-data activity heatmap + Overview risky-project prioritization (closes phase 8) | 🟢 |
 
 ## Acceptance criteria (phase-level)
 - [ ] `projects.health_score` is non-null for every project after the


### PR DESCRIPTION
Spec 035 (#103 / PR #104) merged. Bookkeeping: 035 frontmatter → `done`, Phase 8 README row → 🟢, master tracker → Phase 8 `3/3 specs done. Phase complete.`

**Phase 8 is now closed.** Health score system live + scheduled & transition-driven (033). `/analytics` page with 8 cards on real data + URL-backed date range (034). Overview Risky Projects panel + 12-week heatmap window (035).

Next on the roadmap: Phase 9 — Polish & Production Readiness.