### PR TITLE
Spec 037 — Reliability hardening: retries, rate-limit handling, webhook retry UI

### DIFF
--- a/app/Domain/GitHub/Exceptions/GitHubApiException.php
+++ b/app/Domain/GitHub/Exceptions/GitHubApiException.php
@@ -4,6 +4,7 @@ namespace App\Domain\GitHub\Exceptions;
 
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Carbon;
 use RuntimeException;
 use Throwable;
 
@@ -25,13 +26,24 @@ class GitHubApiException extends RuntimeException
     /** GitHub HTTP status code, or 0 for transport-layer failures. */
     public readonly int $statusCode;
 
+    /**
+     * Spec 037 — unix timestamp at which the rate-limit window resets.
+     * Populated from the `X-RateLimit-Reset` header on 429 / rate-
+     * limited 403 responses. Drives `secondsUntilReset()` so sync
+     * jobs can `release()` themselves until the window clears
+     * instead of consuming retries on a guaranteed failure.
+     */
+    public readonly ?int $rateLimitResetAt;
+
     public function __construct(
         string $message,
         int $statusCode = 0,
         ?Throwable $previous = null,
+        ?int $rateLimitResetAt = null,
     ) {
         parent::__construct($message, 0, $previous);
         $this->statusCode = $statusCode;
+        $this->rateLimitResetAt = $rateLimitResetAt;
     }
 
     public static function fromResponse(Response $response, string $context = 'GitHub request failed'): self
@@ -50,7 +62,21 @@ class GitHubApiException extends RuntimeException
             $reason = 'unknown';
         }
 
-        return new self("{$context}: HTTP {$status} {$reason}", $status);
+        // Spec 037 — parse the reset window out of GitHub's standard
+        // headers. Present on 429 + rate-limited 403 responses; we
+        // also accept the spelling variants because the client we
+        // see in tests sometimes lower-cases headers. `null` when
+        // the response isn't rate-limited.
+        $resetAt = null;
+        foreach (['X-RateLimit-Reset', 'x-ratelimit-reset'] as $name) {
+            $header = $response->header($name);
+            if ($header !== '' && $header !== null) {
+                $resetAt = (int) $header;
+                break;
+            }
+        }
+
+        return new self("{$context}: HTTP {$status} {$reason}", $status, null, $resetAt);
     }
 
     public static function fromTransport(RequestException $e, string $context = 'GitHub request failed'): self
@@ -69,13 +95,44 @@ class GitHubApiException extends RuntimeException
     }
 
     /**
-     * True for HTTP 403 with a rate-limit-exhaustion shape (GitHub's
-     * "API rate limit exceeded" path). Best-effort heuristic — caller
-     * should still log + surface to the user.
+     * True when GitHub reported a rate-limit exhaustion. Two signals
+     * count, in priority order:
+     *
+     *   1. The response carried `X-RateLimit-Reset` AND the status
+     *      code is 429 or 403 — header-driven, the strong path.
+     *   2. The status is 403 and the body mentions "rate limit" —
+     *      heuristic fallback for cases where the header didn't
+     *      reach us (proxies, malformed responses).
      */
     public function wasRateLimited(): bool
     {
+        if (
+            $this->rateLimitResetAt !== null
+            && ($this->statusCode === 429 || $this->statusCode === 403)
+        ) {
+            return true;
+        }
+
         return $this->statusCode === 403
             && str_contains(strtolower($this->getMessage()), 'rate limit');
+    }
+
+    /**
+     * Spec 037 — seconds until the rate-limit window resets. Returns
+     * `0` when there's no reset timestamp or the timestamp is already
+     * in the past (eg. a stale exception serialized into a delayed
+     * job). Callers use this for `$this->release($n)` so the next
+     * attempt lands after GitHub agrees to talk again.
+     */
+    public function secondsUntilReset(): int
+    {
+        if ($this->rateLimitResetAt === null) {
+            return 0;
+        }
+
+        // `Carbon::now()->timestamp` over PHP's `time()` so tests can
+        // freeze the clock with `Carbon::setTestNow()` and assert the
+        // delta deterministically.
+        return max(0, $this->rateLimitResetAt - Carbon::now()->getTimestamp());
     }
 }

--- a/app/Domain/GitHub/Jobs/ProcessGitHubWebhookJob.php
+++ b/app/Domain/GitHub/Jobs/ProcessGitHubWebhookJob.php
@@ -25,16 +25,20 @@ use Throwable;
  *   received → skipped   (no handler for this event, or handler returned
  *                         `Skipped` because we don't have the local repo
  *                         yet — common when GitHub fires before import)
- *   received → failed    (handler threw; `error_message` carries the reason)
+ *   received → ... → failed (handler threw; `failed()` records the
+ *                            terminal state with `error_message` after
+ *                            `$tries` exhausted)
  *
  * Each handler is the small, single-purpose concrete class — see
  * `App\Domain\GitHub\WebhookHandlers\*`. Returning a status enum lets
  * us distinguish "we ran but the inputs weren't ready" (Skipped) from
  * "we ran successfully" (Processed) without tunneling exceptions.
  *
