### PR TITLE
chore(specs): flip 039 to done + Phase 9 tracker 4/6

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -44,7 +44,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 6 | Docker Host Agent MVP | 🟢 | 4/4 specs done (026–029). Phase complete. |
 | 7 | Alerts Engine | 🟢 | 3/3 specs done (030–032). Phase complete. |
 | 8 | Analytics & Health Scores | 🟢 | 3/3 specs done (033–035). Phase complete. |
-| 9 | Polish & Production Readiness | 🟡 | 3/6 specs done (036–038). 039 security, 040 core-flow-tests, 041 production-docs pending. |
+| 9 | Polish & Production Readiness | 🟡 | 4/6 specs done (036–039). 040 core-flow-tests, 041 production-docs pending. |
 | 10 | Future Innovation | ⬜ | — |
 
 ## MVP scope (target for v1)

--- a/specs/phase-9-polish/039-security-audit.md
+++ b/specs/phase-9-polish/039-security-audit.md
@@ -1,7 +1,7 @@
 ---
 spec: security-audit
 phase: 9
-status: in-progress   # not-started | in-progress | blocked | done
+status: done   # not-started | in-progress | blocked | done
 owner: Yoany
 created: 2026-06-24
 updated: 2026-06-24

--- a/specs/phase-9-polish/README.md
+++ b/specs/phase-9-polish/README.md
@@ -27,7 +27,7 @@ docs alone.
 | 036 | UX polish — skeleton loading, empty / error states, reduced-motion, light-mode toggle, responsive edge cases | 🟢 |
 | 037 | Reliability hardening — job retry/backoff, rate-limit response handling, webhook retry UI | 🟢 |
 | 038 | Nexus self-monitoring — internal alerts (queue / GitHub-rate / webhook / agent failures) + observability slice | 🟢 |
-| 039 | Security audit — token encryption pass, Horizon production allow-list, agent fingerprinting opt-in, rate-limit coverage | ⬜ |
+| 039 | Security audit — token encryption pass, Horizon production allow-list, agent fingerprinting opt-in, rate-limit coverage | 🟢 |
 | 040 | Core-flow test coverage — auth → project → repo sync → webhook → alert → resolve, plus seeding-quality fixtures | ⬜ |
 | 041 | Production docs — installation guide, deployment playbook (supervisor / systemd), backup strategy, `.env.production.example` | ⬜ |
 


### PR DESCRIPTION
Spec 039 (#115 / PR #116) merged. Bookkeeping: spec frontmatter → `done`, Phase 9 README row → 🟢, master tracker → 4/6 specs done.

Next on Phase 9: 040 core-flow test coverage (auth → project → repo sync → webhook → alert → resolve, plus seeding-quality fixtures).