### PR TITLE
chore(specs): flip 037 to done + Phase 9 tracker 2/6

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -44,7 +44,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 6 | Docker Host Agent MVP | 🟢 | 4/4 specs done (026–029). Phase complete. |
 | 7 | Alerts Engine | 🟢 | 3/3 specs done (030–032). Phase complete. |
 | 8 | Analytics & Health Scores | 🟢 | 3/3 specs done (033–035). Phase complete. |
-| 9 | Polish & Production Readiness | 🟡 | 1/6 specs done (036). 037 reliability, 038 self-monitoring, 039 security, 040 core-flow-tests, 041 production-docs pending. |
+| 9 | Polish & Production Readiness | 🟡 | 2/6 specs done (036–037). 038 self-monitoring, 039 security, 040 core-flow-tests, 041 production-docs pending. |
 | 10 | Future Innovation | ⬜ | — |
 
 ## MVP scope (target for v1)

--- a/specs/phase-9-polish/037-reliability-hardening.md
+++ b/specs/phase-9-polish/037-reliability-hardening.md
@@ -1,10 +1,10 @@
 ---
 spec: reliability-hardening
 phase: 9
-status: in-progress   # not-started | in-progress | blocked | done
+status: done   # not-started | in-progress | blocked | done
 owner: Yoany
 created: 2026-06-16
-updated: 2026-06-16
+updated: 2026-06-17
 ---
 
 # 037 — Reliability hardening: retries, rate-limit handling, webhook retry UI

--- a/specs/phase-9-polish/README.md
+++ b/specs/phase-9-polish/README.md
@@ -25,7 +25,7 @@ docs alone.
 | # | Task | Status |
 |---|------|--------|
 | 036 | UX polish — skeleton loading, empty / error states, reduced-motion, light-mode toggle, responsive edge cases | 🟢 |
-| 037 | Reliability hardening — job retry/backoff, rate-limit response handling, webhook retry UI | ⬜ |
+| 037 | Reliability hardening — job retry/backoff, rate-limit response handling, webhook retry UI | 🟢 |
 | 038 | Nexus self-monitoring — internal alerts (queue / GitHub-rate / webhook / agent failures) + observability slice | ⬜ |
 | 039 | Security audit — token encryption pass, Horizon production allow-list, agent fingerprinting opt-in, rate-limit coverage | ⬜ |
 | 040 | Core-flow test coverage — auth → project → repo sync → webhook → alert → resolve, plus seeding-quality fixtures | ⬜ |


### PR DESCRIPTION
Spec 037 (#109 / PR #110) merged. Bookkeeping: spec frontmatter → `done`, Phase 9 README row → 🟢, master tracker → 2/6 specs done.

Next on Phase 9: 038 self-monitoring (queue backlog / GitHub-rate / webhook / agent-ingestion internal alerts + observability slice).