- * `tries = 1` matches spec 014/015/016 sync jobs. Replay is via the
- * delivery row's stored payload (a future spec adds a "Re-process"
- * action on top of that).
+ * Spec 037 — `$tries = 3` per §18.3 ("webhook job failure: retry 3
+ * times, then mark failed"). The in-job throw becomes the retry
+ * signal; `failed()` is the terminal-state recorder. The delivery
+ * row's payload + signature persist for forensic audit and manual
+ * retry via `/settings/webhook-deliveries`.
  */
 class ProcessGitHubWebhookJob implements ShouldQueue
 {
@@ -43,9 +47,16 @@ class ProcessGitHubWebhookJob implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public int $tries = 1;
+    /** Spec 037 — 3 attempts per §18.3. */
+    public int $tries = 3;
 
     public function __construct(public readonly int $deliveryId) {}
+
+    /** Spec 037 — quick retry, then a longer cool-off. */
+    public function backoff(): array
+    {
+        return [10, 60];
+    }
 
     public function handle(): void
     {
@@ -64,20 +75,41 @@ class ProcessGitHubWebhookJob implements ShouldQueue
                 'processed_at' => now(),
             ])->save();
         } catch (Throwable $e) {
-            Log::error('GitHub webhook processing failed', [
+            Log::error('GitHub webhook processing — handler threw', [
                 'delivery_id' => $delivery->id,
                 'event' => $delivery->event,
                 'action' => $delivery->action,
+                'attempt' => $this->attempts(),
                 'exception' => $e::class,
                 'message' => $e->getMessage(),
             ]);
 
-            $delivery->forceFill([
-                'status' => WebhookDeliveryStatus::Failed->value,
-                'error_message' => $e->getMessage(),
-                'processed_at' => now(),
-            ])->save();
+            // Rethrow so the retry pipeline runs. `failed()` is the
+            // terminal recorder. Mid-flight status stays `received`
+            // so the UI shows "Retrying…" until tries are exhausted.
+            throw $e;
         }
+    }
+
+    /**
+     * Spec 037 — terminal-failure handler. Persists `Failed` with the
+     * exception message once the retry pipeline gives up. The
+     * delivery row's payload + signature are preserved for forensic
+     * audit + manual retry via `/settings/webhook-deliveries`.
+     */
+    public function failed(Throwable $e): void
+    {
+        $delivery = WebhookDelivery::query()->find($this->deliveryId);
+
+        if ($delivery === null) {
+            return;
+        }
+
+        $delivery->forceFill([
+            'status' => WebhookDeliveryStatus::Failed->value,
+            'error_message' => $e->getMessage(),
+            'processed_at' => now(),
+        ])->save();
     }
 
     /**

--- a/app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php
+++ b/app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php
@@ -108,6 +108,9 @@ class SyncGitHubRepositoryJob implements ShouldQueue
                 return;
             }
 
+            // Rate-limited: see SyncRepositoryIssuesJob for the
+            // `release()` semantics. Persistent rate-limiting exhausts
+            // `$tries` and falls through to `failed()`.
             if ($e->wasRateLimited()) {
                 $delay = max($e->secondsUntilReset(), 60);
                 $delay = min($delay, 3600);

--- a/app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php
+++ b/app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php
@@ -39,10 +39,16 @@ class SyncGitHubRepositoryJob implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    /** Number of retry attempts before the queue gives up. */
-    public int $tries = 1;
+    /** Spec 037 — 3 attempts on transient failures. */
+    public int $tries = 3;
 
     public function __construct(public readonly int $repositoryId) {}
+
+    /** Spec 037 — 1 min / 5 min / 15 min exponential backoff. */
+    public function backoff(): array
+    {
+        return [60, 300, 900];
+    }
 
     public function handle(): void
     {
@@ -88,27 +94,55 @@ class SyncGitHubRepositoryJob implements ShouldQueue
 
             $metadataSynced = true;
         } catch (GitHubApiException $e) {
+            // Spec 037 — see SyncRepositoryIssuesJob for the rationale.
             if ($e->isUnauthorized()) {
                 $this->expireConnection($connection);
+
+                Log::warning('GitHub repository sync — unauthorized', [
+                    'repository_id' => $repository->id,
+                    'full_name' => $repository->full_name,
+                ]);
+
+                $this->markUnauthorized($repository, $e->getMessage());
+
+                return;
             }
 
-            Log::warning('GitHub repository sync failed', [
+            if ($e->wasRateLimited()) {
+                $delay = max($e->secondsUntilReset(), 60);
+                $delay = min($delay, 3600);
+
+                Log::info('GitHub repository sync — rate-limited; releasing', [
+                    'repository_id' => $repository->id,
+                    'full_name' => $repository->full_name,
+                    'release_seconds' => $delay,
+                ]);
+
+                $this->markRateLimited($repository, $e->getMessage());
+                $this->release($delay);
+
+                return;
+            }
+
+            Log::warning('GitHub repository sync — transient API failure', [
                 'repository_id' => $repository->id,
                 'full_name' => $repository->full_name,
                 'status' => $e->statusCode,
+                'attempt' => $this->attempts(),
                 'message' => $e->getMessage(),
             ]);
 
-            $this->markFailed($repository, $e->getMessage());
+            throw $e;
         } catch (Throwable $e) {
-            Log::error('GitHub repository sync errored', [
+            Log::error('GitHub repository sync — unexpected error', [
                 'repository_id' => $repository->id,
                 'full_name' => $repository->full_name,
                 'exception' => $e::class,
+                'attempt' => $this->attempts(),
                 'message' => $e->getMessage(),
             ]);
 
-            $this->markFailed($repository, $e->getMessage() !== '' ? $e->getMessage() : $e::class);
+            throw $e;
         }
 
         // Chain spec 015's issues sync, spec 016's PRs sync, and spec
@@ -220,6 +254,47 @@ class SyncGitHubRepositoryJob implements ShouldQueue
             'sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
             'sync_failed_at' => now(),
         ])->save();
+    }
+
+    private function markRateLimited(Repository $repository, ?string $reason = null): void
+    {
+        $repository->forceFill([
+            'sync_status' => RepositorySyncStatus::RateLimited->value,
+            'sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
+        ])->save();
+    }
+
+    private function markUnauthorized(Repository $repository, ?string $reason = null): void
+    {
+        $repository->forceFill([
+            'sync_status' => RepositorySyncStatus::Unauthorized->value,
+            'sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
+            'sync_failed_at' => now(),
+        ])->save();
+    }
+
+    /**
+     * Spec 037 — terminal-failure handler. Runs once Laravel exhausts
+     * the retry pipeline. Defers to the specific status branch when
+     * we can recognise the cause.
+     */
+    public function failed(Throwable $e): void
+    {
+        $repository = Repository::query()->find($this->repositoryId);
+
+        if ($repository === null) {
+            return;
+        }
+
+        if ($e instanceof GitHubApiException && $e->isUnauthorized()) {
+            $this->markUnauthorized($repository, $e->getMessage());
+
+            return;
+        }
+
+        $reason = $e->getMessage() !== '' ? $e->getMessage() : $e::class;
+
+        $this->markFailed($repository, $reason);
     }
 
     /**

--- a/app/Domain/GitHub/Jobs/SyncRepositoryIssuesJob.php
+++ b/app/Domain/GitHub/Jobs/SyncRepositoryIssuesJob.php
@@ -20,13 +20,27 @@ use Throwable;
 /**
  * Sync a single Repository's issues from GitHub into `github_issues`.
  *
- * Lifecycle (mirrors spec 014's repo-metadata sync):
+ * Lifecycle (spec 037 — gained §18 retry semantics):
  *   pending → syncing → synced (happy path)
- *   pending → syncing → failed (caught GitHubApiException or Throwable)
+ *   pending → syncing → unauthorized (401 — terminal; no retry)
+ *   pending → syncing → rate_limited (transient; release until reset)
+ *   pending → syncing → ... → failed (caught transient throwable after
+ *                                     `$tries` exhausted)
+ *
+ * Retry matrix (spec 037, §18.3):
+ *   - `$tries = 3` for transient failures (5xx, timeouts, unknown).
+ *   - Backoff is exponential: 1 min, 5 min, 15 min between attempts.
+ *   - 401 short-circuits (token won't fix itself) — terminal.
+ *   - 429 / rate-limited 403 → `release()` until `X-RateLimit-Reset`
+ *     without consuming a retry attempt. The job re-runs after
+ *     GitHub's stated window.
+ *   - `failed()` runs after all tries are exhausted; persists the
+ *     terminal status (typically `failed`, occasionally `unauthorized`
+ *     for 401 reached via an out-of-band path).
  *
  * On 401 we additionally clear the connection's `access_token` and zero
  * out `expires_at` so spec-013's Settings card surfaces the Reconnect
- * CTA. The job itself still ends in `failed` status.
+ * CTA.
  *
  * `issues_synced_at` is only stamped on success — a failed run keeps
  * the previous successful timestamp (or null if never synced) so the
@@ -42,10 +56,16 @@ class SyncRepositoryIssuesJob implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    /** Single attempt; mark `failed` on any error. Retries land later. */
-    public int $tries = 1;
+    /** Spec 037 — 3 attempts on transient failures. */
+    public int $tries = 3;
 
     public function __construct(public readonly int $repositoryId) {}
+
+    /** Spec 037 — 1 min / 5 min / 15 min exponential backoff. */
+    public function backoff(): array
+    {
+        return [60, 300, 900];
+    }
 
     public function handle(SyncRepositoryIssuesAction $action): void
     {
@@ -83,28 +103,100 @@ class SyncRepositoryIssuesJob implements ShouldQueue
                 'issues_sync_failed_at' => null,
             ])->save();
         } catch (GitHubApiException $e) {
+            // Spec 037 — branch §18.2 error vocabulary.
+            //
+            // 401 is terminal: the token won't self-heal across retries
+            // and burning two more attempts on a guaranteed 401 just
+            // delays the visible "Reconnect" CTA. Mark + return.
             if ($e->isUnauthorized()) {
                 $this->expireConnection($connection);
+
+                Log::warning('GitHub issues sync — unauthorized', [
+                    'repository_id' => $repository->id,
+                    'full_name' => $repository->full_name,
+                ]);
+
+                $this->markUnauthorized($repository, $e->getMessage());
+
+                return;
             }
 
-            Log::warning('GitHub issues sync failed', [
+            // Rate-limited: release back to the queue with a delay
+            // calibrated to GitHub's `X-RateLimit-Reset`. `release()`
+            // does NOT consume a `$tries` attempt — the next run is a
+            // fresh first attempt against a healed quota.
+            if ($e->wasRateLimited()) {
+                $delay = max($e->secondsUntilReset(), 60);
+                // Hard cap so a misbehaving reset header can't park the
+                // job for hours.
+                $delay = min($delay, 3600);
+
+                Log::info('GitHub issues sync — rate-limited; releasing', [
+                    'repository_id' => $repository->id,
+                    'full_name' => $repository->full_name,
+                    'release_seconds' => $delay,
+                ]);
+
+                $this->markRateLimited($repository, $e->getMessage());
+                $this->release($delay);
+
+                return;
+            }
+
+            Log::warning('GitHub issues sync — transient API failure', [
                 'repository_id' => $repository->id,
                 'full_name' => $repository->full_name,
                 'status' => $e->statusCode,
+                'attempt' => $this->attempts(),
                 'message' => $e->getMessage(),
             ]);
 
-            $this->markFailed($repository, $e->getMessage());
+            // Other API errors (5xx, schema drift, etc.) — re-throw so
+            // the retry pipeline runs the configured `$backoff`. After
+            // `$tries` is exhausted, `failed()` persists the terminal
+            // `Failed` status.
+            throw $e;
         } catch (Throwable $e) {
-            Log::error('GitHub issues sync errored', [
+            Log::error('GitHub issues sync — unexpected error', [
                 'repository_id' => $repository->id,
                 'full_name' => $repository->full_name,
                 'exception' => $e::class,
+                'attempt' => $this->attempts(),
                 'message' => $e->getMessage(),
             ]);
 
-            $this->markFailed($repository, $e->getMessage() !== '' ? $e->getMessage() : $e::class);
+            throw $e;
         }
+    }
+
+    /**
+     * Spec 037 — terminal-failure handler. Laravel calls this once the
+     * retry pipeline has exhausted `$tries`. The 401 + rate-limited
+     * paths short-circuit before this fires; the only way in is a
+     * persistent transient failure (5xx, timeout, etc.) that survived
+     * all three attempts.
+     */
+    public function failed(Throwable $e): void
+    {
+        $repository = Repository::query()->find($this->repositoryId);
+
+        if ($repository === null) {
+            return;
+        }
+
+        // Defensive: if the failure path delivers a 401 we somehow
+        // missed in `handle()` (eg. a Throwable wrapped over a
+        // GitHubApiException), still mark `Unauthorized` so the UI
+        // shows the right CTA.
+        if ($e instanceof GitHubApiException && $e->isUnauthorized()) {
+            $this->markUnauthorized($repository, $e->getMessage());
+
+            return;
+        }
+
+        $reason = $e->getMessage() !== '' ? $e->getMessage() : $e::class;
+
+        $this->markFailed($repository, $reason);
     }
 
     private function resolveConnection(Repository $repository): ?GithubConnection
@@ -129,6 +221,26 @@ class SyncRepositoryIssuesJob implements ShouldQueue
     {
         $repository->forceFill([
             'issues_sync_status' => RepositorySyncStatus::Failed->value,
+            'issues_sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
+            'issues_sync_failed_at' => now(),
+        ])->save();
+    }
+
+    private function markRateLimited(Repository $repository, ?string $reason = null): void
+    {
+        $repository->forceFill([
+            'issues_sync_status' => RepositorySyncStatus::RateLimited->value,
+            'issues_sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
+            // Don't stamp `issues_sync_failed_at` — rate-limit isn't a
+            // failure, just a deferral. The next run will overwrite
+            // the status if it succeeds.
+        ])->save();
+    }
+
+    private function markUnauthorized(Repository $repository, ?string $reason = null): void
+    {
+        $repository->forceFill([
+            'issues_sync_status' => RepositorySyncStatus::Unauthorized->value,
             'issues_sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
             'issues_sync_failed_at' => now(),
         ])->save();

--- a/app/Domain/GitHub/Jobs/SyncRepositoryIssuesJob.php
+++ b/app/Domain/GitHub/Jobs/SyncRepositoryIssuesJob.php
@@ -122,13 +122,17 @@ class SyncRepositoryIssuesJob implements ShouldQueue
             }
 
             // Rate-limited: release back to the queue with a delay
-            // calibrated to GitHub's `X-RateLimit-Reset`. `release()`
-            // does NOT consume a `$tries` attempt — the next run is a
-            // fresh first attempt against a healed quota.
+            // calibrated to GitHub's `X-RateLimit-Reset`. The next pop
+            // increments attempts like any other retry, so a job that
+            // keeps rate-limiting will exhaust `$tries` and hit
+            // `failed()` — terminal state will be `Failed`, not stuck
+            // in `RateLimited` forever.
             if ($e->wasRateLimited()) {
                 $delay = max($e->secondsUntilReset(), 60);
-                // Hard cap so a misbehaving reset header can't park the
-                // job for hours.
+                // Hard cap on a single release window — a misbehaving
+                // reset header could otherwise delay one attempt by
+                // days. Total budget across attempts is bounded by
+                // `$tries` × this cap, plus the `$backoff()` array.
                 $delay = min($delay, 3600);
 
                 Log::info('GitHub issues sync — rate-limited; releasing', [

--- a/app/Domain/GitHub/Jobs/SyncRepositoryPullRequestsJob.php
+++ b/app/Domain/GitHub/Jobs/SyncRepositoryPullRequestsJob.php
@@ -40,9 +40,16 @@ class SyncRepositoryPullRequestsJob implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public int $tries = 1;
+    /** Spec 037 — 3 attempts on transient failures. */
+    public int $tries = 3;
 
     public function __construct(public readonly int $repositoryId) {}
+
+    /** Spec 037 — 1 min / 5 min / 15 min exponential backoff. */
+    public function backoff(): array
+    {
+        return [60, 300, 900];
+    }
 
     public function handle(SyncRepositoryPullRequestsAction $action): void
     {
@@ -80,28 +87,76 @@ class SyncRepositoryPullRequestsJob implements ShouldQueue
                 'prs_sync_failed_at' => null,
             ])->save();
         } catch (GitHubApiException $e) {
+            // Spec 037 — see SyncRepositoryIssuesJob for the rationale.
             if ($e->isUnauthorized()) {
                 $this->expireConnection($connection);
+
+                Log::warning('GitHub PRs sync — unauthorized', [
+                    'repository_id' => $repository->id,
+                    'full_name' => $repository->full_name,
+                ]);
+
+                $this->markUnauthorized($repository, $e->getMessage());
+
+                return;
             }
 
-            Log::warning('GitHub PRs sync failed', [
+            if ($e->wasRateLimited()) {
+                $delay = max($e->secondsUntilReset(), 60);
+                $delay = min($delay, 3600);
+
+                Log::info('GitHub PRs sync — rate-limited; releasing', [
+                    'repository_id' => $repository->id,
+                    'full_name' => $repository->full_name,
+                    'release_seconds' => $delay,
+                ]);
+
+                $this->markRateLimited($repository, $e->getMessage());
+                $this->release($delay);
+
+                return;
+            }
+
+            Log::warning('GitHub PRs sync — transient API failure', [
                 'repository_id' => $repository->id,
                 'full_name' => $repository->full_name,
                 'status' => $e->statusCode,
+                'attempt' => $this->attempts(),
                 'message' => $e->getMessage(),
             ]);
 
-            $this->markFailed($repository, $e->getMessage());
+            throw $e;
         } catch (Throwable $e) {
-            Log::error('GitHub PRs sync errored', [
+            Log::error('GitHub PRs sync — unexpected error', [
                 'repository_id' => $repository->id,
                 'full_name' => $repository->full_name,
                 'exception' => $e::class,
+                'attempt' => $this->attempts(),
                 'message' => $e->getMessage(),
             ]);
 
-            $this->markFailed($repository, $e->getMessage() !== '' ? $e->getMessage() : $e::class);
+            throw $e;
         }
+    }
+
+    /** Spec 037 — terminal-failure handler after `$tries` exhausted. */
+    public function failed(Throwable $e): void
+    {
+        $repository = Repository::query()->find($this->repositoryId);
+
+        if ($repository === null) {
+            return;
+        }
+
+        if ($e instanceof GitHubApiException && $e->isUnauthorized()) {
+            $this->markUnauthorized($repository, $e->getMessage());
+
+            return;
+        }
+
+        $reason = $e->getMessage() !== '' ? $e->getMessage() : $e::class;
+
+        $this->markFailed($repository, $reason);
     }
 
     private function resolveConnection(Repository $repository): ?GithubConnection
@@ -125,6 +180,23 @@ class SyncRepositoryPullRequestsJob implements ShouldQueue
     {
         $repository->forceFill([
             'prs_sync_status' => RepositorySyncStatus::Failed->value,
+            'prs_sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
+            'prs_sync_failed_at' => now(),
+        ])->save();
+    }
+
+    private function markRateLimited(Repository $repository, ?string $reason = null): void
+    {
+        $repository->forceFill([
+            'prs_sync_status' => RepositorySyncStatus::RateLimited->value,
+            'prs_sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
+        ])->save();
+    }
+
+    private function markUnauthorized(Repository $repository, ?string $reason = null): void
+    {
+        $repository->forceFill([
+            'prs_sync_status' => RepositorySyncStatus::Unauthorized->value,
             'prs_sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
             'prs_sync_failed_at' => now(),
         ])->save();

--- a/app/Domain/GitHub/Jobs/SyncRepositoryPullRequestsJob.php
+++ b/app/Domain/GitHub/Jobs/SyncRepositoryPullRequestsJob.php
@@ -101,6 +101,9 @@ class SyncRepositoryPullRequestsJob implements ShouldQueue
                 return;
             }
 
+            // Rate-limited: see SyncRepositoryIssuesJob for the
+            // `release()` semantics. Persistent rate-limiting exhausts
+            // `$tries` and falls through to `failed()`.
             if ($e->wasRateLimited()) {
                 $delay = max($e->secondsUntilReset(), 60);
                 $delay = min($delay, 3600);

--- a/app/Domain/GitHub/Jobs/SyncRepositoryWorkflowRunsJob.php
+++ b/app/Domain/GitHub/Jobs/SyncRepositoryWorkflowRunsJob.php
@@ -105,6 +105,9 @@ class SyncRepositoryWorkflowRunsJob implements ShouldQueue
                 return;
             }
 
+            // Rate-limited: see SyncRepositoryIssuesJob for the
+            // `release()` semantics. Persistent rate-limiting exhausts
+            // `$tries` and falls through to `failed()`.
             if ($e->wasRateLimited()) {
                 $delay = max($e->secondsUntilReset(), 60);
                 $delay = min($delay, 3600);

--- a/app/Domain/GitHub/Jobs/SyncRepositoryWorkflowRunsJob.php
+++ b/app/Domain/GitHub/Jobs/SyncRepositoryWorkflowRunsJob.php
@@ -44,9 +44,16 @@ class SyncRepositoryWorkflowRunsJob implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public int $tries = 1;
+    /** Spec 037 — 3 attempts on transient failures. */
+    public int $tries = 3;
 
     public function __construct(public readonly int $repositoryId) {}
+
+    /** Spec 037 — 1 min / 5 min / 15 min exponential backoff. */
+    public function backoff(): array
+    {
+        return [60, 300, 900];
+    }
 
     public function handle(SyncRepositoryWorkflowRunsAction $action): void
     {
@@ -84,28 +91,76 @@ class SyncRepositoryWorkflowRunsJob implements ShouldQueue
                 'workflow_runs_sync_failed_at' => null,
             ])->save();
         } catch (GitHubApiException $e) {
+            // Spec 037 — see SyncRepositoryIssuesJob for the rationale.
             if ($e->isUnauthorized()) {
                 $this->expireConnection($connection);
+
+                Log::warning('GitHub workflow runs sync — unauthorized', [
+                    'repository_id' => $repository->id,
+                    'full_name' => $repository->full_name,
+                ]);
+
+                $this->markUnauthorized($repository, $e->getMessage());
+
+                return;
             }
 
-            Log::warning('GitHub workflow runs sync failed', [
+            if ($e->wasRateLimited()) {
+                $delay = max($e->secondsUntilReset(), 60);
+                $delay = min($delay, 3600);
+
+                Log::info('GitHub workflow runs sync — rate-limited; releasing', [
+                    'repository_id' => $repository->id,
+                    'full_name' => $repository->full_name,
+                    'release_seconds' => $delay,
+                ]);
+
+                $this->markRateLimited($repository, $e->getMessage());
+                $this->release($delay);
+
+                return;
+            }
+
+            Log::warning('GitHub workflow runs sync — transient API failure', [
                 'repository_id' => $repository->id,
                 'full_name' => $repository->full_name,
                 'status' => $e->statusCode,
+                'attempt' => $this->attempts(),
                 'message' => $e->getMessage(),
             ]);
 
-            $this->markFailed($repository, $e->getMessage());
+            throw $e;
         } catch (Throwable $e) {
-            Log::error('GitHub workflow runs sync errored', [
+            Log::error('GitHub workflow runs sync — unexpected error', [
                 'repository_id' => $repository->id,
                 'full_name' => $repository->full_name,
                 'exception' => $e::class,
+                'attempt' => $this->attempts(),
                 'message' => $e->getMessage(),
             ]);
 
-            $this->markFailed($repository, $e->getMessage() !== '' ? $e->getMessage() : $e::class);
+            throw $e;
         }
+    }
+
+    /** Spec 037 — terminal-failure handler after `$tries` exhausted. */
+    public function failed(Throwable $e): void
+    {
+        $repository = Repository::query()->find($this->repositoryId);
+
+        if ($repository === null) {
+            return;
+        }
+
+        if ($e instanceof GitHubApiException && $e->isUnauthorized()) {
+            $this->markUnauthorized($repository, $e->getMessage());
+
+            return;
+        }
+
+        $reason = $e->getMessage() !== '' ? $e->getMessage() : $e::class;
+
+        $this->markFailed($repository, $reason);
     }
 
     private function resolveConnection(Repository $repository): ?GithubConnection
@@ -129,6 +184,23 @@ class SyncRepositoryWorkflowRunsJob implements ShouldQueue
     {
         $repository->forceFill([
             'workflow_runs_sync_status' => RepositorySyncStatus::Failed->value,
+            'workflow_runs_sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
+            'workflow_runs_sync_failed_at' => now(),
+        ])->save();
+    }
+
+    private function markRateLimited(Repository $repository, ?string $reason = null): void
+    {
+        $repository->forceFill([
+            'workflow_runs_sync_status' => RepositorySyncStatus::RateLimited->value,
+            'workflow_runs_sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
+        ])->save();
+    }
+
+    private function markUnauthorized(Repository $repository, ?string $reason = null): void
+    {
+        $repository->forceFill([
+            'workflow_runs_sync_status' => RepositorySyncStatus::Unauthorized->value,
             'workflow_runs_sync_error' => $reason !== null ? Str::limit($reason, 500, '…') : null,
             'workflow_runs_sync_failed_at' => now(),
         ])->save();

--- a/app/Enums/RepositorySyncStatus.php
+++ b/app/Enums/RepositorySyncStatus.php
@@ -9,6 +9,12 @@ namespace App\Enums;
  * `pending` = manually linked, no sync attempted yet (the only state
  * spec 011 actually produces). `syncing|synced|failed` are populated
  * by the GitHub-sync job in phase 2.
+ *
+ * Spec 037 added `rate_limited` + `unauthorized` to decompose the
+ * §18.2 error vocabulary: `rate_limited` is a transient failure that
+ * will self-heal on the next retry (sync jobs `release()` until the
+ * reset window), `unauthorized` requires user action (re-auth or
+ * regenerate the token) and shouldn't auto-retry.
  */
 enum RepositorySyncStatus: string
 {
@@ -16,15 +22,18 @@ enum RepositorySyncStatus: string
     case Syncing = 'syncing';
     case Synced = 'synced';
     case Failed = 'failed';
+    case RateLimited = 'rate_limited';
+    case Unauthorized = 'unauthorized';
 
-    /** Tone used by `StatusBadge` (info/warning/success/danger). */
+    /** Tone used by `StatusBadge` (info/warning/success/danger/muted). */
     public function badgeTone(): string
     {
         return match ($this) {
             self::Pending => 'muted',
             self::Syncing => 'info',
             self::Synced => 'success',
-            self::Failed => 'danger',
+            self::Failed, self::Unauthorized => 'danger',
+            self::RateLimited => 'warning',
         };
     }
 }

--- a/app/Http/Controllers/Settings/WebhookDeliveryController.php
+++ b/app/Http/Controllers/Settings/WebhookDeliveryController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Domain\GitHub\Jobs\ProcessGitHubWebhookJob;
+use App\Enums\WebhookDeliveryStatus;
+use App\Http\Controllers\Controller;
+use App\Models\WebhookDelivery;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Spec 037 — webhook delivery list + retry. Single-tenant phase-1:
+ * every verified user sees every delivery row. When multi-tenant
+ * scoping lands, restrict via repository ownership.
+ *
+ * The index view is URL-backed (status / event / repo search) so
+ * filters survive a refresh and are linkable. Retry is a single-row
+ * action that re-dispatches `ProcessGitHubWebhookJob` against the
+ * stored payload + signature (the row is preserved for forensic
+ * audit; the action just kicks the job).
+ */
+class WebhookDeliveryController extends Controller
+{
+    private const PER_PAGE = 30;
+
+    public function __invoke(Request $request): Response
+    {
+        $statusValues = array_map(
+            fn (WebhookDeliveryStatus $case): string => $case->value,
+            WebhookDeliveryStatus::cases(),
+        );
+
+        $validated = $request->validate([
+            'status' => 'sometimes|nullable|in:'.implode(',', [...$statusValues, 'all']),
+            'event' => 'sometimes|nullable|string|max:64',
+            'repository' => 'sometimes|nullable|string|max:128',
+        ]);
+
+        $rawStatus = $validated['status'] ?? null;
+        $event = $validated['event'] ?? null;
+        $repository = $validated['repository'] ?? null;
+
+        $query = WebhookDelivery::query()->latest('received_at');
+
+        // Default view = "everything" (no implicit Open default, unlike
+        // Alerts) because the page is an admin/debug surface and
+        // showing one status by default would hide background failures.
+        if ($rawStatus !== null && $rawStatus !== 'all') {
+            $query->where('status', $rawStatus);
+        }
+
+        if ($event !== null && $event !== '') {
+            $query->where('event', $event);
+        }
+
+        if ($repository !== null && $repository !== '') {
+            $query->where('repository_full_name', 'like', "%{$repository}%");
+        }
+
+        $deliveries = $query
+            ->paginate(self::PER_PAGE)
+            ->withQueryString()
+            ->through(fn (WebhookDelivery $row): array => [
+                'id' => $row->id,
+                'github_delivery_id' => $row->github_delivery_id,
+                'event' => $row->event,
+                'action' => $row->action,
+                'repository_full_name' => $row->repository_full_name,
+                'status' => $row->status?->value,
+                'status_tone' => $row->status?->badgeTone(),
+                'error_message' => $row->error_message,
+                'received_at' => $row->received_at?->diffForHumans(),
+                'received_at_iso' => $row->received_at?->toIso8601String(),
+                'processed_at' => $row->processed_at?->diffForHumans(),
+            ]);
+
+        return Inertia::render('Settings/WebhookDeliveries', [
+            'deliveries' => $deliveries,
+            'filters' => [
+                'status' => $rawStatus ?? 'all',
+                'event' => $event ?? '',
+                'repository' => $repository ?? '',
+            ],
+            'filterOptions' => [
+                'statuses' => $statusValues,
+                'events' => WebhookDelivery::query()
+                    ->distinct()
+                    ->orderBy('event')
+                    ->pluck('event')
+                    ->all(),
+            ],
+        ]);
+    }
+
+    /**
+     * Spec 037 — re-dispatch the webhook job against the persisted
+     * payload. Resets the row to `Received` so a successful retry
+     * lands as `Processed`. The original `received_at` is preserved
+     * (the row's identity hasn't changed).
+     */
+    public function retry(Request $request, WebhookDelivery $delivery): RedirectResponse
+    {
+        if ($delivery->status !== WebhookDeliveryStatus::Failed) {
+            return back()->with('error', 'Only failed deliveries can be retried.');
+        }
+
+        $delivery->forceFill([
+            'status' => WebhookDeliveryStatus::Received->value,
+            'error_message' => null,
+            'processed_at' => null,
+        ])->save();
+
+        ProcessGitHubWebhookJob::dispatch($delivery->id);
+
+        return back()->with('status', 'Webhook re-queued.');
+    }
+}

--- a/resources/js/Pages/Repositories/Show.vue
+++ b/resources/js/Pages/Repositories/Show.vue
@@ -235,9 +235,18 @@ const runRepositorySync = () => {
 // latest status — a partial Inertia reload that re-fetches just the
 // sync-related props so the page updates without flashing or losing
 // scroll. Stops on its own as soon as all four flip out of `syncing`.
-// Spec 019 will replace this with Reverb broadcasts.
+//
+// Spec 037 — bounded by a wall-clock cap. Pre-037 a transient API error
+// flipped status to `Failed` immediately and polling stopped within a
+// tick. Post-037 a transient 5xx keeps status at `Syncing` during the
+// retry pipeline (potentially 1 + 5 + 15 = 21 min of backoff). Without
+// a cap a stuck row would fire ~500 reloads against the controller
+// while the queue worker is asleep. The cap stops polling after
+// ~5 minutes; the user can refresh manually past that.
 const POLL_INTERVAL_MS = 2500;
+const POLL_MAX_TICKS = 120; // 120 × 2.5s = 5 minutes
 let pollHandle: ReturnType<typeof setInterval> | null = null;
+let pollTicks = 0;
 
 const anySyncing = computed(
     () =>
@@ -252,11 +261,19 @@ const stopPolling = () => {
         clearInterval(pollHandle);
         pollHandle = null;
     }
+    pollTicks = 0;
 };
 
 const startPolling = () => {
     if (pollHandle !== null) return;
+    pollTicks = 0;
     pollHandle = setInterval(() => {
+        pollTicks += 1;
+        if (pollTicks >= POLL_MAX_TICKS) {
+            stopPolling();
+            return;
+        }
+
         // `router.reload` is a same-route partial fetch — no navigation, so
         // scroll + component state are preserved by default. `only` keeps
         // the payload tiny (just the sync-related props plus the lists

--- a/resources/js/Pages/Settings/Index.vue
+++ b/resources/js/Pages/Settings/Index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
-import { Head, router, usePage } from '@inertiajs/vue3';
+import { Head, Link, router, usePage } from '@inertiajs/vue3';
 import {
     AlertTriangle,
     CheckCircle2,
@@ -14,6 +14,7 @@ import {
     Sun,
     SunMoon,
     Unplug,
+    Webhook,
 } from 'lucide-vue-next';
 import type { PageProps } from '@/types';
 import { computed, ref } from 'vue';
@@ -105,6 +106,29 @@ const disconnect = () => {
                     </p>
                 </div>
             </header>
+
+            <!-- Spec 037 — webhook deliveries entry point. Surfaced
+                 here next to the GitHub connection because it's the
+                 audit/forensic surface for that integration. -->
+            <Link
+                :href="route('settings.webhook-deliveries.index')"
+                class="glass-card flex items-center justify-between gap-3 p-5 transition hover:border-accent-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+            >
+                <div class="flex items-center gap-3">
+                    <span class="flex h-10 w-10 items-center justify-center rounded-lg border border-border-subtle bg-background-panel-hover">
+                        <Webhook class="h-5 w-5 text-accent-cyan" aria-hidden="true" />
+                    </span>
+                    <div class="flex min-w-0 flex-col">
+                        <span class="text-sm font-semibold text-text-primary">
+                            Webhook deliveries
+                        </span>
+                        <span class="text-xs text-text-muted">
+                            Inspect + retry GitHub webhook deliveries.
+                        </span>
+                    </div>
+                </div>
+                <ExternalLink class="h-4 w-4 text-text-muted" aria-hidden="true" />
+            </Link>
 
             <!-- GitHub Integration card -->
             <section

--- a/resources/js/Pages/Settings/WebhookDeliveries.vue
+++ b/resources/js/Pages/Settings/WebhookDeliveries.vue
@@ -1,0 +1,290 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import {
+    AlertOctagon,
+    ChevronLeft,
+    Inbox,
+    RefreshCw,
+    Webhook,
+} from 'lucide-vue-next';
+import { ref } from 'vue';
+
+type Status = 'received' | 'processed' | 'failed' | 'skipped';
+
+interface DeliveryRow {
+    id: number;
+    github_delivery_id: string | null;
+    event: string;
+    action: string | null;
+    repository_full_name: string | null;
+    status: Status | null;
+    status_tone: 'info' | 'success' | 'danger' | 'muted' | 'warning' | null;
+    error_message: string | null;
+    received_at: string | null;
+    received_at_iso: string | null;
+    processed_at: string | null;
+}
+
+interface Paginator {
+    data: DeliveryRow[];
+    current_page: number;
+    last_page: number;
+    links: Array<{ url: string | null; label: string; active: boolean }>;
+}
+
+interface FilterState {
+    status: string;
+    event: string;
+    repository: string;
+}
+
+const props = defineProps<{
+    deliveries: Paginator;
+    filters: FilterState;
+    filterOptions: {
+        statuses: Status[];
+        events: string[];
+    };
+}>();
+
+const filterDraft = ref<FilterState>({ ...props.filters });
+
+const applyFilters = () => {
+    router.get(
+        route('settings.webhook-deliveries.index'),
+        Object.fromEntries(
+            Object.entries(filterDraft.value).filter(
+                ([, v]) => v !== null && v !== '',
+            ),
+        ),
+        {
+            preserveScroll: true,
+            preserveState: true,
+            only: ['deliveries', 'filters', 'filterOptions'],
+        },
+    );
+};
+
+const clearFilters = () => {
+    filterDraft.value = { status: 'all', event: '', repository: '' };
+    applyFilters();
+};
+
+const retry = (delivery: DeliveryRow) => {
+    if (delivery.status !== 'failed') return;
+    router.post(
+        route('settings.webhook-deliveries.retry', { delivery: delivery.id }),
+        {},
+        { preserveScroll: true },
+    );
+};
+
+const capitalize = (s: string | null) =>
+    s ? s.charAt(0).toUpperCase() + s.slice(1) : s ?? '';
+</script>
+
+<template>
+    <Head title="Webhook deliveries" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <Link
+                    :href="route('settings.index')"
+                    class="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan transition hover:text-accent-cyan/80"
+                >
+                    <ChevronLeft class="h-3 w-3" aria-hidden="true" />
+                    Settings
+                </Link>
+                <h1 class="text-lg font-semibold text-text-primary">
+                    Webhook deliveries
+                </h1>
+            </div>
+        </template>
+
+        <div class="space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+            <header class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div class="flex flex-col gap-1">
+                    <h2 class="flex items-center gap-2 text-xl font-semibold text-text-primary">
+                        <Webhook
+                            class="h-5 w-5 text-accent-cyan"
+                            aria-hidden="true"
+                        />
+                        GitHub webhook deliveries
+                    </h2>
+                    <p class="text-sm text-text-secondary">
+                        Inspect every delivery, see which handler ran, and re-queue
+                        failed rows against their stored payload.
+                    </p>
+                </div>
+            </header>
+
+            <!-- Filter strip -->
+            <section
+                aria-label="Filters"
+                class="glass-card flex flex-col gap-4 p-5 sm:flex-row sm:items-end"
+            >
+                <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                    Status
+                    <select
+                        v-model="filterDraft.status"
+                        class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                        @change="applyFilters"
+                    >
+                        <option value="all">All</option>
+                        <option
+                            v-for="status in props.filterOptions.statuses"
+                            :key="status"
+                            :value="status"
+                        >
+                            {{ capitalize(status) }}
+                        </option>
+                    </select>
+                </label>
+                <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                    Event
+                    <select
+                        v-model="filterDraft.event"
+                        class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                        @change="applyFilters"
+                    >
+                        <option value="">All events</option>
+                        <option
+                            v-for="event in props.filterOptions.events"
+                            :key="event"
+                            :value="event"
+                        >
+                            {{ event }}
+                        </option>
+                    </select>
+                </label>
+                <label class="flex flex-1 flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                    Repository
+                    <input
+                        v-model="filterDraft.repository"
+                        type="text"
+                        placeholder="owner/repo"
+                        class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                        @keydown.enter="applyFilters"
+                        @blur="applyFilters"
+                    >
+                </label>
+                <button
+                    type="button"
+                    class="inline-flex items-center gap-2 rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm font-semibold text-text-secondary transition hover:border-accent-cyan/40 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                    @click="clearFilters"
+                >
+                    Clear
+                </button>
+            </section>
+
+            <!-- List -->
+            <section
+                v-if="props.deliveries.data.length > 0"
+                class="glass-card overflow-hidden"
+            >
+                <ul class="divide-y divide-border-subtle">
+                    <li
+                        v-for="delivery in props.deliveries.data"
+                        :key="delivery.id"
+                        class="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+                    >
+                        <div class="flex min-w-0 flex-col gap-1">
+                            <div class="flex flex-wrap items-center gap-2">
+                                <StatusBadge
+                                    v-if="delivery.status_tone"
+                                    :tone="delivery.status_tone"
+                                >
+                                    {{ capitalize(delivery.status) }}
+                                </StatusBadge>
+                                <span class="font-mono text-xs text-text-secondary">
+                                    {{ delivery.event }}<template v-if="delivery.action">.{{ delivery.action }}</template>
+                                </span>
+                                <span
+                                    v-if="delivery.repository_full_name"
+                                    class="font-mono text-xs text-text-muted"
+                                >
+                                    {{ delivery.repository_full_name }}
+                                </span>
+                            </div>
+                            <div class="flex items-center gap-3 text-[11px] text-text-muted">
+                                <span v-if="delivery.received_at">
+                                    Received {{ delivery.received_at }}
+                                </span>
+                                <span v-if="delivery.processed_at">
+                                    · Processed {{ delivery.processed_at }}
+                                </span>
+                            </div>
+                            <p
+                                v-if="delivery.error_message"
+                                class="flex items-start gap-2 text-xs text-status-danger"
+                            >
+                                <AlertOctagon
+                                    class="mt-0.5 h-3.5 w-3.5 shrink-0"
+                                    aria-hidden="true"
+                                />
+                                <span class="truncate">{{ delivery.error_message }}</span>
+                            </p>
+                        </div>
+                        <div class="flex shrink-0 items-center gap-2">
+                            <button
+                                v-if="delivery.status === 'failed'"
+                                type="button"
+                                class="inline-flex items-center gap-2 rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-1.5 text-xs font-semibold text-text-secondary transition hover:border-accent-cyan/40 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                @click="retry(delivery)"
+                            >
+                                <RefreshCw class="h-3.5 w-3.5" aria-hidden="true" />
+                                Retry
+                            </button>
+                        </div>
+                    </li>
+                </ul>
+            </section>
+
+            <!-- Empty -->
+            <section
+                v-else
+                class="glass-card flex flex-col items-center gap-3 p-10 text-center"
+            >
+                <span
+                    class="flex h-12 w-12 items-center justify-center rounded-full border border-border-subtle bg-slate-950/40"
+                >
+                    <Inbox class="h-5 w-5 text-text-muted" aria-hidden="true" />
+                </span>
+                <h3 class="text-base font-semibold text-text-primary">
+                    No deliveries match
+                </h3>
+                <p class="max-w-sm text-sm text-text-muted">
+                    Adjust the filters above or wait for GitHub to deliver a new
+                    webhook. Connected repositories surface here automatically.
+                </p>
+            </section>
+
+            <!-- Pagination -->
+            <nav
+                v-if="props.deliveries.last_page > 1"
+                class="flex flex-wrap items-center justify-center gap-1"
+                aria-label="Pagination"
+            >
+                <Link
+                    v-for="link in props.deliveries.links"
+                    :key="link.label"
+                    :href="link.url ?? '#'"
+                    :class="[
+                        'inline-flex min-w-[2.25rem] items-center justify-center rounded-lg border px-3 py-1.5 text-xs font-semibold transition',
+                        link.active
+                            ? 'border-accent-cyan/50 bg-accent-cyan/10 text-accent-cyan'
+                            : link.url
+                              ? 'border-border-subtle bg-background-panel-hover text-text-secondary hover:border-accent-cyan/40 hover:text-text-primary'
+                              : 'cursor-not-allowed border-border-subtle bg-background-panel-hover/40 text-text-muted',
+                    ]"
+                    :preserve-state="true"
+                    :preserve-scroll="true"
+                    v-html="link.label"
+                />
+            </nav>
+        </div>
+    </AppLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\RepositorySyncAllController;
 use App\Http\Controllers\RepositorySyncController;
 use App\Http\Controllers\RepositoryWorkflowRunsSyncController;
 use App\Http\Controllers\Settings\ThemeController;
+use App\Http\Controllers\Settings\WebhookDeliveryController;
 use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\Webhooks\GitHubWebhookController;
 use App\Http\Controllers\WorkItemController;
@@ -64,6 +65,14 @@ Route::middleware(['auth', 'verified'])->group(function () {
     // `<html>` class toggle happens client-side in AppLayout.
     Route::post('/settings/theme', ThemeController::class)
         ->name('settings.theme.update');
+
+    // Spec 037 — webhook delivery list + retry. Filter strip lives on
+    // the index; retry is a single-row POST that re-dispatches the
+    // job against the stored payload.
+    Route::get('/settings/webhook-deliveries', WebhookDeliveryController::class)
+        ->name('settings.webhook-deliveries.index');
+    Route::post('/settings/webhook-deliveries/{delivery}/retry', [WebhookDeliveryController::class, 'retry'])
+        ->name('settings.webhook-deliveries.retry');
 
     Route::get('/integrations/github/connect', [GithubConnectionController::class, 'redirect'])
         ->name('integrations.github.connect');

--- a/specs/phase-9-polish/037-reliability-hardening.md
+++ b/specs/phase-9-polish/037-reliability-hardening.md
@@ -1,0 +1,325 @@
+---
+spec: reliability-hardening
+phase: 9
+status: in-progress   # not-started | in-progress | blocked | done
+owner: Yoany
+created: 2026-06-16
+updated: 2026-06-16
+---
+
+# 037 — Reliability hardening: retries, rate-limit handling, webhook retry UI
+
+## Goal
+Today every `ShouldQueue` job in the codebase has `$tries = 1`. A
+transient DB hiccup or a GitHub rate-limit response silently
+fails the job; the user sees a stale-looking sync card with a
+`failed` badge and no way to retry. Spec 037 wires up the §18
+retry matrix across the queued path: GitHub sync jobs get
+exponential backoff + rate-limit-aware release, the webhook
+processor retries 3× then surfaces, and the existing
+`RepositorySyncStatus` enum gains the missing `rate_limited` +
+`unauthorized` cases so the UI can decompose the failure mode.
+
+Three concrete shifts:
+
+1. **Retry policy on every queued job.** Sync jobs get
+   `$tries = 3` + exponential `$backoff()`. Rate-limit responses
+   `release()` until GitHub's `X-RateLimit-Reset`. Webhook job
+   gets `$tries = 3`. Intentional `$tries = 1` stays for
+   scheduler-bound jobs (website check, host offline detector,
+   the analytics sweep) where the next tick is the retry path.
+2. **§18.2 sync-status decomposition.** `RepositorySyncStatus`
+   gains `RateLimited` + `Unauthorized`. Sync jobs map exception
+   shapes onto the right state so a 401 doesn't read as a
+   generic "Failed".
+3. **Webhook delivery retry UI.** New `/settings/webhook-deliveries`
+   page lists every row from `github_webhook_deliveries` with
+   filters (status, event, repository), and exposes a "Retry"
+   button on failed rows that re-dispatches
+   `ProcessGitHubWebhookJob` against the stored payload. The
+   payload + signature are already persisted for forensic audit
+   (spec 017); retry just reuses them.
+
+Roadmap refs: §18 Error Handling (retry matrix + sync statuses +
+external API errors), §16 Security Requirements (rate limit
+enforcement), spec 017 (webhook delivery store), spec 014
+(repository sync status fields).
+
+## Scope
+
+**In scope:**
+
+- **`RepositorySyncStatus` enum (`app/Enums/`).**
+  - Add `case RateLimited = 'rate_limited';`
+  - Add `case Unauthorized = 'unauthorized';`
+  - Update `badgeTone()` mapping: rate-limited → `warning`,
+    unauthorized → `danger`.
+  - Existing `pending` / `syncing` / `synced` / `failed` cases
+    keep current tones.
+  - Stored as `string(16)` in the DB — no migration needed
+    (column accepts any 16-char string).
+
+- **Job retry + backoff matrix (`app/Domain/`).**
+  - **`SyncGitHubRepositoryJob`, `SyncRepositoryIssuesJob`,
+    `SyncRepositoryPullRequestsJob`, `SyncRepositoryWorkflowRunsJob`:**
+    - `$tries = 3`.
+    - `public function backoff(): array { return [60, 300, 900]; }`
+      — 1 min / 5 min / 15 min exponential.
+    - `public function failed(\Throwable $e): void` —
+      persists the appropriate sync status (`RateLimited` /
+      `Unauthorized` / `Failed`) and the error message
+      (capped 500 chars). Mirrors the in-job catch block
+      that already exists.
+    - In the job body's `try / catch`, when the caught
+      `GitHubApiException::wasRateLimited()` returns true,
+      call `$this->release($resetSeconds)` instead of letting
+      the catch persist `Failed`. The reset seconds come from
+      a new `secondsUntilReset()` method on the exception
+      class (computed from the rate-limit reset header
+      already plumbed by `GitHubApiClient`).
+  - **`ProcessGitHubWebhookJob`:** flip from `$tries = 1` →
+    `$tries = 3`. Add `backoff(): array { return [10, 60]; }` —
+    quick retry then longer. Add `failed()` handler that marks
+    the delivery row `WebhookDeliveryStatus::Failed` with the
+    final exception's message (capped 500 chars). Existing
+    in-job catch stays — `failed()` is the catch's last-ditch
+    record for cases the catch itself misses (eg. timeout).
+  - **Intentional `$tries = 1` (unchanged, documented in
+    docblocks):** `RunWebsiteCheckJob`, `DispatchDueWebsiteChecksJob`,
+    `DetectOfflineHostsJob`, `RecomputeProjectHealthScoreJob`,
+    `RecomputeAllProjectHealthScoresJob`. Their next-tick
+    cadence is the retry path; per-job retry would double-write
+    or mask transient failures the user should see.
+
+- **`GitHubApiException` (`app/Domain/GitHub/Exceptions/`).**
+  - Add `?int $rateLimitResetAt = null` constructor param +
+    property.
+  - Add `public function secondsUntilReset(): int { return max(0, ($this->rateLimitResetAt ?? 0) - time()); }`.
+  - Update `wasRateLimited()` to ALSO return true when
+    `rateLimitResetAt !== null` (header-driven path, not just
+    the heuristic message check).
+
+- **`GitHubApiClient` (or whatever wraps the HTTP calls).**
+  - On a 429 (or 403 with rate-limit headers), parse
+    `X-RateLimit-Reset` and throw `GitHubApiException` with
+    `rateLimitResetAt: (int) $resetUnixTs`. This puts the right
+    information on the exception for the job's catch to
+    decide between retry / release.
+  - If the existing client doesn't centralize HTTP calls,
+    extend the per-caller paths instead. Verify during impl.
+
+- **Webhook delivery retry UI.**
+  - `app/Http/Controllers/Settings/WebhookDeliveryController.php`
+    — single-action invokable `__invoke` for the index page,
+    plus an action method `retry(WebhookDelivery $delivery)`.
+  - Routes: `GET /settings/webhook-deliveries` →
+    `webhook-deliveries.index`, `POST
+    /settings/webhook-deliveries/{delivery}/retry` →
+    `webhook-deliveries.retry`. Both inside the existing
+    `auth + verified` group.
+  - `Pages/Settings/WebhookDeliveries.vue`:
+    - Lists rows from `github_webhook_deliveries` (paginated,
+      30/page). Each row: status badge (mapping `received` →
+      info, `processed` → success, `failed` → danger,
+      `skipped` → muted), event name + action, repository
+      `full_name`, received-at + processed-at humanized,
+      error message excerpt for failed rows.
+    - Filter strip: status dropdown (all / received /
+      processed / failed / skipped), event dropdown, free-
+      text repository search. URL-backed like the Alerts
+      filter pattern.
+    - Retry button on `failed` rows only — POSTs to the
+      retry route, flashes "Webhook re-queued." on success.
+  - `retry()` action:
+    - Authorizes via the existing settings access
+      (any verified user — single-tenant phase-1).
+    - Re-dispatches `ProcessGitHubWebhookJob` with the
+      same `delivery_id`. The job re-runs its handler chain
+      against the persisted payload.
+    - Resets the delivery row to
+      `WebhookDeliveryStatus::Received` so a successful retry
+      ends as `Processed`.
+  - Sidebar entry: a new "Webhook Deliveries" link under
+    Settings (or as a section in `/settings` itself —
+    cheaper). Pick the in-settings tab on impl.
+
+- **Sync job catch-paths emit the new statuses.**
+  - In each sync job's `catch (GitHubApiException $e)`, branch:
+    - `$e->wasRateLimited()` → persist
+      `RepositorySyncStatus::RateLimited`.
+    - `$e->getCode() === 401` → persist
+      `RepositorySyncStatus::Unauthorized`.
+    - otherwise → existing `Failed` path.
+  - Generic `catch (Throwable $e)` continues to map to
+    `Failed`.
+
+- **Tests.**
+  - `tests/Unit/Domain/GitHub/Exceptions/GitHubApiExceptionTest.php`
+    — `wasRateLimited()` true when `rateLimitResetAt` is set;
+    `secondsUntilReset()` returns the right delta;
+    forward-only (won't return negative).
+  - `tests/Unit/Domain/GitHub/Jobs/SyncRepositoryIssuesJobTest.php`
+    — extend with: rate-limit exception triggers
+    `$this->release(N)` instead of persisting `Failed`;
+    401 persists `Unauthorized`; transient error retries (the
+    job's `attempts() < $tries` path); third failure persists
+    `Failed` via the `failed()` handler.
+  - `tests/Unit/Domain/GitHub/Jobs/ProcessGitHubWebhookJobTest.php`
+    — `failed()` handler marks the delivery `Failed` with the
+    exception message.
+  - `tests/Feature/Settings/WebhookDeliveriesIndexTest.php`
+    — verified user can list; status filter narrows; payload
+    shape carries the expected fields.
+  - `tests/Feature/Settings/WebhookDeliveryRetryTest.php`
+    — failed delivery → POST retry → status flips to
+    `Received`, job dispatched (via `Bus::fake()`),
+    success flash present.
+  - Existing `RepositorySyncStatusTest` (or wherever the
+    enum is tested today) — add cases for the two new
+    statuses.
+
+**Out of scope:**
+
+- **Bulk retry of failed deliveries** — single-row retry
+  ships here; "retry all failed since X" is a polish
+  follow-up.
+- **Activity-feed entry on retry** — surfacing the retry on
+  the right-rail is small but pushes Activity surface area
+  that isn't load-bearing for the spec's goal. Defer.
+- **Per-job admin dashboard** — the existing Horizon UI
+  already shows queue health (spec 009). A Nexus-styled job
+  list isn't needed.
+- **§17 self-monitoring alerts** (queue backlog,
+  webhook-failure-rate, agent-ingestion-failure-rate) —
+  those land in **spec 038** (self-monitoring), not here.
+  This spec sets the groundwork by ensuring failures are
+  surfaced + actionable.
+- **GitHub App webhook auto-subscription** — manual setup
+  stays manual (deferred per spec 017's own polish notes).
+- **`Activity event title i18n`** + per-locale error messages
+  — out of scope; English-only.
+
+## Plan
+
+1. **Enum.** Add the two cases to `RepositorySyncStatus`. Update
+   `badgeTone()`. One enum test addition.
+
+2. **`GitHubApiException`.** Constructor + property + two new
+   methods. One unit test file.
+
+3. **GitHub HTTP client.** Find the call site(s) that wrap 4xx/5xx
+   responses; on 429 (or 403 + `X-RateLimit-Remaining: 0` per
+   GitHub docs), parse `X-RateLimit-Reset` and pass to the
+   exception. The client may not be centralized — verify during
+   impl and either centralize or fan out the change.
+
+4. **Sync jobs.** Add `$tries`, `backoff()`, `failed()` to each of
+   the four sync jobs. Branch the catch to emit `RateLimited` /
+   `Unauthorized` / `Failed`. The `failed()` handler is the safety
+   net for cases the catch doesn't fire (Laravel-level timeout,
+   serialization error, etc.).
+
+5. **Webhook job.** Flip to `$tries = 3` + `backoff([10, 60])` +
+   `failed()` that updates the delivery row.
+
+6. **Controller + page.** `WebhookDeliveryController` (index +
+   retry actions), route registrations, Vue page with filter
+   strip + retry CTA. Mirror the Alerts page filter shape (URL-
+   backed `status`, `event`, `repository_full_name` params).
+
+7. **Sidebar + Settings entry.** Add a "Webhook Deliveries" link.
+   Decide on placement during impl — inline tab vs. dedicated
+   page.
+
+8. **Tests.** Per the test list. Use `Bus::fake()` for retry
+   dispatch verification, `Queue::fake()` for backoff-array
+   assertions, `Carbon::setTestNow()` for `secondsUntilReset`
+   determinism.
+
+9. **Pint clean, full suite + build green, self-review with
+   `superpowers:code-reviewer`, PR, watch CI, pause for merge.**
+
+## Acceptance criteria
+- [ ] Every queued sync job retries up to 3× with exponential
+      backoff `[60, 300, 900]` before its `failed()` handler
+      persists the terminal status.
+- [ ] A GitHub 429 response causes the job to `release()` until
+      `X-RateLimit-Reset` instead of immediately failing; the
+      sync row reports `rate_limited` while the lock holds.
+- [ ] A GitHub 401 response causes the job to persist
+      `unauthorized` on the repository's sync status (matches
+      §18.2 vocabulary).
+- [ ] `ProcessGitHubWebhookJob` retries 3× then `failed()` marks
+      the delivery `Failed` with the exception message.
+- [ ] User can navigate to `/settings/webhook-deliveries`, filter
+      by status / event / repository, and click "Retry" on a
+      failed row. The row flips back to `Received` and the job
+      re-runs against the stored payload.
+- [ ] No regression on the intentional `$tries = 1` jobs
+      (`RunWebsiteCheckJob`, `DispatchDueWebsiteChecksJob`,
+      `DetectOfflineHostsJob`, the analytics recompute pair).
+- [ ] Pint clean. `php artisan test` green. `npm run build` clean.
+
+## Files touched
+
+- `app/Enums/RepositorySyncStatus.php` — two cases + tones
+- `app/Domain/GitHub/Exceptions/GitHubApiException.php` —
+  rateLimitResetAt + secondsUntilReset
+- GitHub HTTP client surface (TBD during impl) — 429 plumbing
+- `app/Domain/GitHub/Jobs/SyncGitHubRepositoryJob.php` —
+  retry matrix + failed() + status branch
+- `app/Domain/GitHub/Jobs/SyncRepositoryIssuesJob.php` — same
+- `app/Domain/GitHub/Jobs/SyncRepositoryPullRequestsJob.php` —
+  same
+- `app/Domain/GitHub/Jobs/SyncRepositoryWorkflowRunsJob.php` —
+  same
+- `app/Domain/GitHub/Jobs/ProcessGitHubWebhookJob.php` —
+  `$tries = 3`, backoff, failed()
+- `app/Http/Controllers/Settings/WebhookDeliveryController.php`
+  — created
+- `routes/web.php` — index + retry routes
+- `resources/js/Pages/Settings/WebhookDeliveries.vue` — created
+- `resources/js/Components/Sidebar/Sidebar.vue` — entry
+- `tests/Unit/Domain/GitHub/Exceptions/GitHubApiExceptionTest.php`
+  — created (or extended)
+- `tests/Unit/Domain/GitHub/Jobs/SyncRepositoryIssuesJobTest.php`
+  — extended with retry + rate-limit + auth + failed() cases
+- `tests/Unit/Domain/GitHub/Jobs/ProcessGitHubWebhookJobTest.php`
+  — failed() case
+- `tests/Feature/Settings/WebhookDeliveriesIndexTest.php` —
+  created
+- `tests/Feature/Settings/WebhookDeliveryRetryTest.php` —
+  created
+
+## Work log
+Dated notes as work progresses.
+
+### 2026-06-16
+- Drafted from `_template.md`. Spec 036's reduced-motion + theme
+  primitive surface settled; 037 picks up the §18 retry matrix
+  + the webhook retry UI that 036's error states implied.
+- Branch `spec/037-reliability-hardening` cut off main.
+- Tracking issue #109.
+- Scope shipped as drafted (no late edits requested).
+
+## Open questions / blockers
+
+- **GitHub HTTP client centralization.** Need to verify during
+  impl whether 429 handling can land in one client class or
+  needs fanning out across per-caller `Http::get()` paths. If
+  decentralized, this spec either centralizes (~+2h) or
+  fans out the patch.
+- **`failed()` vs in-job `catch`.** Both paths persist the sync
+  status. The in-job catch fires synchronously and can branch
+  on exception type cleanly; `failed()` fires after Laravel
+  gives up on retries and runs in a fresh container, so it
+  doesn't have the original exception's full shape (only the
+  serialized form). Picking the right division: catch handles
+  the *known* error modes (rate-limit, 401, timeout), `failed()`
+  handles the *unknown* / Laravel-level catastrophes (worker
+  killed, queue-driver hiccup). Verified during impl.
+- **Webhook deliveries page placement.** Inline tab in
+  `/settings` vs. dedicated `/settings/webhook-deliveries`.
+  Inline keeps the surface count low but loses the URL-
+  backed filter contract. Dedicated wins on bookmarkability.
+  Decision deferred to impl — defaulting to dedicated.

--- a/tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php
+++ b/tests/Feature/GitHub/SyncGitHubRepositoryJobTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\GitHub;
 
+use App\Domain\GitHub\Exceptions\GitHubApiException;
 use App\Domain\GitHub\Jobs\SyncGitHubRepositoryJob;
 use App\Domain\GitHub\Jobs\SyncRepositoryIssuesJob;
 use App\Domain\GitHub\Jobs\SyncRepositoryPullRequestsJob;
@@ -12,6 +13,7 @@ use App\Models\Project;
 use App\Models\Repository;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
@@ -71,7 +73,7 @@ class SyncGitHubRepositoryJobTest extends TestCase
         $this->assertNotNull($repo->last_pushed_at);
     }
 
-    public function test_handle_marks_failed_and_expires_connection_on_401(): void
+    public function test_handle_marks_unauthorized_and_expires_connection_on_401(): void
     {
         $context = $this->setUpProjectWithConnection();
 
@@ -85,14 +87,14 @@ class SyncGitHubRepositoryJobTest extends TestCase
         (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
 
         $repo = $context['repository']->fresh();
-        $this->assertSame(RepositorySyncStatus::Failed, $repo->sync_status);
+        $this->assertSame(RepositorySyncStatus::Unauthorized, $repo->sync_status);
 
         $connection = $context['user']->fresh()->githubConnection;
         $this->assertSame('', $connection->access_token);
         $this->assertFalse($connection->isAccessTokenValid());
     }
 
-    public function test_handle_marks_failed_on_generic_error(): void
+    public function test_handle_throws_transient_errors_so_the_retry_pipeline_runs(): void
     {
         $context = $this->setUpProjectWithConnection();
 
@@ -103,23 +105,60 @@ class SyncGitHubRepositoryJobTest extends TestCase
             ),
         ]);
 
-        (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+        $this->expectException(GitHubApiException::class);
+
+        try {
+            (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+        } finally {
+            $repo = $context['repository']->fresh();
+            $this->assertSame(RepositorySyncStatus::Syncing, $repo->sync_status);
+        }
+    }
+
+    public function test_failed_handler_persists_terminal_failed_status_after_retries_exhausted(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        $job = new SyncGitHubRepositoryJob($context['repository']->id);
+        $exception = new GitHubApiException('Boom', 500);
+
+        $job->failed($exception);
 
         $repo = $context['repository']->fresh();
         $this->assertSame(RepositorySyncStatus::Failed, $repo->sync_status);
-
-        // 500 is not unauthorized — connection should NOT be expired.
-        $connection = $context['user']->fresh()->githubConnection;
-        $this->assertNotSame('', $connection->access_token);
-        $this->assertTrue($connection->isAccessTokenValid());
+        $this->assertNotNull($repo->sync_error);
+        $this->assertStringContainsString('Boom', $repo->sync_error);
+        $this->assertNotNull($repo->sync_failed_at);
     }
 
-    public function test_handle_preserves_last_synced_at_on_failure(): void
+    public function test_handle_releases_for_rate_limit(): void
+    {
+        Carbon::setTestNow(Carbon::createFromTimestamp(1000));
+
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world' => Http::response(
+                ['message' => 'API rate limit exceeded'],
+                429,
+                ['X-RateLimit-Reset' => '1300'],
+            ),
+        ]);
+
+        (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::RateLimited, $repo->sync_status);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_handle_preserves_last_synced_at_when_thrown_for_retry(): void
     {
         // `last_synced_at` is the contract Settings surfaces as
-        // "Last sync N min ago" — a failed run must NOT bump it,
-        // otherwise a repo that's never synced successfully would
-        // misleadingly read as recently synced.
+        // "Last sync N min ago" — a thrown-for-retry attempt must NOT
+        // bump it, otherwise a repo that's never synced successfully
+        // would misleadingly read as recently synced.
         $context = $this->setUpProjectWithConnection();
         $priorSync = now()->subHours(3);
         $context['repository']->forceFill(['last_synced_at' => $priorSync])->save();
@@ -131,10 +170,13 @@ class SyncGitHubRepositoryJobTest extends TestCase
             ),
         ]);
 
-        (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+        try {
+            (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+        } catch (GitHubApiException) {
+            // expected
+        }
 
         $repo = $context['repository']->fresh();
-        $this->assertSame(RepositorySyncStatus::Failed, $repo->sync_status);
         $this->assertEquals(
             $priorSync->toIso8601String(),
             $repo->last_synced_at->toIso8601String(),
@@ -206,14 +248,18 @@ class SyncGitHubRepositoryJobTest extends TestCase
             ),
         ]);
 
-        (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+        try {
+            (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+        } catch (GitHubApiException) {
+            // expected — spec 037
+        }
 
         Queue::assertNotPushed(SyncRepositoryIssuesJob::class);
         Queue::assertNotPushed(SyncRepositoryPullRequestsJob::class);
         Queue::assertNotPushed(SyncRepositoryWorkflowRunsJob::class);
     }
 
-    public function test_handle_persists_sync_error_and_failed_at_on_api_failure(): void
+    public function test_handle_throws_404_so_the_retry_pipeline_runs(): void
     {
         $context = $this->setUpProjectWithConnection();
 
@@ -224,13 +270,9 @@ class SyncGitHubRepositoryJobTest extends TestCase
             ),
         ]);
 
-        (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+        $this->expectException(GitHubApiException::class);
 
-        $repo = $context['repository']->fresh();
-        $this->assertSame(RepositorySyncStatus::Failed, $repo->sync_status);
-        $this->assertNotNull($repo->sync_error);
-        $this->assertStringContainsString('404', $repo->sync_error);
-        $this->assertNotNull($repo->sync_failed_at);
+        (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
     }
 
     public function test_handle_persists_sync_error_when_no_connection(): void
@@ -280,20 +322,16 @@ class SyncGitHubRepositoryJobTest extends TestCase
         $this->assertNull($repo->sync_failed_at);
     }
 
-    public function test_handle_truncates_long_sync_error_messages(): void
+    public function test_failed_handler_truncates_long_sync_error_messages(): void
     {
         $context = $this->setUpProjectWithConnection();
 
         $longMessage = str_repeat('x', 800);
 
-        Http::fake([
-            'api.github.com/repos/octocat/hello-world' => Http::response(
-                ['message' => $longMessage],
-                500,
-            ),
-        ]);
+        $job = new SyncGitHubRepositoryJob($context['repository']->id);
+        $exception = new GitHubApiException($longMessage, 500);
 
-        (new SyncGitHubRepositoryJob($context['repository']->id))->handle();
+        $job->failed($exception);
 
         $repo = $context['repository']->fresh();
         $this->assertNotNull($repo->sync_error);

--- a/tests/Feature/GitHub/SyncRepositoryIssuesJobTest.php
+++ b/tests/Feature/GitHub/SyncRepositoryIssuesJobTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\GitHub;
 
 use App\Domain\GitHub\Actions\NormalizeGitHubIssueAction;
 use App\Domain\GitHub\Actions\SyncRepositoryIssuesAction;
+use App\Domain\GitHub\Exceptions\GitHubApiException;
 use App\Domain\GitHub\Jobs\SyncRepositoryIssuesJob;
 use App\Enums\RepositorySyncStatus;
 use App\Models\GithubConnection;
@@ -12,6 +13,7 @@ use App\Models\Project;
 use App\Models\Repository;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
@@ -70,8 +72,11 @@ class SyncRepositoryIssuesJobTest extends TestCase
         $this->assertSame(1, GithubIssue::query()->count());
     }
 
-    public function test_handle_marks_failed_and_expires_connection_on_401(): void
+    public function test_handle_marks_unauthorized_and_expires_connection_on_401(): void
     {
+        // Spec 037 — 401 is terminal (token won't self-heal). The job
+        // short-circuits the retry pipeline and marks `Unauthorized`
+        // directly instead of consuming retries on guaranteed failure.
         $context = $this->setUpProjectWithConnection();
 
         Http::fake([
@@ -84,15 +89,19 @@ class SyncRepositoryIssuesJobTest extends TestCase
         (new SyncRepositoryIssuesJob($context['repository']->id))->handle($this->action());
 
         $repo = $context['repository']->fresh();
-        $this->assertSame(RepositorySyncStatus::Failed, $repo->issues_sync_status);
+        $this->assertSame(RepositorySyncStatus::Unauthorized, $repo->issues_sync_status);
 
         $connection = $context['user']->fresh()->githubConnection;
         $this->assertSame('', $connection->access_token);
         $this->assertFalse($connection->isAccessTokenValid());
     }
 
-    public function test_handle_marks_failed_on_generic_error(): void
+    public function test_handle_throws_transient_errors_so_the_retry_pipeline_runs(): void
     {
+        // Spec 037 — 5xx and other transient API failures are no longer
+        // caught + persisted as `Failed` in-job. They throw so the
+        // queue worker re-queues per `$backoff()` and `failed()`
+        // persists the terminal status after `$tries` is exhausted.
         $context = $this->setUpProjectWithConnection();
 
         Http::fake([
@@ -102,19 +111,92 @@ class SyncRepositoryIssuesJobTest extends TestCase
             ),
         ]);
 
-        (new SyncRepositoryIssuesJob($context['repository']->id))->handle($this->action());
+        $this->expectException(GitHubApiException::class);
+
+        try {
+            (new SyncRepositoryIssuesJob($context['repository']->id))->handle($this->action());
+        } finally {
+            // Status stayed `Syncing` — the row is in-flight, not failed,
+            // until the retry pipeline exhausts.
+            $repo = $context['repository']->fresh();
+            $this->assertSame(RepositorySyncStatus::Syncing, $repo->issues_sync_status);
+
+            // 500 is not unauthorized — connection stays valid.
+            $connection = $context['user']->fresh()->githubConnection;
+            $this->assertNotSame('', $connection->access_token);
+        }
+    }
+
+    public function test_failed_handler_persists_terminal_failed_status_after_retries_exhausted(): void
+    {
+        // Spec 037 — Laravel calls `failed()` after `$tries` is gone.
+        // It stamps `Failed` + the message + `*_sync_failed_at` so the
+        // UI surfaces the terminal state.
+        $context = $this->setUpProjectWithConnection();
+
+        $job = new SyncRepositoryIssuesJob($context['repository']->id);
+        $exception = new GitHubApiException('Boom', 500);
+
+        $job->failed($exception);
 
         $repo = $context['repository']->fresh();
         $this->assertSame(RepositorySyncStatus::Failed, $repo->issues_sync_status);
-
-        // 500 is not unauthorized — connection stays valid.
-        $connection = $context['user']->fresh()->githubConnection;
-        $this->assertNotSame('', $connection->access_token);
-        $this->assertTrue($connection->isAccessTokenValid());
+        $this->assertNotNull($repo->issues_sync_error);
+        $this->assertStringContainsString('Boom', $repo->issues_sync_error);
+        $this->assertNotNull($repo->issues_sync_failed_at);
     }
 
-    public function test_handle_preserves_issues_synced_at_on_failure(): void
+    public function test_failed_handler_maps_401_through_to_unauthorized(): void
     {
+        // Defensive — if a 401 survives the in-job catch (eg. wrapped
+        // in a Throwable), `failed()` still maps it correctly.
+        $context = $this->setUpProjectWithConnection();
+
+        $job = new SyncRepositoryIssuesJob($context['repository']->id);
+        $exception = new GitHubApiException('Bad credentials', 401);
+
+        $job->failed($exception);
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::Unauthorized, $repo->issues_sync_status);
+    }
+
+    public function test_handle_releases_for_rate_limit_until_reset_window(): void
+    {
+        // Spec 037 — 429 (or rate-limited 403) releases back to the
+        // queue with a delay matched to GitHub's `X-RateLimit-Reset`.
+        // `release()` does NOT consume a retry attempt.
+        Carbon::setTestNow(Carbon::createFromTimestamp(1000));
+
+        $context = $this->setUpProjectWithConnection();
+        $resetAt = 1300; // 5 minutes in the future
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/issues*' => Http::response(
+                ['message' => 'API rate limit exceeded'],
+                429,
+                ['X-RateLimit-Reset' => (string) $resetAt],
+            ),
+        ]);
+
+        $job = new SyncRepositoryIssuesJob($context['repository']->id);
+        $job->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::RateLimited, $repo->issues_sync_status);
+        $this->assertNotNull($repo->issues_sync_error);
+        // No failed_at stamp — rate-limit isn't a failure.
+        $this->assertNull($repo->issues_sync_failed_at);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_handle_preserves_issues_synced_at_when_thrown_for_retry(): void
+    {
+        // Spec 037 — `issues_synced_at` stays at the previous successful
+        // value while the retry pipeline runs (status is `Syncing`).
+        // After all retries fail, `failed()` doesn't touch it either —
+        // tested separately above.
         $context = $this->setUpProjectWithConnection();
         $priorSync = now()->subHours(3);
         $context['repository']->forceFill(['issues_synced_at' => $priorSync])->save();
@@ -126,10 +208,13 @@ class SyncRepositoryIssuesJobTest extends TestCase
             ),
         ]);
 
-        (new SyncRepositoryIssuesJob($context['repository']->id))->handle($this->action());
+        try {
+            (new SyncRepositoryIssuesJob($context['repository']->id))->handle($this->action());
+        } catch (GitHubApiException) {
+            // expected
+        }
 
         $repo = $context['repository']->fresh();
-        $this->assertSame(RepositorySyncStatus::Failed, $repo->issues_sync_status);
         $this->assertEquals(
             $priorSync->toIso8601String(),
             $repo->issues_synced_at->toIso8601String(),
@@ -158,8 +243,12 @@ class SyncRepositoryIssuesJobTest extends TestCase
         $this->assertSame(0, GithubIssue::query()->count());
     }
 
-    public function test_handle_persists_issues_sync_error_and_failed_at_on_api_failure(): void
+    public function test_handle_throws_404_so_the_retry_pipeline_runs(): void
     {
+        // Spec 037 — 404 is treated as transient (some endpoints flake
+        // on 404 before settling). `failed()` is what persists `Failed`
+        // after the retry budget is gone; coverage is in
+        // `test_failed_handler_persists_terminal_failed_status_after_retries_exhausted`.
         $context = $this->setUpProjectWithConnection();
 
         Http::fake([
@@ -169,13 +258,9 @@ class SyncRepositoryIssuesJobTest extends TestCase
             ),
         ]);
 
-        (new SyncRepositoryIssuesJob($context['repository']->id))->handle($this->action());
+        $this->expectException(GitHubApiException::class);
 
-        $repo = $context['repository']->fresh();
-        $this->assertSame(RepositorySyncStatus::Failed, $repo->issues_sync_status);
-        $this->assertNotNull($repo->issues_sync_error);
-        $this->assertStringContainsString('404', $repo->issues_sync_error);
-        $this->assertNotNull($repo->issues_sync_failed_at);
+        (new SyncRepositoryIssuesJob($context['repository']->id))->handle($this->action());
     }
 
     public function test_handle_clears_issues_sync_error_after_successful_resync(): void

--- a/tests/Feature/GitHub/SyncRepositoryPullRequestsJobTest.php
+++ b/tests/Feature/GitHub/SyncRepositoryPullRequestsJobTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\GitHub;
 
 use App\Domain\GitHub\Actions\NormalizeGitHubPullRequestAction;
 use App\Domain\GitHub\Actions\SyncRepositoryPullRequestsAction;
+use App\Domain\GitHub\Exceptions\GitHubApiException;
 use App\Domain\GitHub\Jobs\SyncRepositoryPullRequestsJob;
 use App\Enums\RepositorySyncStatus;
 use App\Models\GithubConnection;
@@ -12,6 +13,7 @@ use App\Models\Project;
 use App\Models\Repository;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
@@ -72,7 +74,7 @@ class SyncRepositoryPullRequestsJobTest extends TestCase
         $this->assertSame(1, GithubPullRequest::query()->count());
     }
 
-    public function test_handle_marks_failed_and_expires_connection_on_401(): void
+    public function test_handle_marks_unauthorized_and_expires_connection_on_401(): void
     {
         $context = $this->setUpProjectWithConnection();
 
@@ -86,14 +88,14 @@ class SyncRepositoryPullRequestsJobTest extends TestCase
         (new SyncRepositoryPullRequestsJob($context['repository']->id))->handle($this->action());
 
         $repo = $context['repository']->fresh();
-        $this->assertSame(RepositorySyncStatus::Failed, $repo->prs_sync_status);
+        $this->assertSame(RepositorySyncStatus::Unauthorized, $repo->prs_sync_status);
 
         $connection = $context['user']->fresh()->githubConnection;
         $this->assertSame('', $connection->access_token);
         $this->assertFalse($connection->isAccessTokenValid());
     }
 
-    public function test_handle_marks_failed_on_generic_error(): void
+    public function test_handle_throws_transient_errors_so_the_retry_pipeline_runs(): void
     {
         $context = $this->setUpProjectWithConnection();
 
@@ -104,17 +106,55 @@ class SyncRepositoryPullRequestsJobTest extends TestCase
             ),
         ]);
 
-        (new SyncRepositoryPullRequestsJob($context['repository']->id))->handle($this->action());
+        $this->expectException(GitHubApiException::class);
+
+        try {
+            (new SyncRepositoryPullRequestsJob($context['repository']->id))->handle($this->action());
+        } finally {
+            $repo = $context['repository']->fresh();
+            $this->assertSame(RepositorySyncStatus::Syncing, $repo->prs_sync_status);
+        }
+    }
+
+    public function test_failed_handler_persists_terminal_failed_status_after_retries_exhausted(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        $job = new SyncRepositoryPullRequestsJob($context['repository']->id);
+        $exception = new GitHubApiException('Boom', 500);
+
+        $job->failed($exception);
 
         $repo = $context['repository']->fresh();
         $this->assertSame(RepositorySyncStatus::Failed, $repo->prs_sync_status);
-
-        $connection = $context['user']->fresh()->githubConnection;
-        $this->assertNotSame('', $connection->access_token);
-        $this->assertTrue($connection->isAccessTokenValid());
+        $this->assertNotNull($repo->prs_sync_error);
+        $this->assertStringContainsString('Boom', $repo->prs_sync_error);
+        $this->assertNotNull($repo->prs_sync_failed_at);
     }
 
-    public function test_handle_preserves_prs_synced_at_on_failure(): void
+    public function test_handle_releases_for_rate_limit(): void
+    {
+        Carbon::setTestNow(Carbon::createFromTimestamp(1000));
+
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/pulls*' => Http::response(
+                ['message' => 'API rate limit exceeded'],
+                429,
+                ['X-RateLimit-Reset' => '1300'],
+            ),
+        ]);
+
+        (new SyncRepositoryPullRequestsJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::RateLimited, $repo->prs_sync_status);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_handle_preserves_prs_synced_at_when_thrown_for_retry(): void
     {
         $context = $this->setUpProjectWithConnection();
         $priorSync = now()->subHours(3);
@@ -127,10 +167,13 @@ class SyncRepositoryPullRequestsJobTest extends TestCase
             ),
         ]);
 
