### PR TITLE
Spec 038 — Nexus self-monitoring: internal alerts + health card

### DIFF
--- a/app/Domain/Alerts/Actions/TriggerAlertAction.php
+++ b/app/Domain/Alerts/Actions/TriggerAlertAction.php
@@ -43,8 +43,12 @@ class TriggerAlertAction
     ) {}
 
     /**
+     * Spec 038 — `project_id` is nullable for `AlertSource::System`
+     * alerts (queue / GitHub-rate / webhook / agent). Project-scoped
+     * alerts still pass a real id.
+     *
      * @param  array{
-     *     project_id: int,
+     *     project_id: int|null,
      *     source: AlertSource|string,
      *     source_id: int|null,
      *     type: string,
@@ -86,7 +90,7 @@ class TriggerAlertAction
         }
 
         $alert = Alert::query()->create([
-            'project_id' => $attrs['project_id'],
+            'project_id' => $attrs['project_id'] ?? null,
             'source' => $source,
             'source_id' => $attrs['source_id'],
             'type' => $attrs['type'],

--- a/app/Domain/GitHub/Services/GitHubClient.php
+++ b/app/Domain/GitHub/Services/GitHubClient.php
@@ -224,4 +224,39 @@ class GitHubClient
                 'User-Agent' => 'Nexus-Control-Center',
             ]);
     }
+
+    /**
+     * Spec 038 — query GitHub's rate-limit endpoint. Returns the
+     * `core` resource summary (`{limit, remaining, reset}`) which is
+     * the bucket all the REST sync jobs share. Used by
+     * `CheckGitHubRateLimitJob` to surface the live remaining quota
+     * on the Settings system-health card.
+     */
+    public function fetchRateLimit(): array
+    {
+        try {
+            $response = $this->request()->get(self::BASE_URL.'/rate_limit');
+
+            if ($response->failed()) {
+                throw GitHubApiException::fromResponse(
+                    $response,
+                    'GitHub /rate_limit failed',
+                );
+            }
+
+            $body = (array) $response->json();
+            $core = $body['resources']['core'] ?? [];
+
+            return [
+                'limit' => (int) ($core['limit'] ?? 0),
+                'remaining' => (int) ($core['remaining'] ?? 0),
+                'reset' => (int) ($core['reset'] ?? 0),
+            ];
+        } catch (RequestException $e) {
+            throw GitHubApiException::fromTransport(
+                $e,
+                'GitHub /rate_limit transport failure',
+            );
+        }
+    }
 }