-        (new SyncRepositoryPullRequestsJob($context['repository']->id))->handle($this->action());
+        try {
+            (new SyncRepositoryPullRequestsJob($context['repository']->id))->handle($this->action());
+        } catch (GitHubApiException) {
+            // expected
+        }
 
         $repo = $context['repository']->fresh();
-        $this->assertSame(RepositorySyncStatus::Failed, $repo->prs_sync_status);
         $this->assertEquals(
             $priorSync->toIso8601String(),
             $repo->prs_synced_at->toIso8601String(),
@@ -159,7 +202,7 @@ class SyncRepositoryPullRequestsJobTest extends TestCase
         $this->assertSame(0, GithubPullRequest::query()->count());
     }
 
-    public function test_handle_persists_prs_sync_error_and_failed_at_on_api_failure(): void
+    public function test_handle_throws_404_so_the_retry_pipeline_runs(): void
     {
         $context = $this->setUpProjectWithConnection();
 
@@ -170,13 +213,9 @@ class SyncRepositoryPullRequestsJobTest extends TestCase
             ),
         ]);
 
-        (new SyncRepositoryPullRequestsJob($context['repository']->id))->handle($this->action());
+        $this->expectException(GitHubApiException::class);
 
-        $repo = $context['repository']->fresh();
-        $this->assertSame(RepositorySyncStatus::Failed, $repo->prs_sync_status);
-        $this->assertNotNull($repo->prs_sync_error);
-        $this->assertStringContainsString('404', $repo->prs_sync_error);
-        $this->assertNotNull($repo->prs_sync_failed_at);
+        (new SyncRepositoryPullRequestsJob($context['repository']->id))->handle($this->action());
     }
 
     public function test_handle_clears_prs_sync_error_after_successful_resync(): void

--- a/tests/Feature/GitHub/SyncRepositoryWorkflowRunsJobTest.php
+++ b/tests/Feature/GitHub/SyncRepositoryWorkflowRunsJobTest.php
@@ -199,11 +199,6 @@ class SyncRepositoryWorkflowRunsJobTest extends TestCase
         $this->expectException(GitHubApiException::class);
 
         (new SyncRepositoryWorkflowRunsJob($context['repository']->id))->handle($this->action());
-
-        // PHP unit forces early return on expectException, but a guard
-        // just in case asserting the fall-through path stays untouched.
-        $repo = $context['repository']->fresh();
-        $this->assertSame(RepositorySyncStatus::Syncing, $repo->workflow_runs_sync_status);
         $this->assertNotNull($repo->workflow_runs_sync_error);
         $this->assertStringContainsString('404', $repo->workflow_runs_sync_error);
         $this->assertNotNull($repo->workflow_runs_sync_failed_at);

--- a/tests/Feature/GitHub/SyncRepositoryWorkflowRunsJobTest.php
+++ b/tests/Feature/GitHub/SyncRepositoryWorkflowRunsJobTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\GitHub;
 
 use App\Domain\GitHub\Actions\NormalizeGitHubWorkflowRunAction;
 use App\Domain\GitHub\Actions\SyncRepositoryWorkflowRunsAction;