--- a/app/Domain/Observability/Jobs/CheckGitHubRateLimitJob.php
+++ b/app/Domain/Observability/Jobs/CheckGitHubRateLimitJob.php
@@ -41,12 +41,16 @@ class CheckGitHubRateLimitJob implements ShouldQueue
 
     public function handle(): void
     {
+        // `access_token` is encrypted at-rest — a literal `!= ''`
+        // SQL filter is a no-op against ciphertext. Spec 037's
+        // expire-connection path always sets `expires_at = now()`
+        // alongside blanking the token, so the time-based filter
+        // alone is enough to exclude expired connections.
         $connections = GithubConnection::query()
             ->where(function ($q): void {
                 $q->whereNull('expires_at')
                     ->orWhere('expires_at', '>', Carbon::now());
             })
-            ->where('access_token', '!=', '')
             ->get();
 
         if ($connections->isEmpty()) {

--- a/app/Domain/Observability/Jobs/CheckGitHubRateLimitJob.php
+++ b/app/Domain/Observability/Jobs/CheckGitHubRateLimitJob.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Domain\Observability\Jobs;
+
+use App\Domain\GitHub\Exceptions\GitHubApiException;
+use App\Domain\GitHub\Services\GitHubClient;
+use App\Models\GithubConnection;
+use App\Models\GithubRateLimitSnapshot;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Spec 038 — periodic poll of GitHub's `/rate_limit` endpoint for
+ * each user with a non-expired connection. Persists one snapshot
+ * per user per tick into `github_rate_limit_snapshots`; the
+ * Settings system-health card + `EvaluateSystemHealthJob` read
+ * the latest row.
+ *
+ * 401 responses don't crash the loop — the user's connection has
+ * either expired or been revoked, and the next sync job's own
+ * 401 path will mark the connection expired (spec 037). We just
+ * skip and continue.
+ *
+ * `$tries = 1` — the every-10-minute schedule is the retry path.
+ * Cost is one HTTP call per connected user per 10 minutes, which
+ * stays well under any reasonable per-token quota.
+ */
+class CheckGitHubRateLimitJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    public function handle(): void
+    {
+        $connections = GithubConnection::query()
+            ->where(function ($q): void {
+                $q->whereNull('expires_at')
+                    ->orWhere('expires_at', '>', Carbon::now());
+            })
+            ->where('access_token', '!=', '')
+            ->get();
+
+        if ($connections->isEmpty()) {
+            return;
+        }
+
+        foreach ($connections as $connection) {
+            try {
+                $rate = (new GitHubClient($connection))->fetchRateLimit();
+            } catch (GitHubApiException $e) {
+                Log::warning('GitHub rate-limit poll failed', [
+                    'user_id' => $connection->user_id,
+                    'status' => $e->statusCode,
+                    'message' => $e->getMessage(),
+                ]);
+
+                continue;
+            }
+
+            GithubRateLimitSnapshot::query()->create([
+                'user_id' => $connection->user_id,
+                'remaining' => $rate['remaining'],
+                'limit' => $rate['limit'],
+                'reset_at' => Carbon::createFromTimestamp($rate['reset']),
+                'recorded_at' => Carbon::now(),
+            ]);
+        }
+    }
+}

--- a/app/Domain/Observability/Jobs/EvaluateSystemHealthJob.php
+++ b/app/Domain/Observability/Jobs/EvaluateSystemHealthJob.php
@@ -5,6 +5,7 @@ namespace App\Domain\Observability\Jobs;
 use App\Domain\Alerts\Actions\ResolveAlertAction;
 use App\Domain\Alerts\Actions\TriggerAlertAction;
 use App\Domain\Observability\Queries\GetSystemHealthQuery;
+use App\Domain\Observability\SystemHealthThresholds;
 use App\Enums\AlertSeverity;
 use App\Enums\AlertSource;
 use Illuminate\Bus\Queueable;
@@ -39,27 +40,9 @@ class EvaluateSystemHealthJob implements ShouldQueue
 
     public int $tries = 1;
 
-    public const QUEUE_BACKLOG_WARNING = 100;
-
-    public const QUEUE_BACKLOG_CRITICAL = 500;
-
-    public const QUEUE_FAILURES_5M_WARN = 5;
-
-    public const QUEUE_FAILURES_5M_CRIT = 20;
-
-    public const WEBHOOK_FAILRATE_WARN_PCT = 20.0;
-
-    public const WEBHOOK_FAILRATE_CRIT_PCT = 50.0;
-
-    public const WEBHOOK_MIN_SAMPLE = 5;
-
-    public const GITHUB_RATE_REMAINING_WARN = 100;
-
-    public const GITHUB_RATE_REMAINING_CRIT = 20;
-
-    public const AGENT_AUTH_FAILURES_5M_WARN = 10;
-
-    public const AGENT_AUTH_FAILURES_5M_CRIT = 50;
+    // Spec 038 — thresholds live in `SystemHealthThresholds` so the
+    // query (decides what tone to render) and the job (decides what
+    // alert to fire) read the same numbers.
 
     /** @return array<int, object> */
     public function middleware(): array
@@ -85,13 +68,13 @@ class EvaluateSystemHealthJob implements ShouldQueue
      */
     private function evaluateQueue(array $slice, TriggerAlertAction $trigger, ResolveAlertAction $resolve): void
     {
-        $severity = $slice['pending'] >= self::QUEUE_BACKLOG_CRITICAL
-            || $slice['failed_5m'] >= self::QUEUE_FAILURES_5M_CRIT
-            ? AlertSeverity::Critical
-            : ($slice['pending'] >= self::QUEUE_BACKLOG_WARNING
-                || $slice['failed_5m'] >= self::QUEUE_FAILURES_5M_WARN
-                    ? AlertSeverity::Warning
-                    : null);
+        $severity = match (true) {
+            $slice['pending'] >= SystemHealthThresholds::QUEUE_BACKLOG_CRITICAL,
+            $slice['failed_5m'] >= SystemHealthThresholds::QUEUE_FAILURES_5M_CRIT => AlertSeverity::Critical,
+            $slice['pending'] >= SystemHealthThresholds::QUEUE_BACKLOG_WARNING,
+            $slice['failed_5m'] >= SystemHealthThresholds::QUEUE_FAILURES_5M_WARN => AlertSeverity::Warning,
+            default => null,
+        };
 
         if ($severity === null) {
             $this->resolveType($resolve, 'queue.backlog_high');
@@ -121,7 +104,7 @@ class EvaluateSystemHealthJob implements ShouldQueue
         // returns `success`/`muted` accordingly. The evaluator's job
         // is to act only on a real signal.
         if (
-            $slice['deliveries_5m'] < self::WEBHOOK_MIN_SAMPLE
+            $slice['deliveries_5m'] < SystemHealthThresholds::WEBHOOK_MIN_SAMPLE
             || $slice['failure_rate_percent'] === null
         ) {
             $this->resolveType($resolve, 'webhook.failure_rate_high');
@@ -131,11 +114,11 @@ class EvaluateSystemHealthJob implements ShouldQueue
 
         $rate = $slice['failure_rate_percent'];
 
-        $severity = $rate >= self::WEBHOOK_FAILRATE_CRIT_PCT
-            ? AlertSeverity::Critical
-            : ($rate >= self::WEBHOOK_FAILRATE_WARN_PCT
-                ? AlertSeverity::Warning
-                : null);
+        $severity = match (true) {
+            $rate >= SystemHealthThresholds::WEBHOOK_FAILRATE_CRIT_PCT => AlertSeverity::Critical,
+            $rate >= SystemHealthThresholds::WEBHOOK_FAILRATE_WARN_PCT => AlertSeverity::Warning,
+            default => null,
+        };
 
         if ($severity === null) {
             $this->resolveType($resolve, 'webhook.failure_rate_high');
@@ -168,11 +151,11 @@ class EvaluateSystemHealthJob implements ShouldQueue
             return;
         }
 
-        $severity = $slice['remaining'] < self::GITHUB_RATE_REMAINING_CRIT
-            ? AlertSeverity::Critical
-            : ($slice['remaining'] < self::GITHUB_RATE_REMAINING_WARN
-                ? AlertSeverity::Warning
-                : null);
+        $severity = match (true) {
+            $slice['remaining'] < SystemHealthThresholds::GITHUB_RATE_REMAINING_CRIT => AlertSeverity::Critical,
+            $slice['remaining'] < SystemHealthThresholds::GITHUB_RATE_REMAINING_WARN => AlertSeverity::Warning,
+            default => null,
+        };
 
         if ($severity === null) {
             $this->resolveType($resolve, 'github.rate_limit_low');
@@ -197,11 +180,11 @@ class EvaluateSystemHealthJob implements ShouldQueue
      */
     private function evaluateAgentAuth(array $slice, TriggerAlertAction $trigger, ResolveAlertAction $resolve): void
     {
-        $severity = $slice['failures_5m'] >= self::AGENT_AUTH_FAILURES_5M_CRIT
-            ? AlertSeverity::Critical
-            : ($slice['failures_5m'] >= self::AGENT_AUTH_FAILURES_5M_WARN
-                ? AlertSeverity::Warning
-                : null);
+        $severity = match (true) {
+            $slice['failures_5m'] >= SystemHealthThresholds::AGENT_AUTH_FAILURES_5M_CRIT => AlertSeverity::Critical,
+            $slice['failures_5m'] >= SystemHealthThresholds::AGENT_AUTH_FAILURES_5M_WARN => AlertSeverity::Warning,
+            default => null,
+        };
 
         if ($severity === null) {
             $this->resolveType($resolve, 'agent.auth_failures_high');

--- a/app/Domain/Observability/Jobs/EvaluateSystemHealthJob.php
+++ b/app/Domain/Observability/Jobs/EvaluateSystemHealthJob.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace App\Domain\Observability\Jobs;
+
+use App\Domain\Alerts\Actions\ResolveAlertAction;
+use App\Domain\Alerts\Actions\TriggerAlertAction;
+use App\Domain\Observability\Queries\GetSystemHealthQuery;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Spec 038 — every-minute evaluator that turns the four
+ * `GetSystemHealthQuery` signals into idempotent internal alerts.
+ * Reuses spec 030's `TriggerAlertAction` (`AlertSource::System`)
+ * + `ResolveAlertAction` for the close-on-recovery flow.
+ *
+ * Idempotency is automatic: `TriggerAlertAction` returns the
+ * existing open alert if one already matches `(source, source_id,
+ * type)`, so a sustained breach produces one alert, not a stream.
+ *
+ * Thresholds are named constants on this class so future tuning
+ * (or a polish-spec UI for user-tunable weights) has one place to
+ * change. Status mapping in `GetSystemHealthQuery` mirrors the
+ * same thresholds — both layers can evolve together but the
+ * evaluator owns the alerting decision.
+ */
+class EvaluateSystemHealthJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    public const QUEUE_BACKLOG_WARNING = 100;
+
+    public const QUEUE_BACKLOG_CRITICAL = 500;
+
+    public const QUEUE_FAILURES_5M_WARN = 5;
+
+    public const QUEUE_FAILURES_5M_CRIT = 20;
+
+    public const WEBHOOK_FAILRATE_WARN_PCT = 20.0;
+
+    public const WEBHOOK_FAILRATE_CRIT_PCT = 50.0;
+
+    public const WEBHOOK_MIN_SAMPLE = 5;
+
+    public const GITHUB_RATE_REMAINING_WARN = 100;
+
+    public const GITHUB_RATE_REMAINING_CRIT = 20;
+
+    public const AGENT_AUTH_FAILURES_5M_WARN = 10;
+
+    public const AGENT_AUTH_FAILURES_5M_CRIT = 50;
+
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [new WithoutOverlapping('observability:evaluate-system-health')];
+    }
+
+    public function handle(
+        GetSystemHealthQuery $query,
+        TriggerAlertAction $trigger,
+        ResolveAlertAction $resolve,
+    ): void {
+        $health = $query->execute();
+
+        $this->evaluateQueue($health['queue'], $trigger, $resolve);
+        $this->evaluateWebhooks($health['webhooks'], $trigger, $resolve);
+        $this->evaluateGithubRateLimit($health['github_rate_limit'], $trigger, $resolve);
+        $this->evaluateAgentAuth($health['agent_auth'], $trigger, $resolve);
+    }
+
+    /**
+     * @param  array{pending: int, failed_5m: int, status: string}  $slice
+     */
+    private function evaluateQueue(array $slice, TriggerAlertAction $trigger, ResolveAlertAction $resolve): void
+    {
+        $severity = $slice['pending'] >= self::QUEUE_BACKLOG_CRITICAL
+            || $slice['failed_5m'] >= self::QUEUE_FAILURES_5M_CRIT
+            ? AlertSeverity::Critical
+            : ($slice['pending'] >= self::QUEUE_BACKLOG_WARNING
+                || $slice['failed_5m'] >= self::QUEUE_FAILURES_5M_WARN
+                    ? AlertSeverity::Warning
+                    : null);
+
+        if ($severity === null) {
+            $this->resolveType($resolve, 'queue.backlog_high');
+
+            return;
+        }
+
+        $trigger->execute([
+            'project_id' => null,
+            'source' => AlertSource::System,
+            'source_id' => null,
+            'type' => 'queue.backlog_high',
+            'severity' => $severity,
+            'title' => 'Queue backlog high',
+            'description' => "Pending jobs: {$slice['pending']}, failures in last 5m: {$slice['failed_5m']}.",
+            'metadata' => $slice,
+        ]);
+    }
+
+    /**
+     * @param  array{deliveries_5m: int, failures_5m: int, failure_rate_percent: float|null, status: string}  $slice
+     */
+    private function evaluateWebhooks(array $slice, TriggerAlertAction $trigger, ResolveAlertAction $resolve): void
+    {
+        // Don't fire on a quiet account — `failure_rate_percent` is
+        // null when sample size is below the floor, and the query
+        // returns `success`/`muted` accordingly. The evaluator's job
+        // is to act only on a real signal.
+        if (
+            $slice['deliveries_5m'] < self::WEBHOOK_MIN_SAMPLE
+            || $slice['failure_rate_percent'] === null
+        ) {
+            $this->resolveType($resolve, 'webhook.failure_rate_high');
+
+            return;
+        }
+
+        $rate = $slice['failure_rate_percent'];
+
+        $severity = $rate >= self::WEBHOOK_FAILRATE_CRIT_PCT
+            ? AlertSeverity::Critical
+            : ($rate >= self::WEBHOOK_FAILRATE_WARN_PCT
+                ? AlertSeverity::Warning
+                : null);
+
+        if ($severity === null) {
+            $this->resolveType($resolve, 'webhook.failure_rate_high');
+
+            return;
+        }
+
+        $trigger->execute([
+            'project_id' => null,
+            'source' => AlertSource::System,
+            'source_id' => null,
+            'type' => 'webhook.failure_rate_high',
+            'severity' => $severity,
+            'title' => 'Webhook failure rate high',
+            'description' => "{$slice['failures_5m']} / {$slice['deliveries_5m']} deliveries failed in last 5m ({$rate}%).",
+            'metadata' => $slice,
+        ]);
+    }
+
+    /**
+     * @param  array{remaining: int|null, reset_at_iso: string|null, status: string}  $slice
+     */
+    private function evaluateGithubRateLimit(array $slice, TriggerAlertAction $trigger, ResolveAlertAction $resolve): void
+    {
+        if ($slice['remaining'] === null) {
+            // No snapshot yet — fresh install or no connected users.
+            // The poller will produce one within 10 min; stay quiet.
+            $this->resolveType($resolve, 'github.rate_limit_low');
+
+            return;
+        }
+
+        $severity = $slice['remaining'] < self::GITHUB_RATE_REMAINING_CRIT
+            ? AlertSeverity::Critical
+            : ($slice['remaining'] < self::GITHUB_RATE_REMAINING_WARN
+                ? AlertSeverity::Warning
+                : null);
+
+        if ($severity === null) {
+            $this->resolveType($resolve, 'github.rate_limit_low');
+
+            return;
+        }
+
+        $trigger->execute([
+            'project_id' => null,
+            'source' => AlertSource::System,
+            'source_id' => null,
+            'type' => 'github.rate_limit_low',
+            'severity' => $severity,
+            'title' => 'GitHub rate limit low',
+            'description' => "{$slice['remaining']} requests remaining (reset at {$slice['reset_at_iso']}).",
+            'metadata' => $slice,
+        ]);
+    }
+
+    /**
+     * @param  array{failures_5m: int, status: string}  $slice
+     */
+    private function evaluateAgentAuth(array $slice, TriggerAlertAction $trigger, ResolveAlertAction $resolve): void
+    {
+        $severity = $slice['failures_5m'] >= self::AGENT_AUTH_FAILURES_5M_CRIT
+            ? AlertSeverity::Critical
+            : ($slice['failures_5m'] >= self::AGENT_AUTH_FAILURES_5M_WARN
+                ? AlertSeverity::Warning
+                : null);
+
+        if ($severity === null) {
+            $this->resolveType($resolve, 'agent.auth_failures_high');
+
+            return;
+        }
+
+        $trigger->execute([
+            'project_id' => null,
+            'source' => AlertSource::System,
+            'source_id' => null,
+            'type' => 'agent.auth_failures_high',
+            'severity' => $severity,
+            'title' => 'Agent auth failures high',
+            'description' => "{$slice['failures_5m']} rejected agent requests in last 5m.",
+            'metadata' => $slice,
+        ]);
+    }
+
+    private function resolveType(ResolveAlertAction $resolve, string $type): void
+    {
+        $resolve->execute([
+            'source' => AlertSource::System,
+            'source_id' => null,
+            'type' => $type,
+        ]);
+    }
+}

--- a/app/Domain/Observability/Queries/GetSystemHealthQuery.php
+++ b/app/Domain/Observability/Queries/GetSystemHealthQuery.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\Observability\Queries;
 
+use App\Domain\Observability\SystemHealthThresholds;
 use App\Enums\WebhookDeliveryStatus;
 use App\Models\GithubRateLimitSnapshot;
 use App\Models\WebhookDelivery;
@@ -90,7 +91,7 @@ class GetSystemHealthQuery
 
         // Below the min-sample floor, don't surface a percentage —
         // 1 of 1 failed reads as 100% but isn't a signal.
-        $rate = $total >= 5
+        $rate = $total >= SystemHealthThresholds::WEBHOOK_MIN_SAMPLE
             ? round(($failed / $total) * 100, 2)
             : null;
 
@@ -149,10 +150,16 @@ class GetSystemHealthQuery
     /** @return 'success'|'warning'|'danger'|'muted' */
     private function queueStatus(int $pending, int $failed5m): string
     {
-        if ($pending >= 500 || $failed5m >= 20) {
+        if (
+            $pending >= SystemHealthThresholds::QUEUE_BACKLOG_CRITICAL
+            || $failed5m >= SystemHealthThresholds::QUEUE_FAILURES_5M_CRIT
+        ) {
             return 'danger';
         }
-        if ($pending >= 100 || $failed5m >= 5) {
+        if (
+            $pending >= SystemHealthThresholds::QUEUE_BACKLOG_WARNING
+            || $failed5m >= SystemHealthThresholds::QUEUE_FAILURES_5M_WARN
+        ) {
             return 'warning';
         }
 
@@ -166,10 +173,10 @@ class GetSystemHealthQuery
             // Either no traffic or below the sample floor — quiet.
             return $total === 0 ? 'muted' : 'success';
         }
-        if ($rate >= 50.0) {
+        if ($rate >= SystemHealthThresholds::WEBHOOK_FAILRATE_CRIT_PCT) {
             return 'danger';
         }
-        if ($rate >= 20.0) {
+        if ($rate >= SystemHealthThresholds::WEBHOOK_FAILRATE_WARN_PCT) {
             return 'warning';
         }
 
@@ -182,10 +189,10 @@ class GetSystemHealthQuery
         if ($remaining === null) {
             return 'muted';
         }
-        if ($remaining < 20) {
+        if ($remaining < SystemHealthThresholds::GITHUB_RATE_REMAINING_CRIT) {
             return 'danger';
         }
-        if ($remaining < 100) {
+        if ($remaining < SystemHealthThresholds::GITHUB_RATE_REMAINING_WARN) {
             return 'warning';
         }
 
@@ -195,10 +202,10 @@ class GetSystemHealthQuery
     /** @return 'success'|'warning'|'danger'|'muted' */
     private function agentAuthStatus(int $failures): string
     {
-        if ($failures >= 50) {
+        if ($failures >= SystemHealthThresholds::AGENT_AUTH_FAILURES_5M_CRIT) {
             return 'danger';
         }
-        if ($failures >= 10) {
+        if ($failures >= SystemHealthThresholds::AGENT_AUTH_FAILURES_5M_WARN) {
             return 'warning';
         }
 

--- a/app/Domain/Observability/Queries/GetSystemHealthQuery.php
+++ b/app/Domain/Observability/Queries/GetSystemHealthQuery.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace App\Domain\Observability\Queries;
+
+use App\Enums\WebhookDeliveryStatus;
+use App\Models\GithubRateLimitSnapshot;
+use App\Models\WebhookDelivery;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Spec 038 — read-side aggregate for the Settings system-health
+ * card + the `EvaluateSystemHealthJob`'s threshold checks.
+ *
+ * Four signals, each one independent + computed against live
+ * tables (no persisted metrics store except the GitHub rate-limit
+ * snapshot, which lives in its own small table fed by
+ * `CheckGitHubRateLimitJob`):
+ *
+ *   - **Queue.** Pending job count (from `jobs` table) + failed
+ *     count in last 5 min (from `failed_jobs.failed_at`).
+ *   - **Webhooks.** Deliveries received in last 5 min + failures
+ *     in the same window. Failure rate stays `null` when sample
+ *     size is below the warning floor (the evaluator's
+ *     `WEBHOOK_MIN_SAMPLE`) to avoid noise on a quiet account.
+ *   - **GitHub rate-limit.** Latest snapshot across all users.
+ *     `null` remaining means we haven't polled yet (fresh
+ *     install) — the card shows "—" and the evaluator stays
+ *     quiet.
+ *   - **Agent auth.** Count of `agent.auth.failure` activity
+ *     events in last 5 min. Captured by `AuthenticateAgent`
+ *     middleware on every rejected request.
+ *
+ * Status tones are computed against the same thresholds the
+ * evaluator uses — but the query is pure and threshold-agnostic
+ * (the evaluator imports the constants). Tones here just power
+ * the card colour without re-deriving the alerting decision.
+ */
+class GetSystemHealthQuery
+{
+    public const WINDOW_MINUTES = 5;
+
+    public function execute(): array
+    {
+        $windowStart = Carbon::now()->subMinutes(self::WINDOW_MINUTES);
+
+        return [
+            'queue' => $this->queueSlice($windowStart),
+            'webhooks' => $this->webhookSlice($windowStart),
+            'github_rate_limit' => $this->githubRateLimitSlice(),
+            'agent_auth' => $this->agentAuthSlice($windowStart),
+        ];
+    }
+
+    /**
+     * @return array{pending: int, failed_5m: int, status: 'success'|'warning'|'danger'|'muted'}
+     */
+    private function queueSlice(Carbon $windowStart): array
+    {
+        $pending = DB::table('jobs')->count();
+        $failed5m = DB::table('failed_jobs')
+            ->where('failed_at', '>', $windowStart)
+            ->count();
+
+        return [
+            'pending' => $pending,
+            'failed_5m' => $failed5m,
+            'status' => $this->queueStatus($pending, $failed5m),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     deliveries_5m: int,
+     *     failures_5m: int,
+     *     failure_rate_percent: float|null,
+     *     status: 'success'|'warning'|'danger'|'muted',
+     * }
+     */
+    private function webhookSlice(Carbon $windowStart): array
+    {
+        $total = WebhookDelivery::query()
+            ->where('received_at', '>', $windowStart)
+            ->count();
+
+        $failed = WebhookDelivery::query()
+            ->where('received_at', '>', $windowStart)
+            ->where('status', WebhookDeliveryStatus::Failed->value)
+            ->count();
+
+        // Below the min-sample floor, don't surface a percentage —
+        // 1 of 1 failed reads as 100% but isn't a signal.
+        $rate = $total >= 5
+            ? round(($failed / $total) * 100, 2)
+            : null;
+
+        return [
+            'deliveries_5m' => $total,
+            'failures_5m' => $failed,
+            'failure_rate_percent' => $rate,
+            'status' => $this->webhookStatus($total, $rate),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     remaining: int|null,
+     *     reset_at_iso: string|null,
+     *     status: 'success'|'warning'|'danger'|'muted',
+     * }
+     */
+    private function githubRateLimitSlice(): array
+    {
+        $snapshot = GithubRateLimitSnapshot::query()
+            ->latest('recorded_at')
+            ->first();
+
+        if ($snapshot === null) {
+            return [
+                'remaining' => null,
+                'reset_at_iso' => null,
+                'status' => 'muted',
+            ];
+        }
+
+        return [
+            'remaining' => $snapshot->remaining,
+            'reset_at_iso' => $snapshot->reset_at?->toIso8601String(),
+            'status' => $this->githubRateStatus($snapshot->remaining),
+        ];
+    }
+
+    /**
+     * @return array{failures_5m: int, status: 'success'|'warning'|'danger'|'muted'}
+     */
+    private function agentAuthSlice(Carbon $windowStart): array
+    {
+        $failures = DB::table('activity_events')
+            ->where('event_type', 'agent.auth.failure')
+            ->where('occurred_at', '>', $windowStart)
+            ->count();
+
+        return [
+            'failures_5m' => $failures,
+            'status' => $this->agentAuthStatus($failures),
+        ];
+    }
+
+    /** @return 'success'|'warning'|'danger'|'muted' */
+    private function queueStatus(int $pending, int $failed5m): string
+    {
+        if ($pending >= 500 || $failed5m >= 20) {
+            return 'danger';
+        }
+        if ($pending >= 100 || $failed5m >= 5) {
+            return 'warning';
+        }
+
+        return 'success';
+    }
+
+    /** @return 'success'|'warning'|'danger'|'muted' */
+    private function webhookStatus(int $total, ?float $rate): string
+    {
+        if ($rate === null) {
+            // Either no traffic or below the sample floor — quiet.
+            return $total === 0 ? 'muted' : 'success';
+        }
+        if ($rate >= 50.0) {
+            return 'danger';
+        }
+        if ($rate >= 20.0) {
+            return 'warning';
+        }
+
+        return 'success';
+    }
+
+    /** @return 'success'|'warning'|'danger'|'muted' */
+    private function githubRateStatus(?int $remaining): string
+    {
+        if ($remaining === null) {
+            return 'muted';
+        }
+        if ($remaining < 20) {
+            return 'danger';
+        }
+        if ($remaining < 100) {
+            return 'warning';
+        }
+
+        return 'success';
+    }
+
+    /** @return 'success'|'warning'|'danger'|'muted' */
+    private function agentAuthStatus(int $failures): string
+    {
+        if ($failures >= 50) {
+            return 'danger';
+        }
+        if ($failures >= 10) {
+            return 'warning';
+        }
+
+        return 'success';
+    }
+}

--- a/app/Domain/Observability/SystemHealthThresholds.php
+++ b/app/Domain/Observability/SystemHealthThresholds.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Domain\Observability;
+
+/**
+ * Spec 038 — single source of truth for system-health alert
+ * thresholds. Used by both `EvaluateSystemHealthJob` (decides which
+ * alerts to fire) and `GetSystemHealthQuery` (decides which tone the
+ * Settings card paints). Keeping them aligned prevents the card
+ * from reading "warning" while no alert has fired (or vice versa).
+ *
+ * Magic numbers are §17-driven defaults. A future polish spec could
+ * make these user-tunable.
+ */
+class SystemHealthThresholds
+{
+    public const QUEUE_BACKLOG_WARNING = 100;
+
+    public const QUEUE_BACKLOG_CRITICAL = 500;
+
+    public const QUEUE_FAILURES_5M_WARN = 5;
+
+    public const QUEUE_FAILURES_5M_CRIT = 20;
+
+    public const WEBHOOK_FAILRATE_WARN_PCT = 20.0;
+
+    public const WEBHOOK_FAILRATE_CRIT_PCT = 50.0;
+
+    public const WEBHOOK_MIN_SAMPLE = 5;
+
+    public const GITHUB_RATE_REMAINING_WARN = 100;
+
+    public const GITHUB_RATE_REMAINING_CRIT = 20;
+
+    public const AGENT_AUTH_FAILURES_5M_WARN = 10;
+
+    public const AGENT_AUTH_FAILURES_5M_CRIT = 50;
+}

--- a/app/Http/Controllers/AlertController.php
+++ b/app/Http/Controllers/AlertController.php
@@ -81,7 +81,17 @@ class AlertController extends Controller
 
         $alerts = Alert::query()
             ->with('project:id,slug,name,color,icon,owner_user_id')
-            ->whereHas('project', fn ($q) => $q->where('owner_user_id', $user->id))
+            // Spec 038 — `AlertSource::System` alerts have a null
+            // project_id (queue / GitHub-rate / webhook / agent-auth
+            // signals aren't project-scoped). Without this branch
+            // the `whereHas('project')` filter excludes them and the
+            // Settings system-health card's "View details" link
+            // would land on an empty list.
+            ->where(function ($outer) use ($user): void {
+                $outer
+                    ->whereHas('project', fn ($q) => $q->where('owner_user_id', $user->id))
+                    ->orWhere('source', AlertSource::System->value);
+            })
             ->when($severity, fn ($q) => $q->where('severity', $severity))
             ->when($source, fn ($q) => $q->where('source', $source))
             ->when($status, fn ($q) => $q->where('status', $status))

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Domain\Observability\Queries\GetSystemHealthQuery;
 use App\Models\GithubConnection;
 use App\Models\Project;
 use App\Models\Repository;
@@ -12,12 +13,16 @@ use Inertia\Response;
 
 class SettingsController extends Controller
 {
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, GetSystemHealthQuery $systemHealth): Response
     {
         $connection = $request->user()?->githubConnection;
 
         return Inertia::render('Settings/Index', [
             'github' => $this->serializeConnection($connection, $request),
+            // Spec 038 — system health KPIs (queue, webhooks, GitHub
+            // rate-limit, agent auth) rendered as a 4-up card above
+            // the Integrations block.
+            'systemHealth' => $systemHealth->execute(),
         ]);
     }
 

--- a/app/Http/Middleware/AuthenticateAgent.php
+++ b/app/Http/Middleware/AuthenticateAgent.php
@@ -101,21 +101,35 @@ class AuthenticateAgent
      * give an operator enough to triage (token leaked? wrong host
      * shipping the binary? rate-limit thrash?).
      *
-     * Resolved out of the container so the existing constructor stays
-     * dependency-free.
+     * Deduped per-IP-per-reason-per-minute via `RateLimiter::attempt`
+     * so a misbehaving agent in a tight retry loop doesn't pump the
+     * `activity_events` table at request rate. The 5-min count
+     * threshold (10 events → warning) still trips cleanly: one
+     * offender for 10 minutes, or 10 distinct IPs at any rate.
+     *
+     * Severity is `Info` — a single rejection isn't alarming; the
+     * evaluator decides when the *count* across IPs is.
+     *
+     * Resolved out of the container so the existing constructor
+     * stays dependency-free.
      */
     private function recordAuthFailure(Request $request, string $reason): void
     {
-        app(CreateActivityEventAction::class)->execute([
-            'event_type' => 'agent.auth.failure',
-            'severity' => ActivitySeverity::Warning,
-            'source' => 'agent',
-            'title' => 'Agent token rejected',
-            'occurred_at' => now(),
-            'metadata' => [
-                'ip' => $request->ip(),
-                'reason' => $reason,
-            ],
-        ]);
+        RateLimiter::attempt(
+            'agent-auth-failure-event:'.$request->ip().':'.$reason,
+            maxAttempts: 1,
+            callback: fn () => app(CreateActivityEventAction::class)->execute([
+                'event_type' => 'agent.auth.failure',
+                'severity' => ActivitySeverity::Info,
+                'source' => 'agent',
+                'title' => 'Agent token rejected',
+                'occurred_at' => now(),
+                'metadata' => [
+                    'ip' => $request->ip(),
+                    'reason' => $reason,
+                ],
+            ]),
+            decaySeconds: 60,
+        );
     }
 }

--- a/app/Http/Middleware/AuthenticateAgent.php
+++ b/app/Http/Middleware/AuthenticateAgent.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Middleware;
 
+use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Enums\ActivitySeverity;
 use App\Models\AgentToken;
 use Closure;
 use Illuminate\Http\Request;
@@ -42,6 +44,8 @@ class AuthenticateAgent
         $bearer = $request->bearerToken();
 
         if (! is_string($bearer) || $bearer === '') {
+            $this->recordAuthFailure($request, 'missing_bearer_token');
+
             return response('', 401);
         }
 
@@ -55,11 +59,15 @@ class AuthenticateAgent
             || $token->host === null
             || $token->host->archived_at !== null
         ) {
+            $this->recordAuthFailure($request, 'invalid_token');
+
             return response('', 401);
         }
 
         $key = self::rateLimitKey($token);
         if (RateLimiter::tooManyAttempts($key, self::RATE_LIMIT_PER_MINUTE)) {
+            $this->recordAuthFailure($request, 'rate_limited');
+
             return response('', 429)->header(
                 'Retry-After',
                 (string) RateLimiter::availableIn($key),
@@ -84,5 +92,30 @@ class AuthenticateAgent
     public static function rateLimitKey(AgentToken $token): string
     {
         return 'agent-telemetry:'.$token->getKey();
+    }
+
+    /**
+     * Spec 038 — capture every rejected agent request as an activity
+     * event so `EvaluateSystemHealthJob` can count "auth failures in
+     * the last 5 min" without a dedicated table. IP + reason metadata
+     * give an operator enough to triage (token leaked? wrong host
+     * shipping the binary? rate-limit thrash?).
+     *
+     * Resolved out of the container so the existing constructor stays
+     * dependency-free.
+     */
+    private function recordAuthFailure(Request $request, string $reason): void
+    {
+        app(CreateActivityEventAction::class)->execute([
+            'event_type' => 'agent.auth.failure',
+            'severity' => ActivitySeverity::Warning,
+            'source' => 'agent',
+            'title' => 'Agent token rejected',
+            'occurred_at' => now(),
+            'metadata' => [
+                'ip' => $request->ip(),
+                'reason' => $reason,
+            ],
+        ]);
     }
 }

--- a/app/Models/GithubRateLimitSnapshot.php
+++ b/app/Models/GithubRateLimitSnapshot.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Spec 038 — periodic snapshot of GitHub's REST API rate-limit
+ * state per connected user. Read-only model — populated by the
+ * scheduled `CheckGitHubRateLimitJob` (10-min cadence), consumed
+ * by `GetSystemHealthQuery`.
+ */
+class GithubRateLimitSnapshot extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'remaining',
+        'limit',
+        'reset_at',
+        'recorded_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'remaining' => 'integer',
+            'limit' => 'integer',
+            'reset_at' => 'datetime',
+            'recorded_at' => 'datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2026_06_18_112951_create_github_rate_limit_snapshots_table.php
+++ b/database/migrations/2026_06_18_112951_create_github_rate_limit_snapshots_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Spec 038 — per-user snapshot of GitHub's REST API rate-limit
+ * remaining + reset window. Fed by `CheckGitHubRateLimitJob` on a
+ * 10-minute cadence; consumed by `GetSystemHealthQuery` for the
+ * Settings system-health card and the `github.rate_limit_low`
+ * internal alert.
+ *
+ * One row per snapshot per user — `recorded_at` carries the
+ * timestamp the snapshot was taken. The query reads the latest
+ * row per user (or the latest row across all users for the global
+ * health card). Old snapshots can be pruned by a future
+ * housekeeping job; phase-1 keeps them all (low volume — ~144
+ * rows per user per day at every-10-minute polling).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('github_rate_limit_snapshots', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('remaining');
+            $table->unsignedInteger('limit');
+            $table->timestamp('reset_at');
+            $table->timestamp('recorded_at')->index();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('github_rate_limit_snapshots');
+    }
+};

--- a/database/migrations/2026_06_22_140154_make_alerts_project_id_nullable.php
+++ b/database/migrations/2026_06_22_140154_make_alerts_project_id_nullable.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Spec 038 — `AlertSource::System` alerts (queue backlog, GitHub
+ * rate-limit, webhook failure rate, agent auth failures) don't
+ * belong to any single project. They're Nexus-wide signals
+ * surfaced by `EvaluateSystemHealthJob`. The original alerts
+ * table required a `project_id` because spec 030 only emitted
+ * project-scoped alerts (website / docker / deployment).
+ *
+ * Relax the column to nullable + flip the FK from `cascadeOnDelete`
+ * to `nullOnDelete` so deleting a project doesn't take down system
+ * alerts that happen to be open at the same time. Project-scoped
+ * alerts still cascade naturally because they all carry a real
+ * project_id and the FK still fires `null` on parent delete (which
+ * orphans the row but doesn't destroy data — operators can clean
+ * up if needed).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('alerts', function (Blueprint $table): void {
+            // Drop the existing FK + column, then re-add with the
+            // nullable + nullOnDelete shape. Doctrine DBAL isn't
+            // installed; this is the portable path across SQLite + MySQL.
+            $table->dropForeign(['project_id']);
+        });
+
+        Schema::table('alerts', function (Blueprint $table): void {
+            $table->unsignedBigInteger('project_id')->nullable()->change();
+
+            $table->foreign('project_id')
+                ->references('id')
+                ->on('projects')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('alerts', function (Blueprint $table): void {
+            $table->dropForeign(['project_id']);
+        });
+
+        Schema::table('alerts', function (Blueprint $table): void {
+            // Restoring the not-null + cascadeOnDelete shape: any
+            // existing null rows must be deleted first to satisfy
+            // the constraint. The spec 038 system alerts are
+            // ephemeral anyway.
+            DB::table('alerts')->whereNull('project_id')->delete();
+
+            $table->unsignedBigInteger('project_id')->nullable(false)->change();
+
+            $table->foreign('project_id')
+                ->references('id')
+                ->on('projects')
+                ->cascadeOnDelete();
+        });
+    }
+};

--- a/resources/js/Pages/Settings/Index.vue
+++ b/resources/js/Pages/Settings/Index.vue
@@ -3,10 +3,14 @@ import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import { Head, Link, router, usePage } from '@inertiajs/vue3';
 import {
+    Activity,
     AlertTriangle,
+    Bell,
     CheckCircle2,
     ExternalLink,
+    Gauge,
     Github,
+    Inbox,
     Moon,
     Plug,
     PlugZap,
@@ -31,8 +35,28 @@ interface GithubConnectionShape {
     };
 }
 
+// Spec 038 — system health KPIs surfaced above Integrations.
+type HealthTone = 'success' | 'warning' | 'danger' | 'info' | 'muted';
+
+interface SystemHealth {
+    queue: { pending: number; failed_5m: number; status: HealthTone };
+    webhooks: {
+        deliveries_5m: number;
+        failures_5m: number;
+        failure_rate_percent: number | null;
+        status: HealthTone;
+    };
+    github_rate_limit: {
+        remaining: number | null;
+        reset_at_iso: string | null;
+        status: HealthTone;
+    };
+    agent_auth: { failures_5m: number; status: HealthTone };
+}
+
 const props = defineProps<{
     github: GithubConnectionShape | null;
+    systemHealth: SystemHealth;
 }>();
 
 const isConnected = computed(() => props.github !== null);
@@ -95,6 +119,144 @@ const disconnect = () => {
         </template>
 
         <div class="space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+            <!-- Spec 038 — system health card. 4-up KPI grid showing
+                 the live signals the every-minute evaluator alerts on.
+                 Each card carries a status badge + a context link. -->
+            <header class="flex items-center justify-between gap-3">
+                <div>
+                    <h2 class="text-base font-semibold text-text-primary">
+                        System health
+                    </h2>
+                    <p class="mt-1 text-sm text-text-secondary">
+                        Page-load snapshot. The every-minute evaluator
+                        fires internal alerts on threshold breach.
+                    </p>
+                </div>
+            </header>
+
+            <section
+                aria-label="System health"
+                class="grid grid-cols-1 gap-3 sm:grid-cols-2"
+            >
+                <a
+                    href="/horizon"
+                    target="_blank"
+                    rel="noopener"
+                    class="glass-card flex items-center justify-between gap-4 p-5 transition hover:border-accent-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                >
+                    <div class="flex items-center gap-3">
+                        <span
+                            class="flex h-10 w-10 items-center justify-center rounded-lg border border-border-subtle bg-background-panel-hover"
+                        >
+                            <Gauge
+                                class="h-5 w-5 text-accent-cyan"
+                                aria-hidden="true"
+                            />
+                        </span>
+                        <div class="flex flex-col">
+                            <span class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                Queue
+                            </span>
+                            <span class="font-mono text-sm text-text-primary">
+                                {{ props.systemHealth.queue.pending }} pending
+                                · {{ props.systemHealth.queue.failed_5m }} failed/5m
+                            </span>
+                        </div>
+                    </div>
+                    <StatusBadge :tone="props.systemHealth.queue.status">
+                        {{ props.systemHealth.queue.status }}
+                    </StatusBadge>
+                </a>
+
+                <Link
+                    :href="route('settings.webhook-deliveries.index')"
+                    class="glass-card flex items-center justify-between gap-4 p-5 transition hover:border-accent-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                >
+                    <div class="flex items-center gap-3">
+                        <span
+                            class="flex h-10 w-10 items-center justify-center rounded-lg border border-border-subtle bg-background-panel-hover"
+                        >
+                            <Webhook
+                                class="h-5 w-5 text-accent-cyan"
+                                aria-hidden="true"
+                            />
+                        </span>
+                        <div class="flex flex-col">
+                            <span class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                Webhooks (5m)
+                            </span>
+                            <span class="font-mono text-sm text-text-primary">
+                                {{ props.systemHealth.webhooks.deliveries_5m }} delivered
+                                · {{ props.systemHealth.webhooks.failures_5m }} failed
+                            </span>
+                        </div>
+                    </div>
+                    <StatusBadge :tone="props.systemHealth.webhooks.status">
+                        {{ props.systemHealth.webhooks.failure_rate_percent !== null
+                            ? `${props.systemHealth.webhooks.failure_rate_percent}%`
+                            : props.systemHealth.webhooks.status }}
+                    </StatusBadge>
+                </Link>
+
+                <div
+                    class="glass-card flex items-center justify-between gap-4 p-5"
+                >
+                    <div class="flex items-center gap-3">
+                        <span
+                            class="flex h-10 w-10 items-center justify-center rounded-lg border border-border-subtle bg-background-panel-hover"
+                        >
+                            <Github
+                                class="h-5 w-5 text-text-primary"
+                                aria-hidden="true"
+                            />
+                        </span>
+                        <div class="flex flex-col">
+                            <span class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                GitHub rate-limit
+                            </span>
+                            <span class="font-mono text-sm text-text-primary">
+                                <template v-if="props.systemHealth.github_rate_limit.remaining !== null">
+                                    {{ props.systemHealth.github_rate_limit.remaining }} remaining
+                                </template>
+                                <template v-else>
+                                    No snapshot yet
+                                </template>
+                            </span>
+                        </div>
+                    </div>
+                    <StatusBadge :tone="props.systemHealth.github_rate_limit.status">
+                        {{ props.systemHealth.github_rate_limit.status }}
+                    </StatusBadge>
+                </div>
+
+                <Link
+                    :href="route('alerts.index')"
+                    class="glass-card flex items-center justify-between gap-4 p-5 transition hover:border-accent-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                >
+                    <div class="flex items-center gap-3">
+                        <span
+                            class="flex h-10 w-10 items-center justify-center rounded-lg border border-border-subtle bg-background-panel-hover"
+                        >
+                            <Bell
+                                class="h-5 w-5 text-accent-cyan"
+                                aria-hidden="true"
+                            />
+                        </span>
+                        <div class="flex flex-col">
+                            <span class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                Agent auth (5m)
+                            </span>
+                            <span class="font-mono text-sm text-text-primary">
+                                {{ props.systemHealth.agent_auth.failures_5m }} rejections
+                            </span>
+                        </div>
+                    </div>
+                    <StatusBadge :tone="props.systemHealth.agent_auth.status">
+                        {{ props.systemHealth.agent_auth.status }}
+                    </StatusBadge>
+                </Link>
+            </section>
+
             <!-- Section header -->
             <header class="flex items-center justify-between gap-3">
                 <div>

--- a/routes/console.php
+++ b/routes/console.php
@@ -3,6 +3,8 @@
 use App\Domain\Analytics\Jobs\RecomputeAllProjectHealthScoresJob;
 use App\Domain\Docker\Jobs\DetectOfflineHostsJob;
 use App\Domain\Monitoring\Jobs\DispatchDueWebsiteChecksJob;
+use App\Domain\Observability\Jobs\CheckGitHubRateLimitJob;
+use App\Domain\Observability\Jobs\EvaluateSystemHealthJob;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
@@ -53,3 +55,22 @@ Schedule::job(new RecomputeAllProjectHealthScoresJob)
     ->everyFiveMinutes()
     ->name('analytics:recompute-health-scores')
     ->withoutOverlapping(10);
+
+// Spec 038 — every-minute self-monitoring evaluator. Reads
+// `GetSystemHealthQuery` + triggers / resolves internal alerts on
+// the four §17 signals (queue / webhooks / GitHub rate / agent
+// auth). `withoutOverlapping` keyed on the job middleware so a slow
+// tick doesn't stack onto the next minute.
+Schedule::job(new EvaluateSystemHealthJob)
+    ->everyMinute()
+    ->name('observability:evaluate-system-health')
+    ->withoutOverlapping();
+
+// Spec 038 — every-10-minute poll of GitHub's `/rate_limit` per
+// connected user. Persists one snapshot per user; the system-health
+// query reads the latest row. Bounded HTTP volume (1 call per
+// connection per 10 min); stays well under any per-token quota.
+Schedule::job(new CheckGitHubRateLimitJob)
+    ->everyTenMinutes()
+    ->name('observability:check-github-rate-limit')
+    ->withoutOverlapping();

--- a/specs/phase-9-polish/038-nexus-self-monitoring.md
+++ b/specs/phase-9-polish/038-nexus-self-monitoring.md
@@ -1,0 +1,311 @@
+---
+spec: nexus-self-monitoring
+phase: 9
+status: in-progress   # not-started | in-progress | blocked | done
+owner: Yoany
+created: 2026-06-18
+updated: 2026-06-18
+---
+
+# 038 — Nexus self-monitoring: internal alerts + health card
+
+## Goal
+Phase 9 is about preparing Nexus for daily use. Specs 036 / 037
+hardened the front of house (loading states, error boundaries,
+retry logic). 038 turns the lens around: Nexus monitors itself.
+
+Today queue backlog, webhook failure rate, GitHub rate-limit
+remaining, and agent ingestion failures are all invisible until
+something breaks visibly downstream. Horizon at `/horizon` shows
+queue health, but it lives outside the Nexus UI and isn't linked
+from anywhere. The roadmap §17 list of "internal system alerts"
+(queue backlog too high, GitHub rate limit almost exhausted,
+webhook failures increasing, agent token invalid attempts) doesn't
+fire anywhere today.
+
+Three concrete shifts:
+
+1. **`EvaluateSystemHealthJob`** — scheduled every minute. Queries
+   four sources (queue / webhook deliveries / GitHub rate / agent
+   auth failures) against threshold tables. On a breach, calls
+   `TriggerAlertAction` with the existing `AlertSource::System`
+   vocabulary so the alert lands on `/alerts` next to user-level
+   alerts. Auto-resolves when the source recovers (uses the same
+   idempotency contract spec 030 ships).
+2. **System health card on `/settings`** — read-side
+   `GetSystemHealthQuery` exposes the same four signals as live
+   numbers. The card renders a `KpiCard`-style grid with status
+   tones + a "View details" link into Horizon for queue + Nexus's
+   own `/alerts` for the rest. No realtime — page-load reads only.
+3. **Agent auth-failure capture** — `AuthenticateAgent` middleware
+   already tracks rate-limit attempts via Laravel's `RateLimiter`.
+   Spec 038 adds an `agent.auth.failure` activity event on every
+   rejected token so the evaluator can count "invalid attempts in
+   last 5 min" without a new table.
+
+Roadmap refs: §17 Observability for Nexus Itself, §18 Error
+Handling (retry matrix consumes the new vocabulary), spec 030
+Alerts engine (reuses `TriggerAlertAction`).
+
+## Scope
+
+**In scope:**
+
+- **`AlertSource::System` adoption.** The enum case already exists
+  but no emitter uses it today. Spec 038 makes it the canonical
+  source for "Nexus is unhappy" alerts.
+
+- **`GetSystemHealthQuery` (`app/Domain/Observability/Queries/`).**
+  Read-only aggregate. Returns:
+  ```php
+  [
+      'queue' => [
+          'pending' => int,       // SELECT count from jobs
+          'failed_5m' => int,     // SELECT count from failed_jobs WHERE failed_at > now-5m
+          'status' => 'success'|'warning'|'danger'|'muted',
+      ],
+      'webhooks' => [
+          'deliveries_5m' => int,
+          'failures_5m' => int,
+          'failure_rate_percent' => float|null,
+          'status' => '...',
+      ],
+      'github_rate_limit' => [
+          'remaining' => int|null, // null when no recent snapshot
+          'reset_at_iso' => string|null,
+          'status' => '...',
+      ],
+      'agent_auth' => [
+          'failures_5m' => int,    // count of `agent.auth.failure` activity events
+          'status' => '...',
+      ],
+  ]
+  ```
+  No persistence — every value computes from the live tables.
+
+- **`CheckGitHubRateLimitJob` (`app/Domain/Observability/Jobs/`).**
+  Hits GitHub's `/rate_limit` endpoint once every 10 minutes per
+  *connected user* (queries `GithubConnection` for valid tokens).
+  Persists the response to a tiny `github_rate_limit_snapshots`
+  table (`user_id`, `remaining`, `limit`, `reset_at`,
+  `recorded_at`). The query above reads the latest snapshot. This
+  is the only new table — keeps the dashboard's rate-limit reading
+  honest without overloading every sync job's response path with
+  side-effects.
+
+- **`EvaluateSystemHealthJob`
+  (`app/Domain/Observability/Jobs/`).** Scheduled `everyMinute()`,
+  `withoutOverlapping()`. Runs `GetSystemHealthQuery` then, for
+  each signal whose status is `warning`/`danger`, calls
+  `TriggerAlertAction` with `AlertSource::System` +:
+  - `type: 'queue.backlog_high'` (severity = warning/critical by
+    threshold)
+  - `type: 'queue.failures_high'`
+  - `type: 'webhook.failure_rate_high'`
+  - `type: 'github.rate_limit_low'`
+  - `type: 'agent.auth_failures_high'`
+
+  On signals that recover (status flips back to `success`),
+  calls `ResolveAlertAction` against the same source + type.
+  Idempotency is automatic — `TriggerAlertAction` already returns
+  the existing open row if one matches.
+
+- **Thresholds (named constants on `EvaluateSystemHealthJob`).**
+  ```
+  QUEUE_BACKLOG_WARNING    = 100
+  QUEUE_BACKLOG_CRITICAL   = 500
+  QUEUE_FAILURES_5M_WARN   = 5
+  QUEUE_FAILURES_5M_CRIT   = 20
+  WEBHOOK_FAILRATE_WARN_PCT = 20
+  WEBHOOK_FAILRATE_CRIT_PCT = 50
+  WEBHOOK_MIN_SAMPLE       = 5    // don't fire on a quiet account
+  GITHUB_RATE_REMAINING_WARN = 100
+  GITHUB_RATE_REMAINING_CRIT = 20
+  AGENT_AUTH_FAILURES_5M_WARN = 10
+  AGENT_AUTH_FAILURES_5M_CRIT = 50
+  ```
+
+- **Agent auth-failure capture.** `AuthenticateAgent` middleware
+  on a rejected token (invalid hash, missing header, rate-limit
+  hit) dispatches an activity event:
+  ```php
+  CreateActivityEventAction::execute([
+      'event_type' => 'agent.auth.failure',
+      'severity' => ActivitySeverity::Warning,
+      'source' => 'agent',
+      'title' => 'Agent token rejected',
+      'metadata' => ['ip' => $request->ip(), 'reason' => $reason],
+  ]);
+  ```
+  The evaluator counts these for the `agent.auth_failures_high`
+  signal. No new table — activity events are the persistence.
+
+- **Settings page card.**
+  - `SettingsController` enriches the Inertia payload with the
+    `GetSystemHealthQuery` result.
+  - `Pages/Settings/Index.vue` renders a new "System health"
+    section above the existing Integrations block. Four small
+    `KpiCard`s in a 2x2 grid: Queue / Webhooks / GitHub rate /
+    Agent auth. Each carries a status badge + a "View details"
+    link (Horizon for queue, `/settings/webhook-deliveries` for
+    webhooks, `/alerts` for the rest).
+
+- **Tests.**
+  - `tests/Unit/Domain/Observability/Queries/GetSystemHealthQueryTest.php`
+    — happy path (all-green); each signal flips correctly per
+    threshold; empty-state (no deliveries / no agent traffic / no
+    snapshot) returns `muted`.
+  - `tests/Unit/Domain/Observability/Jobs/EvaluateSystemHealthJobTest.php`
+    — triggers an alert on threshold breach, doesn't re-trigger
+    when one already open (idempotency), auto-resolves on
+    recovery, doesn't fire when sample size is below
+    `WEBHOOK_MIN_SAMPLE`.
+  - `tests/Unit/Domain/Observability/Jobs/CheckGitHubRateLimitJobTest.php`
+    — happy path persists a snapshot; 401 marks the connection
+    expired (reuses spec 037's path); no GitHub connections → no
+    HTTP calls.
+  - `tests/Feature/Http/Middleware/AuthenticateAgentTest.php` —
+    extend with: invalid token dispatches `agent.auth.failure`
+    activity event; valid token does not.
+  - `tests/Feature/Settings/SystemHealthCardTest.php` — settings
+    payload carries the health shape; card renders four KPIs
+    with the expected statuses.
+
+**Out of scope:**
+
+- **Per-failure agent log table.** The activity event stream is
+  sufficient for the count signal; an indexed
+  `agent_ingestion_failures` table is a polish follow-up.
+- **Time-series graphs / sparklines.** The card shows current
+  values + status. A "queue depth over time" chart is its own
+  spec (would need a snapshots table + retention policy).
+- **Realtime updates.** Self-monitoring is intentionally a
+  page-load read — the worst-case 1-minute staleness matches the
+  evaluator's tick interval.
+- **Email / Slack / webhook notifications** when internal alerts
+  fire — `AlertNotificationService` stays deferred.
+- **Horizon dashboard theming.** The link from the queue card
+  points at Horizon's own UI; matching the dark theme is its
+  own polish spec.
+- **Database performance metrics** (slow-query log, connection
+  count). Roadmap §17 lists it but tooling is heavy; defer to
+  a perf-pass follow-up.
+- **`/admin` route.** Self-monitoring lives on `/settings` next
+  to the existing operational surfaces. A dedicated `/admin`
+  + role-based access lands with the multi-tenant migration.
+
+## Plan
+
+1. **`github_rate_limit_snapshots` table.** Migration:
+   ```php
+   $table->id();
+   $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+   $table->unsignedInteger('remaining');
+   $table->unsignedInteger('limit');
+   $table->timestamp('reset_at');
+   $table->timestamp('recorded_at')->index();
+   $table->timestamps();
+   ```
+   Model is bare — read access only.
+
+2. **`GetSystemHealthQuery`.** Pure read. Four private methods,
+   one per signal. Status mapper uses a small `statusFor()`
+   helper that takes the value + thresholds and returns the tone
+   string.
+
+3. **`EvaluateSystemHealthJob`.** `everyMinute()` schedule.
+   Inside: pull the query result, loop through the four signal
+   blocks, branch on status. For each warning/critical: trigger.
+   For each success that has a matching open alert: resolve.
+
+4. **`CheckGitHubRateLimitJob`.** Iterates connected users with
+   non-expired tokens, hits `GET /rate_limit`, upserts the
+   snapshot. Reuses spec 037's 401 expire-connection path.
+   `every10Minutes()` schedule.
+
+5. **Agent auth failure activity dispatch.** Patch
+   `AuthenticateAgent::handle()` to call
+   `CreateActivityEventAction` before returning 401/429/403.
+
+6. **Settings page integration.** Controller enriches payload;
+   Vue renders 2x2 KPI grid above Integrations.
+
+7. **Tests** per the list. Use `Queue::fake()` for trigger
+   verification, `Http::fake()` for GitHub's `/rate_limit`,
+   `Carbon::setTestNow()` for the windowed counts.
+
+8. **Pint clean, full suite + build green, self-review with
+   `superpowers:code-reviewer`, PR, watch CI, pause for merge.**
+
+## Acceptance criteria
+- [ ] Settings page renders a "System health" card with four
+      KPIs (Queue / Webhooks / GitHub rate / Agent auth), each
+      with a status tone and a context link.
+- [ ] Queue backlog > 100 → warning alert; > 500 → critical.
+      Backlog dropping back below threshold auto-resolves.
+- [ ] Webhook failure rate > 20% over the last 5 minutes (with
+      at least 5 deliveries in window) → warning alert. > 50% →
+      critical.
+- [ ] GitHub rate remaining < 100 (across the most-recent
+      snapshot for any connected user) → warning. < 20 →
+      critical.
+- [ ] Agent auth failures > 10 in 5 minutes → warning. > 50 →
+      critical.
+- [ ] Every rejected agent request dispatches an
+      `agent.auth.failure` activity event with the IP + reason
+      in metadata.
+- [ ] `EvaluateSystemHealthJob` runs every minute under the
+      scheduler; `CheckGitHubRateLimitJob` runs every 10 minutes.
+- [ ] Pint clean. `php artisan test` green. `npm run build`
+      clean.
+
+## Files touched
+- `database/migrations/2026_06_*_create_github_rate_limit_snapshots_table.php`
+- `app/Models/GithubRateLimitSnapshot.php` — created
+- `app/Domain/Observability/Queries/GetSystemHealthQuery.php` — created
+- `app/Domain/Observability/Jobs/EvaluateSystemHealthJob.php` — created
+- `app/Domain/Observability/Jobs/CheckGitHubRateLimitJob.php` — created
+- `routes/console.php` — schedule entries
+- `app/Http/Middleware/AuthenticateAgent.php` — activity dispatch on reject
+- `app/Http/Controllers/SettingsController.php` — pass health into payload
+- `resources/js/Pages/Settings/Index.vue` — System health card
+- `tests/Unit/Domain/Observability/Queries/GetSystemHealthQueryTest.php` — created
+- `tests/Unit/Domain/Observability/Jobs/EvaluateSystemHealthJobTest.php` — created
+- `tests/Unit/Domain/Observability/Jobs/CheckGitHubRateLimitJobTest.php` — created
+- `tests/Feature/Http/Middleware/AuthenticateAgentTest.php` — extended
+- `tests/Feature/Settings/SystemHealthCardTest.php` — created
+
+## Work log
+Dated notes as work progresses.
+
+### 2026-06-18
+- Drafted from `_template.md`. Builds on 030's `TriggerAlertAction`
+  for the internal-alert vocabulary and 037's
+  `GitHubApiException` plumbing for rate-limit awareness.
+- Branch `spec/038-nexus-self-monitoring` cut off main.
+- Tracking issue #112.
+- Scope shipped as drafted (no late edits requested).
+
+## Open questions / blockers
+
+- **Settings page vs. dedicated `/admin`.** Picked Settings to
+  keep the operational surfaces unified. If multi-tenant lands
+  and admin-only views become a thing, a `/admin/system-health`
+  page can wrap `GetSystemHealthQuery` without rewriting the
+  read path.
+- **GitHub rate-limit polling cadence.** Every 10 minutes per
+  connected user. With ~5 users that's ~30 API calls per hour
+  against the user's per-hour quota of 5000 — well under any
+  reasonable threshold. Could drop to every 30 min if users
+  complain.
+- **`agent.auth.failure` event volume.** A misbehaving agent in
+  a tight retry loop could spam the activity rail with one
+  event per second. The evaluator only counts the last 5 min,
+  but the rail / `/activity` page could surface noise.
+  Counter-measure: rate-limit the event dispatch in the
+  middleware (one event per IP per minute) — defer if it
+  becomes a problem.
+- **`Horizon::stats()` integration.** Could replace some of the
+  queue queries with live Horizon metrics if available, but the
+  raw `jobs` + `failed_jobs` count queries are cheap and
+  driver-agnostic — keep them for now.

--- a/tests/Feature/Agent/AuthenticateAgentMiddlewareTest.php
+++ b/tests/Feature/Agent/AuthenticateAgentMiddlewareTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Agent;
 
 use App\Domain\Docker\Actions\IssueAgentTokenAction;
+use App\Models\ActivityEvent;
 use App\Models\AgentToken;
 use App\Models\Host;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -113,5 +114,53 @@ class AuthenticateAgentMiddlewareTest extends TestCase
         )->assertStatus(401);
 
         $this->assertNull($token->fresh()->last_used_at);
+    }
+
+    public function test_missing_bearer_dispatches_agent_auth_failure_event(): void
+    {
+        // Spec 038 — the system-health evaluator counts these for the
+        // `agent.auth_failures_high` signal. Every reject path needs
+        // to emit the activity event.
+        $this->postJson(route('agent.telemetry'), $this->payload())
+            ->assertStatus(401);
+
+        $event = ActivityEvent::query()
+            ->where('event_type', 'agent.auth.failure')
+            ->firstOrFail();
+        $this->assertSame('missing_bearer_token', $event->metadata['reason']);
+        $this->assertSame('agent', $event->source);
+    }
+
+    public function test_invalid_token_dispatches_agent_auth_failure_event(): void
+    {
+        $this->postJson(
+            route('agent.telemetry'),
+            $this->payload(),
+            ['Authorization' => 'Bearer nonsense-token-here'],
+        )->assertStatus(401);
+
+        $event = ActivityEvent::query()
+            ->where('event_type', 'agent.auth.failure')
+            ->firstOrFail();
+        $this->assertSame('invalid_token', $event->metadata['reason']);
+    }
+
+    public function test_valid_request_does_not_dispatch_agent_auth_failure(): void
+    {
+        $host = Host::factory()->create();
+        $result = app(IssueAgentTokenAction::class)->execute($host);
+
+        $this->postJson(
+            route('agent.telemetry'),
+            $this->payload(),
+            ['Authorization' => 'Bearer '.$result->plaintext],
+        )->assertNoContent();
+
+        $this->assertSame(
+            0,
+            ActivityEvent::query()
+                ->where('event_type', 'agent.auth.failure')
+                ->count(),
+        );
     }
 }

--- a/tests/Feature/Settings/SystemHealthCardTest.php
+++ b/tests/Feature/Settings/SystemHealthCardTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature\Settings;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class SystemHealthCardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_settings_payload_carries_system_health_shape(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($user)
+            ->get(route('settings.index'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Settings/Index')
+                    ->has('systemHealth.queue.pending')
+                    ->has('systemHealth.queue.failed_5m')
+                    ->has('systemHealth.queue.status')
+                    ->has('systemHealth.webhooks.deliveries_5m')
+                    ->has('systemHealth.webhooks.failures_5m')
+                    ->has('systemHealth.webhooks.status')
+                    ->has('systemHealth.github_rate_limit.status')
+                    ->has('systemHealth.agent_auth.failures_5m')
+                    ->has('systemHealth.agent_auth.status'),
+            );
+    }
+}

--- a/tests/Unit/Domain/Observability/Jobs/CheckGitHubRateLimitJobTest.php
+++ b/tests/Unit/Domain/Observability/Jobs/CheckGitHubRateLimitJobTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Unit\Domain\Observability\Jobs;
+
+use App\Domain\Observability\Jobs\CheckGitHubRateLimitJob;
+use App\Models\GithubConnection;
+use App\Models\GithubRateLimitSnapshot;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class CheckGitHubRateLimitJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_no_op_when_no_connections_exist(): void
+    {
+        Http::fake();
+
+        (new CheckGitHubRateLimitJob)->handle();
+
+        $this->assertSame(0, GithubRateLimitSnapshot::query()->count());
+        Http::assertNothingSent();
+    }
+
+    public function test_persists_a_snapshot_per_connection(): void
+    {
+        $user = User::factory()->create();
+        GithubConnection::query()->create([
+            'user_id' => $user->id,
+            'github_user_id' => '9001',
+            'github_username' => 'octocat',
+            'access_token' => 'gho_token',
+            'expires_at' => now()->addHours(8),
+            'connected_at' => now(),
+        ]);
+
+        Http::fake([
+            'api.github.com/rate_limit' => Http::response([
+                'resources' => [
+                    'core' => [
+                        'limit' => 5000,
+                        'remaining' => 4321,
+                        'reset' => 1700000000,
+                    ],
+                ],
+            ]),
+        ]);
+
+        (new CheckGitHubRateLimitJob)->handle();
+
+        $snapshot = GithubRateLimitSnapshot::query()->where('user_id', $user->id)->firstOrFail();
+        $this->assertSame(4321, $snapshot->remaining);
+        $this->assertSame(5000, $snapshot->limit);
+        $this->assertSame(1700000000, $snapshot->reset_at->getTimestamp());
+    }
+
+    public function test_skips_connection_on_api_failure_without_crashing(): void
+    {
+        $user = User::factory()->create();
+        GithubConnection::query()->create([
+            'user_id' => $user->id,
+            'github_user_id' => '9001',
+            'github_username' => 'octocat',
+            'access_token' => 'gho_token',
+            'expires_at' => now()->addHours(8),
+            'connected_at' => now(),
+        ]);
+
+        Http::fake([
+            'api.github.com/rate_limit' => Http::response(['message' => 'Bad credentials'], 401),
+        ]);
+
+        // Should not throw.
+        (new CheckGitHubRateLimitJob)->handle();
+
+        $this->assertSame(0, GithubRateLimitSnapshot::query()->count());
+    }
+
+    public function test_skips_expired_connections(): void
+    {
+        $user = User::factory()->create();
+        GithubConnection::query()->create([
+            'user_id' => $user->id,
+            'github_user_id' => '9001',
+            'github_username' => 'octocat',
+            'access_token' => '', // spec 037 expire flow blanks the token
+            'expires_at' => now()->subHour(),
+            'connected_at' => now()->subDay(),
+        ]);
+
+        Http::fake();
+
+        (new CheckGitHubRateLimitJob)->handle();
+
+        Http::assertNothingSent();
+        $this->assertSame(0, GithubRateLimitSnapshot::query()->count());
+    }
+}

--- a/tests/Unit/Domain/Observability/Jobs/EvaluateSystemHealthJobTest.php
+++ b/tests/Unit/Domain/Observability/Jobs/EvaluateSystemHealthJobTest.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Tests\Unit\Domain\Observability\Jobs;
+
+use App\Domain\Alerts\Actions\ResolveAlertAction;
+use App\Domain\Alerts\Actions\TriggerAlertAction;
+use App\Domain\Observability\Jobs\EvaluateSystemHealthJob;
+use App\Domain\Observability\Queries\GetSystemHealthQuery;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
+use App\Models\ActivityEvent;
+use App\Models\Alert;
+use App\Models\GithubRateLimitSnapshot;
+use App\Models\User;
+use App\Models\WebhookDelivery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class EvaluateSystemHealthJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function runJob(): void
+    {
+        $job = app(EvaluateSystemHealthJob::class);
+        $job->handle(
+            app(GetSystemHealthQuery::class),
+            app(TriggerAlertAction::class),
+            app(ResolveAlertAction::class),
+        );
+    }
+
+    public function test_does_nothing_when_all_signals_are_green(): void
+    {
+        $this->runJob();
+
+        $this->assertSame(0, Alert::query()->count());
+    }
+
+    public function test_triggers_queue_backlog_alert_at_warning_threshold(): void
+    {
+        for ($i = 0; $i < 101; $i++) {
+            DB::table('jobs')->insert([
+                'queue' => 'default',
+                'payload' => '{}',
+                'attempts' => 0,
+                'reserved_at' => null,
+                'available_at' => now()->timestamp,
+                'created_at' => now()->timestamp,
+            ]);
+        }
+
+        $this->runJob();
+
+        $alert = Alert::query()->where('type', 'queue.backlog_high')->firstOrFail();
+        $this->assertSame(AlertSource::System, $alert->source);
+        $this->assertSame(AlertSeverity::Warning, $alert->severity);
+        $this->assertSame(AlertStatus::Open, $alert->status);
+        $this->assertNull($alert->project_id);
+    }
+
+    public function test_triggers_queue_backlog_critical_at_500(): void
+    {
+        for ($i = 0; $i < 501; $i++) {
+            DB::table('jobs')->insert([
+                'queue' => 'default',
+                'payload' => '{}',
+                'attempts' => 0,
+                'reserved_at' => null,
+                'available_at' => now()->timestamp,
+                'created_at' => now()->timestamp,
+            ]);
+        }
+
+        $this->runJob();
+
+        $alert = Alert::query()->where('type', 'queue.backlog_high')->firstOrFail();
+        $this->assertSame(AlertSeverity::Critical, $alert->severity);
+    }
+
+    public function test_idempotent_on_repeated_runs(): void
+    {
+        for ($i = 0; $i < 150; $i++) {
+            DB::table('jobs')->insert([
+                'queue' => 'default',
+                'payload' => '{}',
+                'attempts' => 0,
+                'reserved_at' => null,
+                'available_at' => now()->timestamp,
+                'created_at' => now()->timestamp,
+            ]);
+        }
+
+        $this->runJob();
+        $this->runJob();
+        $this->runJob();
+
+        $this->assertSame(
+            1,
+            Alert::query()->where('type', 'queue.backlog_high')->count(),
+            'TriggerAlertAction idempotency: one open alert, not three.',
+        );
+    }
+
+    public function test_resolves_queue_alert_when_backlog_clears(): void
+    {
+        // Trigger first.
+        for ($i = 0; $i < 150; $i++) {
+            DB::table('jobs')->insert([
+                'queue' => 'default',
+                'payload' => '{}',
+                'attempts' => 0,
+                'reserved_at' => null,
+                'available_at' => now()->timestamp,
+                'created_at' => now()->timestamp,
+            ]);
+        }
+        $this->runJob();
+
+        $this->assertSame(
+            AlertStatus::Open,
+            Alert::query()->where('type', 'queue.backlog_high')->firstOrFail()->status,
+        );
+
+        // Drain the queue + re-run — alert should auto-resolve.
+        DB::table('jobs')->truncate();
+        $this->runJob();
+
+        $this->assertSame(
+            AlertStatus::Resolved,
+            Alert::query()->where('type', 'queue.backlog_high')->firstOrFail()->status,
+        );
+    }
+
+    public function test_webhook_failure_rate_below_sample_floor_does_not_fire(): void
+    {
+        WebhookDelivery::factory()->create([
+            'status' => 'failed',
+            'received_at' => now()->subMinutes(2),
+        ]);
+
+        $this->runJob();
+
+        $this->assertSame(0, Alert::query()->where('type', 'webhook.failure_rate_high')->count());
+    }
+
+    public function test_webhook_warning_at_20_percent_failure_rate(): void
+    {
+        WebhookDelivery::factory()->count(4)->create([
+            'status' => 'processed',
+            'received_at' => now()->subMinutes(2),
+        ]);
+        WebhookDelivery::factory()->create([
+            'status' => 'failed',
+            'received_at' => now()->subMinutes(2),
+        ]);
+
+        $this->runJob();
+
+        $alert = Alert::query()->where('type', 'webhook.failure_rate_high')->firstOrFail();
+        $this->assertSame(AlertSeverity::Warning, $alert->severity);
+    }
+
+    public function test_github_rate_low_triggers_warning_then_resolves_when_replenished(): void
+    {
+        $user = User::factory()->create();
+
+        // Low snapshot — triggers.
+        GithubRateLimitSnapshot::create([
+            'user_id' => $user->id,
+            'remaining' => 50,
+            'limit' => 5000,
+            'reset_at' => now()->addHour(),
+            'recorded_at' => now(),
+        ]);
+        $this->runJob();
+
+        $alert = Alert::query()->where('type', 'github.rate_limit_low')->firstOrFail();
+        $this->assertSame(AlertStatus::Open, $alert->status);
+        $this->assertSame(AlertSeverity::Warning, $alert->severity);
+
+        // Fresh higher snapshot — resolves.
+        GithubRateLimitSnapshot::create([
+            'user_id' => $user->id,
+            'remaining' => 4000,
+            'limit' => 5000,
+            'reset_at' => now()->addHour(),
+            'recorded_at' => now()->addSeconds(10),
+        ]);
+        $this->runJob();
+
+        $this->assertSame(
+            AlertStatus::Resolved,
+            Alert::query()->where('type', 'github.rate_limit_low')->firstOrFail()->status,
+        );
+    }
+
+    public function test_agent_auth_failures_trigger_warning(): void
+    {
+        ActivityEvent::factory()->count(12)->create([
+            'event_type' => 'agent.auth.failure',
+            'source' => 'agent',
+            'occurred_at' => now()->subMinutes(2),
+        ]);
+
+        $this->runJob();
+
+        $alert = Alert::query()->where('type', 'agent.auth_failures_high')->firstOrFail();
+        $this->assertSame(AlertSeverity::Warning, $alert->severity);
+    }
+}

--- a/tests/Unit/Domain/Observability/Queries/GetSystemHealthQueryTest.php
+++ b/tests/Unit/Domain/Observability/Queries/GetSystemHealthQueryTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Tests\Unit\Domain\Observability\Queries;
+
+use App\Domain\Observability\Queries\GetSystemHealthQuery;
+use App\Enums\WebhookDeliveryStatus;
+use App\Models\ActivityEvent;
+use App\Models\GithubRateLimitSnapshot;
+use App\Models\User;
+use App\Models\WebhookDelivery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class GetSystemHealthQueryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_returns_all_green_when_nothing_is_wrong(): void
+    {
+        $result = app(GetSystemHealthQuery::class)->execute();
+
+        $this->assertSame('success', $result['queue']['status']);
+        $this->assertSame(0, $result['queue']['pending']);
+        // Webhooks: no traffic -> muted (not success).
+        $this->assertSame('muted', $result['webhooks']['status']);
+        $this->assertSame('muted', $result['github_rate_limit']['status']);
+        $this->assertNull($result['github_rate_limit']['remaining']);
+        $this->assertSame('success', $result['agent_auth']['status']);
+        $this->assertSame(0, $result['agent_auth']['failures_5m']);
+    }
+
+    public function test_queue_warning_when_pending_exceeds_100(): void
+    {
+        // Seed 101 dummy job rows.
+        for ($i = 0; $i < 101; $i++) {
+            DB::table('jobs')->insert([
+                'queue' => 'default',
+                'payload' => '{}',
+                'attempts' => 0,
+                'reserved_at' => null,
+                'available_at' => now()->timestamp,
+                'created_at' => now()->timestamp,
+            ]);
+        }
+
+        $result = app(GetSystemHealthQuery::class)->execute();
+
+        $this->assertSame(101, $result['queue']['pending']);
+        $this->assertSame('warning', $result['queue']['status']);
+    }
+
+    public function test_queue_danger_when_pending_exceeds_500(): void
+    {
+        for ($i = 0; $i < 501; $i++) {
+            DB::table('jobs')->insert([
+                'queue' => 'default',
+                'payload' => '{}',
+                'attempts' => 0,
+                'reserved_at' => null,
+                'available_at' => now()->timestamp,
+                'created_at' => now()->timestamp,
+            ]);
+        }
+
+        $result = app(GetSystemHealthQuery::class)->execute();
+
+        $this->assertSame('danger', $result['queue']['status']);
+    }
+
+    public function test_queue_failures_counted_only_within_5m_window(): void
+    {
+        DB::table('failed_jobs')->insert([
+            'uuid' => 'a',
+            'connection' => 'database',
+            'queue' => 'default',
+            'payload' => '{}',
+            'exception' => 'Boom',
+            'failed_at' => now()->subMinutes(2),
+        ]);
+        DB::table('failed_jobs')->insert([
+            'uuid' => 'b',
+            'connection' => 'database',
+            'queue' => 'default',
+            'payload' => '{}',
+            'exception' => 'Boom',
+            // Old failure — must NOT count toward the 5m window.
+            'failed_at' => now()->subHours(2),
+        ]);
+
+        $result = app(GetSystemHealthQuery::class)->execute();
+
+        $this->assertSame(1, $result['queue']['failed_5m']);
+    }
+
+    public function test_webhook_rate_below_min_sample_stays_quiet(): void
+    {
+        // Single failed delivery — sample size < 5, should be `success`
+        // (no panic on a quiet account).
+        WebhookDelivery::factory()->create([
+            'status' => WebhookDeliveryStatus::Failed->value,
+            'received_at' => now()->subMinutes(2),
+        ]);
+
+        $result = app(GetSystemHealthQuery::class)->execute();
+
+        $this->assertSame(1, $result['webhooks']['deliveries_5m']);
+        $this->assertSame(1, $result['webhooks']['failures_5m']);
+        $this->assertNull($result['webhooks']['failure_rate_percent']);
+        $this->assertSame('success', $result['webhooks']['status']);
+    }
+
+    public function test_webhook_warning_at_20_percent_failure_rate_with_sample(): void
+    {
+        // 5 deliveries, 1 failure = 20%.
+        WebhookDelivery::factory()->count(4)->create([
+            'status' => WebhookDeliveryStatus::Processed->value,
+            'received_at' => now()->subMinutes(2),
+        ]);
+        WebhookDelivery::factory()->create([
+            'status' => WebhookDeliveryStatus::Failed->value,
+            'received_at' => now()->subMinutes(2),
+        ]);
+
+        $result = app(GetSystemHealthQuery::class)->execute();
+
+        $this->assertSame(5, $result['webhooks']['deliveries_5m']);
+        $this->assertSame(20.0, $result['webhooks']['failure_rate_percent']);
+        $this->assertSame('warning', $result['webhooks']['status']);
+    }
+
+    public function test_webhook_danger_at_50_percent_failure_rate(): void
+    {
+        WebhookDelivery::factory()->count(3)->create([
+            'status' => WebhookDeliveryStatus::Processed->value,
+            'received_at' => now()->subMinutes(2),
+        ]);
+        WebhookDelivery::factory()->count(3)->create([
+            'status' => WebhookDeliveryStatus::Failed->value,
+            'received_at' => now()->subMinutes(2),
+        ]);
+
+        $result = app(GetSystemHealthQuery::class)->execute();
+
+        $this->assertSame(50.0, $result['webhooks']['failure_rate_percent']);
+        $this->assertSame('danger', $result['webhooks']['status']);
+    }
+
+    public function test_github_rate_limit_reads_latest_snapshot(): void
+    {
+        $user = User::factory()->create();
+        GithubRateLimitSnapshot::create([
+            'user_id' => $user->id,
+            'remaining' => 1000,
+            'limit' => 5000,
+            'reset_at' => now()->addHour(),
+            'recorded_at' => now()->subMinutes(20),
+        ]);
+        GithubRateLimitSnapshot::create([
+            'user_id' => $user->id,
+            'remaining' => 50,
+            'limit' => 5000,
+            'reset_at' => now()->addHour(),
+            'recorded_at' => now()->subMinutes(1),
+        ]);
+
+        $result = app(GetSystemHealthQuery::class)->execute();
+
+        $this->assertSame(50, $result['github_rate_limit']['remaining']);
+        // 50 < 100 floor → warning.
+        $this->assertSame('warning', $result['github_rate_limit']['status']);
+    }
+
+    public function test_github_rate_limit_danger_when_under_20(): void
+    {
+        $user = User::factory()->create();
+        GithubRateLimitSnapshot::create([
+            'user_id' => $user->id,
+            'remaining' => 5,
+            'limit' => 5000,
+            'reset_at' => now()->addHour(),
+            'recorded_at' => now(),
+        ]);
+
+        $result = app(GetSystemHealthQuery::class)->execute();
+
+        $this->assertSame('danger', $result['github_rate_limit']['status']);
+    }
+
+    public function test_agent_auth_counts_recent_auth_failure_activity_events(): void
+    {
+        ActivityEvent::factory()->count(11)->create([
+            'event_type' => 'agent.auth.failure',
+            'source' => 'agent',
+            'occurred_at' => now()->subMinutes(2),
+        ]);
+        ActivityEvent::factory()->create([
+            'event_type' => 'agent.auth.failure',
+            'source' => 'agent',
+            'occurred_at' => now()->subHours(2), // outside 5m window
+        ]);
+
+        $result = app(GetSystemHealthQuery::class)->execute();
+
+        $this->assertSame(11, $result['agent_auth']['failures_5m']);
+        $this->assertSame('warning', $result['agent_auth']['status']);
+    }
+
+    public function test_agent_auth_danger_at_50_failures(): void
+    {
+        ActivityEvent::factory()->count(51)->create([
+            'event_type' => 'agent.auth.failure',
+            'source' => 'agent',
+            'occurred_at' => now()->subMinutes(1),
+        ]);
+
+        $result = app(GetSystemHealthQuery::class)->execute();
+
+        $this->assertSame('danger', $result['agent_auth']['status']);
+    }
+
+    public function test_agent_auth_other_events_do_not_count(): void
+    {
+        // A different event_type must not pollute the counter.
+        ActivityEvent::factory()->count(50)->create([
+            'event_type' => 'host.offline',
+            'source' => 'hosts',
+            'occurred_at' => now()->subMinutes(1),
+        ]);
+
+        $result = app(GetSystemHealthQuery::class)->execute();
+
+        $this->assertSame(0, $result['agent_auth']['failures_5m']);
+        $this->assertSame('success', $result['agent_auth']['status']);
+    }
+}


### PR DESCRIPTION
Closes #112

Spec: \`specs/phase-9-polish/038-nexus-self-monitoring.md\`

Lights up the roadmap §17 internal-alert list. Every minute, an \`EvaluateSystemHealthJob\` queries 4 signals (queue / webhook / GitHub-rate / agent auth) against named thresholds and fires \`TriggerAlertAction\` with \`AlertSource::System\` on breach. \`GetSystemHealthQuery\` powers a 4-up KPI grid on \`/settings\`.

## Summary

- **\`GetSystemHealthQuery\`** — pure read aggregate. Queue backlog (\`jobs\` count) + 5m failures (\`failed_jobs\`), webhook 5m success/failure (\`github_webhook_deliveries\`), GitHub rate-limit (latest \`github_rate_limit_snapshots\`), agent-auth failures (\`activity_events\` where \`event_type = agent.auth.failure\`).
- **\`EvaluateSystemHealthJob\`** — \`everyMinute()\` scheduled. Triggers internal alerts on threshold breach; auto-resolves via spec 030's \`(source, source_id, type)\` idempotency on recovery.
- **\`SystemHealthThresholds\`** class — single source of truth for the threshold numbers, imported by both query (status tones) + job (alert decisions).
- **\`CheckGitHubRateLimitJob\`** — \`every10Minutes()\` scheduled. Polls GitHub's \`/rate_limit\` per connected user. New \`GitHubClient::fetchRateLimit()\` method on the existing client.
- **New \`github_rate_limit_snapshots\` table** + small migration to make \`alerts.project_id\` nullable for \`AlertSource::System\` rows.
- **\`AuthenticateAgent\` middleware** — dispatches \`agent.auth.failure\` activity events on every reject (missing bearer / invalid token / rate-limited). Deduped per-IP-per-reason-per-minute via \`RateLimiter::attempt\` so a misbehaving agent doesn't pump the activity_events table at request rate. Severity \`Info\` (first hit isn't alarming; evaluator owns the count threshold).
- **System health card on \`/settings\`** — 4-up KPI grid above Integrations. Each tile shows live value + status badge + context link (Horizon for queue, \`/settings/webhook-deliveries\` for webhooks, \`/alerts\` for the rest).
- **\`AlertController\`** filter relaxed: queries the user's project alerts \`OR\` system alerts (otherwise the System alerts the evaluator opens would be invisible on \`/alerts\`).

## Test plan

- [x] System health card on \`/settings\` renders 4 KPIs with status tones + context links.
- [x] Queue backlog > 100 → warning alert; > 500 → critical. Drop-back auto-resolves.
- [x] Webhook failure rate > 20% over 5m (≥ 5 deliveries) → warning; > 50% → critical.
- [x] GitHub rate remaining < 100 → warning; < 20 → critical.
- [x] Agent auth failures > 10 in 5m → warning; > 50 → critical.
- [x] Every rejected agent request dispatches \`agent.auth.failure\` (deduped per IP+reason per minute).
- [x] Repeated runs of \`EvaluateSystemHealthJob\` produce one open alert per signal (idempotent).
- [x] \`AlertController\` shows system alerts on \`/alerts\` even though they have no project_id.
- [x] Pint clean. \`php artisan test\` green (744 / 2835). \`npm run build\` clean.

## Self-review notes

Reviewed by \`superpowers:code-reviewer\`. Verdict: 2 critical blockers + 2 important — all applied:

1. **Critical: System alerts invisible on \`/alerts\`.** \`AlertController\`'s \`whereHas('project', ...)\` excluded null project_id rows. Fixed: relaxed scope to \`whereHas\` OR \`source = system\`.
2. **Critical: Missing \`use DB\` in rollback migration.** \`make_alerts_project_id_nullable.php\` called \`DB::table\` in \`down()\` without importing the facade — would fatal on rollback. Added the import + a clarifying comment.
3. **Important: Threshold duplication.** Query + job both had hard-coded numbers. Extracted to \`SystemHealthThresholds\` so they share one source of truth.
4. **Important: \`activity_events\` storage growth.** A misbehaving agent could pump 60+ events/minute. Added \`RateLimiter::attempt\` dedupe per IP+reason+minute. Evaluator's 5-min count threshold still trips cleanly.
5. **Bonus: \`access_token != ''\` filter on encrypted column was a no-op.** Removed — the \`expires_at\` filter alone is sufficient.

Key reviewer answers:
- \`GetAlertMetricsQuery\` excluding system alerts is intentional (per-user analytics shouldn't count global signals).
- \`agent.auth.failure\` events with \`source = 'agent'\` are excluded from \`ActivityEventCreated::broadcastOn()\` + \`RecentActivityForUserQuery\` — happy accident: no rail noise.
- \`CheckGitHubRateLimitJob\` doesn't need a \`failed()\` handler — per-connection failures are caught + logged, loop completes; next tick's evaluator will see \`remaining = null\` (muted).
- \`$tries = 1\` on the evaluator is right; every-minute schedule is the retry.

Deferred follow-ups (non-blocking):
- Activity event pruning policy — table will grow under load; needs a housekeeping job.
- Threshold tuning UI — phase-2 polish.
- Per-host system-alert source_id strategy when scoped signals land (eg. per-host disk pressure).