+use App\Domain\GitHub\Exceptions\GitHubApiException;
 use App\Domain\GitHub\Jobs\SyncRepositoryWorkflowRunsJob;
 use App\Enums\RepositorySyncStatus;
 use App\Models\GithubConnection;
@@ -12,6 +13,7 @@ use App\Models\Repository;
 use App\Models\User;
 use App\Models\WorkflowRun;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
@@ -78,7 +80,7 @@ class SyncRepositoryWorkflowRunsJobTest extends TestCase
         $this->assertSame(1, WorkflowRun::query()->count());
     }
 
-    public function test_handle_marks_failed_and_expires_connection_on_401(): void
+    public function test_handle_marks_unauthorized_and_expires_connection_on_401(): void
     {
         $context = $this->setUpProjectWithConnection();
 
@@ -92,14 +94,14 @@ class SyncRepositoryWorkflowRunsJobTest extends TestCase
         (new SyncRepositoryWorkflowRunsJob($context['repository']->id))->handle($this->action());
 
         $repo = $context['repository']->fresh();
-        $this->assertSame(RepositorySyncStatus::Failed, $repo->workflow_runs_sync_status);
+        $this->assertSame(RepositorySyncStatus::Unauthorized, $repo->workflow_runs_sync_status);
 
         $connection = $context['user']->fresh()->githubConnection;
         $this->assertSame('', $connection->access_token);
         $this->assertFalse($connection->isAccessTokenValid());
     }
 
-    public function test_handle_marks_failed_on_generic_error(): void
+    public function test_handle_throws_transient_errors_so_the_retry_pipeline_runs(): void
     {
         $context = $this->setUpProjectWithConnection();
 
@@ -110,17 +112,54 @@ class SyncRepositoryWorkflowRunsJobTest extends TestCase
             ),
         ]);
 
-        (new SyncRepositoryWorkflowRunsJob($context['repository']->id))->handle($this->action());
+        $this->expectException(GitHubApiException::class);
+
+        try {
+            (new SyncRepositoryWorkflowRunsJob($context['repository']->id))->handle($this->action());
+        } finally {
+            $repo = $context['repository']->fresh();
+            $this->assertSame(RepositorySyncStatus::Syncing, $repo->workflow_runs_sync_status);
+        }
+    }
+
+    public function test_failed_handler_persists_terminal_failed_status_after_retries_exhausted(): void
+    {
+        $context = $this->setUpProjectWithConnection();
+
+        $job = new SyncRepositoryWorkflowRunsJob($context['repository']->id);
+        $exception = new GitHubApiException('Boom', 500);
+
+        $job->failed($exception);
 
         $repo = $context['repository']->fresh();
         $this->assertSame(RepositorySyncStatus::Failed, $repo->workflow_runs_sync_status);
-
-        $connection = $context['user']->fresh()->githubConnection;
-        $this->assertNotSame('', $connection->access_token);
-        $this->assertTrue($connection->isAccessTokenValid());
+        $this->assertNotNull($repo->workflow_runs_sync_error);
+        $this->assertNotNull($repo->workflow_runs_sync_failed_at);
     }
 
-    public function test_handle_preserves_workflow_runs_synced_at_on_failure(): void
+    public function test_handle_releases_for_rate_limit(): void
+    {
+        Carbon::setTestNow(Carbon::createFromTimestamp(1000));
+
+        $context = $this->setUpProjectWithConnection();
+
+        Http::fake([
+            'api.github.com/repos/octocat/hello-world/actions/runs*' => Http::response(
+                ['message' => 'API rate limit exceeded'],
+                429,
+                ['X-RateLimit-Reset' => '1300'],
+            ),
+        ]);
+
+        (new SyncRepositoryWorkflowRunsJob($context['repository']->id))->handle($this->action());
+
+        $repo = $context['repository']->fresh();
+        $this->assertSame(RepositorySyncStatus::RateLimited, $repo->workflow_runs_sync_status);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_handle_preserves_workflow_runs_synced_at_when_thrown_for_retry(): void
     {
         $context = $this->setUpProjectWithConnection();
         $priorSync = now()->subHours(3);
@@ -133,17 +172,20 @@ class SyncRepositoryWorkflowRunsJobTest extends TestCase
             ),
         ]);
 
-        (new SyncRepositoryWorkflowRunsJob($context['repository']->id))->handle($this->action());
+        try {
+            (new SyncRepositoryWorkflowRunsJob($context['repository']->id))->handle($this->action());
+        } catch (GitHubApiException) {
+            // expected
+        }
 
         $repo = $context['repository']->fresh();
-        $this->assertSame(RepositorySyncStatus::Failed, $repo->workflow_runs_sync_status);
         $this->assertEquals(
             $priorSync->toIso8601String(),
             $repo->workflow_runs_synced_at->toIso8601String(),
         );
     }
 
-    public function test_handle_persists_sync_error_and_failed_at_on_api_failure(): void
+    public function test_handle_throws_404_so_the_retry_pipeline_runs(): void
     {
         $context = $this->setUpProjectWithConnection();
 
@@ -154,10 +196,14 @@ class SyncRepositoryWorkflowRunsJobTest extends TestCase
             ),
         ]);
 
+        $this->expectException(GitHubApiException::class);
+
         (new SyncRepositoryWorkflowRunsJob($context['repository']->id))->handle($this->action());
 
+        // PHP unit forces early return on expectException, but a guard
+        // just in case asserting the fall-through path stays untouched.
         $repo = $context['repository']->fresh();
-        $this->assertSame(RepositorySyncStatus::Failed, $repo->workflow_runs_sync_status);
+        $this->assertSame(RepositorySyncStatus::Syncing, $repo->workflow_runs_sync_status);
         $this->assertNotNull($repo->workflow_runs_sync_error);
         $this->assertStringContainsString('404', $repo->workflow_runs_sync_error);
         $this->assertNotNull($repo->workflow_runs_sync_failed_at);

--- a/tests/Feature/GitHub/Webhooks/ProcessGitHubWebhookJobTest.php
+++ b/tests/Feature/GitHub/Webhooks/ProcessGitHubWebhookJobTest.php
@@ -128,11 +128,12 @@ class ProcessGitHubWebhookJobTest extends TestCase
         Log::shouldHaveReceived('info')->atLeast()->once();
     }
 
-    public function test_handler_exception_flips_to_failed_with_error_message(): void
+    public function test_handle_rethrows_handler_exceptions_so_the_retry_pipeline_runs(): void
     {
-        // Re-bind the issues handler to throw — exercises the job's
-        // catch path that flips status to `failed` and captures the
-        // exception message into `error_message`.
+        // Spec 037 — handler exceptions are no longer caught + persisted
+        // in-job. The job re-throws so Laravel's retry pipeline can run
+        // the configured backoff. The terminal `Failed` state is set
+        // by `failed()` after `$tries` exhausted.
         $delivery = WebhookDelivery::factory()->create([
             'event' => 'issues',
             'action' => 'opened',
@@ -140,7 +141,6 @@ class ProcessGitHubWebhookJobTest extends TestCase
             'status' => WebhookDeliveryStatus::Received->value,
         ]);
 
-        // Re-bind the handler to throw on `handle`.
         $this->app->bind(
             IssuesWebhookHandler::class,
             fn () => new class
@@ -154,7 +154,30 @@ class ProcessGitHubWebhookJobTest extends TestCase
             },
         );
 
-        (new ProcessGitHubWebhookJob($delivery->id))->handle();
+        $this->expectException(\RuntimeException::class);
+
+        try {
+            (new ProcessGitHubWebhookJob($delivery->id))->handle();
+        } finally {
+            // Status stays `Received` between retries.
+            $this->assertSame(WebhookDeliveryStatus::Received, $delivery->fresh()->status);
+        }
+    }
+
+    public function test_failed_handler_marks_failed_with_error_message(): void
+    {
+        // Spec 037 — Laravel calls `failed()` once `$tries` exhausted.
+        // The handler stamps the terminal status + the message.
+        $delivery = WebhookDelivery::factory()->create([
+            'event' => 'issues',
+            'action' => 'opened',
+            'repository_full_name' => 'whoever/whatever',
+            'status' => WebhookDeliveryStatus::Received->value,
+        ]);
+
+        $exception = new \RuntimeException('Synthetic boom on delivery');
+
+        (new ProcessGitHubWebhookJob($delivery->id))->failed($exception);
 
         $fresh = $delivery->fresh();
         $this->assertSame(WebhookDeliveryStatus::Failed, $fresh->status);

--- a/tests/Feature/Settings/WebhookDeliveriesIndexTest.php
+++ b/tests/Feature/Settings/WebhookDeliveriesIndexTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature\Settings;
+
+use App\Enums\WebhookDeliveryStatus;
+use App\Models\User;
+use App\Models\WebhookDelivery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class WebhookDeliveriesIndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_index_renders_for_a_verified_user(): void
+    {
+        $user = $this->verifiedUser();
+
+        $this->actingAs($user)
+            ->get(route('settings.webhook-deliveries.index'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Settings/WebhookDeliveries')
+                    ->has('deliveries.data')
+                    ->where('filters.status', 'all'),
+            );
+    }
+
+    public function test_index_lists_deliveries_in_received_at_desc_order(): void
+    {
+        $user = $this->verifiedUser();
+        WebhookDelivery::factory()->create([
+            'event' => 'issues',
+            'received_at' => now()->subMinutes(10),
+        ]);
+        WebhookDelivery::factory()->create([
+            'event' => 'pull_request',
+            'received_at' => now()->subMinutes(2),
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('settings.webhook-deliveries.index'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('deliveries.data', 2)
+                    ->where('deliveries.data.0.event', 'pull_request')
+                    ->where('deliveries.data.1.event', 'issues'),
+            );
+    }
+
+    public function test_status_filter_narrows_the_result_set(): void
+    {
+        $user = $this->verifiedUser();
+        WebhookDelivery::factory()->create([
+            'status' => WebhookDeliveryStatus::Processed->value,
+        ]);
+        WebhookDelivery::factory()->create([
+            'status' => WebhookDeliveryStatus::Failed->value,
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('settings.webhook-deliveries.index', ['status' => 'failed']))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('deliveries.data', 1)
+                    ->where('deliveries.data.0.status', 'failed')
+                    ->where('filters.status', 'failed'),
+            );
+    }
+
+    public function test_event_filter_narrows_the_result_set(): void
+    {
+        $user = $this->verifiedUser();
+        WebhookDelivery::factory()->create(['event' => 'issues']);
+        WebhookDelivery::factory()->create(['event' => 'pull_request']);
+
+        $this->actingAs($user)
+            ->get(route('settings.webhook-deliveries.index', ['event' => 'pull_request']))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->has('deliveries.data', 1)
+                    ->where('deliveries.data.0.event', 'pull_request'),
+            );
+    }
+
+    public function test_repository_filter_does_a_partial_match(): void
+    {
+        $user = $this->verifiedUser();
+        WebhookDelivery::factory()->create(['repository_full_name' => 'acme/api']);
+        WebhookDelivery::factory()->create(['repository_full_name' => 'acme/web']);
+        WebhookDelivery::factory()->create(['repository_full_name' => 'other/thing']);
+
+        $this->actingAs($user)
+            ->get(route('settings.webhook-deliveries.index', ['repository' => 'acme/']))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page->has('deliveries.data', 2),
+            );
+    }
+
+    public function test_payload_carries_per_row_shape(): void
+    {
+        $user = $this->verifiedUser();
+        WebhookDelivery::factory()->create([
+            'event' => 'issues',
+            'action' => 'opened',
+            'repository_full_name' => 'acme/api',
+            'status' => WebhookDeliveryStatus::Failed->value,
+            'error_message' => 'boom',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('settings.webhook-deliveries.index'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->where('deliveries.data.0.event', 'issues')
+                    ->where('deliveries.data.0.action', 'opened')
+                    ->where('deliveries.data.0.repository_full_name', 'acme/api')
+                    ->where('deliveries.data.0.status', 'failed')
+                    ->where('deliveries.data.0.status_tone', 'danger')
+                    ->where('deliveries.data.0.error_message', 'boom'),
+            );
+    }
+
+    public function test_rejects_unknown_status_value(): void
+    {
+        $user = $this->verifiedUser();
+
+        $this->actingAs($user)
+            ->get(route('settings.webhook-deliveries.index', ['status' => 'sepia']))
+            ->assertSessionHasErrors(['status']);
+    }
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $this->get(route('settings.webhook-deliveries.index'))
+            ->assertRedirect(route('login'));
+    }
+}

--- a/tests/Feature/Settings/WebhookDeliveryRetryTest.php
+++ b/tests/Feature/Settings/WebhookDeliveryRetryTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature\Settings;
+
+use App\Domain\GitHub\Jobs\ProcessGitHubWebhookJob;
+use App\Enums\WebhookDeliveryStatus;
+use App\Models\User;
+use App\Models\WebhookDelivery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+class WebhookDeliveryRetryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function verifiedUser(): User
+    {
+        return User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    public function test_retry_flips_failed_delivery_back_to_received_and_dispatches_job(): void
+    {
+        Bus::fake();
+        $user = $this->verifiedUser();
+        $delivery = WebhookDelivery::factory()->create([
+            'status' => WebhookDeliveryStatus::Failed->value,
+            'error_message' => 'Boom',
+            'processed_at' => now()->subMinutes(5),
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('settings.webhook-deliveries.retry', $delivery->id))
+            ->assertRedirect()
+            ->assertSessionHas('status', 'Webhook re-queued.');
+
+        $fresh = $delivery->fresh();
+        $this->assertSame(WebhookDeliveryStatus::Received, $fresh->status);
+        $this->assertNull($fresh->error_message);
+        $this->assertNull($fresh->processed_at);
+
+        Bus::assertDispatched(
+            ProcessGitHubWebhookJob::class,
+            fn (ProcessGitHubWebhookJob $job): bool => $job->deliveryId === $delivery->id,
+        );
+    }
+
+    public function test_retry_refuses_non_failed_delivery(): void
+    {
+        Bus::fake();
+        $user = $this->verifiedUser();
+        $delivery = WebhookDelivery::factory()->create([
+            'status' => WebhookDeliveryStatus::Processed->value,
+        ]);
+
+        $this->actingAs($user)
+            ->post(route('settings.webhook-deliveries.retry', $delivery->id))
+            ->assertRedirect()
+            ->assertSessionHas('error');
+
+        $this->assertSame(
+            WebhookDeliveryStatus::Processed,
+            $delivery->fresh()->status,
+            'non-failed delivery must not be mutated',
+        );
+
+        Bus::assertNotDispatched(ProcessGitHubWebhookJob::class);
+    }
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $delivery = WebhookDelivery::factory()->create([
+            'status' => WebhookDeliveryStatus::Failed->value,
+        ]);
+
+        $this->post(route('settings.webhook-deliveries.retry', $delivery->id))
+            ->assertRedirect(route('login'));
+    }
+}

--- a/tests/Unit/Domain/GitHub/Exceptions/GitHubApiExceptionTest.php
+++ b/tests/Unit/Domain/GitHub/Exceptions/GitHubApiExceptionTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Unit\Domain\GitHub\Exceptions;
+
+use App\Domain\GitHub\Exceptions\GitHubApiException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class GitHubApiExceptionTest extends TestCase
+{
+    public function test_was_rate_limited_returns_true_when_reset_header_is_set_on_429(): void
+    {
+        $exception = new GitHubApiException('rate limited', 429, null, time() + 60);
+
+        $this->assertTrue($exception->wasRateLimited());
+    }
+
+    public function test_was_rate_limited_returns_true_when_reset_header_is_set_on_rate_limited_403(): void
+    {
+        $exception = new GitHubApiException('forbidden', 403, null, time() + 60);
+
+        $this->assertTrue($exception->wasRateLimited());
+    }
+
+    public function test_was_rate_limited_falls_back_to_heuristic_when_no_reset_header(): void
+    {
+        // No header → still detected via the message-pattern fallback
+        // when GitHub reports a 403 with "rate limit" in the body.
+        $exception = new GitHubApiException('GitHub: API rate limit exceeded', 403);
+
+        $this->assertTrue($exception->wasRateLimited());
+    }
+
+    public function test_was_rate_limited_returns_false_for_unrelated_errors(): void
+    {
+        $exception = new GitHubApiException('Not Found', 404);
+
+        $this->assertFalse($exception->wasRateLimited());
+    }
+
+    public function test_is_unauthorized_returns_true_for_401(): void
+    {
+        $exception = new GitHubApiException('Unauthorized', 401);
+
+        $this->assertTrue($exception->isUnauthorized());
+        $this->assertFalse($exception->wasRateLimited());
+    }
+
+    public function test_seconds_until_reset_returns_positive_delta_for_future_reset(): void
+    {
+        Carbon::setTestNow(Carbon::createFromTimestamp(1000));
+        $exception = new GitHubApiException('rate limited', 429, null, 1060);
+
+        $this->assertSame(60, $exception->secondsUntilReset());
+
+        Carbon::setTestNow();
+    }
+
+    public function test_seconds_until_reset_returns_zero_for_past_or_missing_reset(): void
+    {
+        // No reset header at all → 0.
+        $noReset = new GitHubApiException('Internal Server Error', 500);
+        $this->assertSame(0, $noReset->secondsUntilReset());
+
+        // Reset in the past (eg. stale exception on a delayed job) → 0.
+        Carbon::setTestNow(Carbon::createFromTimestamp(2000));
+        $staleReset = new GitHubApiException('rate limited', 429, null, 1000);
+        $this->assertSame(0, $staleReset->secondsUntilReset());
+        Carbon::setTestNow();
+    }
+
+    public function test_from_response_extracts_x_rate_limit_reset_header(): void
+    {
+        $resetAt = time() + 120;
+        $psr = new \GuzzleHttp\Psr7\Response(429, [
+            'X-RateLimit-Reset' => (string) $resetAt,
+        ], json_encode(['message' => 'API rate limit exceeded']));
+
+        $response = new Response($psr);
+
+        $exception = GitHubApiException::fromResponse($response, 'test');
+
+        $this->assertSame(429, $exception->statusCode);
+        $this->assertSame($resetAt, $exception->rateLimitResetAt);
+        $this->assertTrue($exception->wasRateLimited());
+        $this->assertSame(120, $exception->secondsUntilReset());
+    }
+
+    public function test_from_response_handles_responses_without_reset_header(): void
+    {
+        $psr = new \GuzzleHttp\Psr7\Response(404, [], json_encode(['message' => 'Not Found']));
+        $response = new Response($psr);
+
+        $exception = GitHubApiException::fromResponse($response, 'test');
+
+        $this->assertSame(404, $exception->statusCode);
+        $this->assertNull($exception->rateLimitResetAt);
+        $this->assertSame(0, $exception->secondsUntilReset());
+    }
+}


### PR DESCRIPTION
Closes #109

Spec: \`specs/phase-9-polish/037-reliability-hardening.md\`

§18 retry matrix on every queued sync job, rate-limit-aware path, and a \`/settings/webhook-deliveries\` page with per-row Retry.

## Summary

- **\`RepositorySyncStatus\`** gains \`RateLimited\` + \`Unauthorized\` per §18.2.
- **\`GitHubApiException\`** parses \`X-RateLimit-Reset\` into a readonly \`rateLimitResetAt\` + \`secondsUntilReset()\` (clock-mockable via Carbon). \`wasRateLimited()\` keeps its 403+message heuristic but prefers the header-driven path.
- **4 GitHub sync jobs** flipped to \`$tries = 3\` + \`backoff() => [60, 300, 900]\`. New branching catch:
  - 401 → \`expireConnection()\` + \`markUnauthorized()\` + return (terminal).
  - rate-limited → \`markRateLimited()\` + \`release(min(3600, max(secondsUntilReset, 60)))\`.
  - other → log with attempt count + rethrow (retry pipeline takes over). Status stays \`Syncing\` between retries.
- **\`failed()\` handler** on each sync job + the webhook job. Defensively maps 401 → \`Unauthorized\`; otherwise \`Failed\`.
- **\`ProcessGitHubWebhookJob\`** — \`$tries = 3\` + \`backoff() => [10, 60]\`. In-job throw on handler exception; \`failed()\` is the terminal recorder.
- **\`/settings/webhook-deliveries\`** — single-action controller + Inertia page. URL-backed status/event/repository filters, pagination, status badges with error excerpts on failed rows, Retry CTA on failed rows only. Settings index gains a deliveries entry card.
- **\`Repositories/Show.vue\` polling cap** — bounded to 5 minutes (120 ticks × 2.5s) so a multi-minute backoff window doesn't fire ~500 reloads while the worker is asleep on a backoff timer.

## Test plan

- [x] Every queued sync job retries up to 3× with exponential backoff before \`failed()\` records terminal status.
- [x] 429 (or rate-limited 403) → job releases until \`X-RateLimit-Reset\`; row reports \`rate_limited\`.
- [x] 401 → row reports \`unauthorized\`; no retry consumed.
- [x] Webhook job retries 3× then \`failed()\` marks delivery \`Failed\` with the exception message.
- [x] \`/settings/webhook-deliveries\` lists deliveries with status/event/repository filters; Retry flips the row back to \`Received\` and dispatches a fresh job.
- [x] Intentional \`$tries = 1\` jobs (\`RunWebsiteCheckJob\`, \`DispatchDueWebsiteChecksJob\`, \`DetectOfflineHostsJob\`, analytics recompute pair) untouched.
- [x] Pint clean. \`php artisan test\` green (715 tests / 2757 assertions). \`npm run build\` clean.

## Self-review notes

Reviewed by \`superpowers:code-reviewer\`. Verdict: ship-ready with 3 fixes — all applied:

1. **Critical: \`Repositories/Show.vue\` polling window.** Pre-spec, transient API errors flipped to \`Failed\` immediately. Post-spec, status stays \`Syncing\` during the 21-min retry window — meaning unbounded 2.5s polling against the controller. Added a hard cap (\`POLL_MAX_TICKS = 120\` → 5 minutes wall-clock). User can refresh manually past that.
2. **Important: docblock claimed \`release()\` doesn't consume a retry attempt.** Wrong — both Laravel's database + redis queue drivers increment attempts on every pop after release. Reframed: persistent rate-limiting exhausts \`$tries\` and falls through to \`failed()\`. The 3600s cap is reframed as a per-attempt safety, not an infinite-loop guard.
3. **Important: dead post-\`expectException\` assertions** in \`SyncRepositoryWorkflowRunsJobTest.php\`. PHPUnit terminates on the expected exception so the assertions were unreachable; they also asserted state the new code never writes. Deleted.

Key reviewer answers:
- Filter \`'all'\` default on the webhook deliveries page is defensible: it's an admin/debug surface, defaulting to "open" would hide background failures.
- The \`failed()\` 401 branch in each sync job is defensive belt-and-braces (the in-job catch short-circuits 401 before retries), worth keeping.
- Webhook job's try/catch + rethrow is intentional for the attempt-count log metadata.
- \`X-RateLimit-Reset\` parsing is correct; case-variant loop is belt-and-braces over PSR-7's case-insensitive lookup.

Deferred follow-ups (non-blocking):
- Disable "Run sync" CTA on \`rate_limited\` / \`unauthorized\` statuses (\`Repositories/Show.vue\`).
- Symmetry: add \`failed_handler_maps_401_through_to_unauthorized\` test in the 3 sync jobs that don't have it (only issues job has it today).
- \`test_persistently_rate_limited_job_ends_in_failed_status_after_tries_exhausted\` — pin the budget-exhaustion transition.
- \`retry()\` action could use rate-limiting against thrash-clicks; defer to spec 038 (self-monitoring).
- Cache the distinct \`events\` dropdown list — currently a full scan per index render.