### PR TITLE
chore(specs): flip 040 to done + Phase 9 tracker 5/6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _ide_helper.php
 Homestead.json
 Homestead.yaml
 Thumbs.db
+.atl/

--- a/specs/README.md
+++ b/specs/README.md
@@ -44,7 +44,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 6 | Docker Host Agent MVP | 🟢 | 4/4 specs done (026–029). Phase complete. |
 | 7 | Alerts Engine | 🟢 | 3/3 specs done (030–032). Phase complete. |
 | 8 | Analytics & Health Scores | 🟢 | 3/3 specs done (033–035). Phase complete. |
-| 9 | Polish & Production Readiness | 🟡 | 4/6 specs done (036–039). 040 core-flow-tests, 041 production-docs pending. |
+| 9 | Polish & Production Readiness | 🟡 | 5/6 specs done (036–040). 041 production-docs remaining to close Phase 9. |
 | 10 | Future Innovation | ⬜ | — |
 
 ## MVP scope (target for v1)

--- a/specs/phase-9-polish/040-core-flow-test-coverage.md
+++ b/specs/phase-9-polish/040-core-flow-test-coverage.md
@@ -1,10 +1,10 @@
 ---
 spec: core-flow-test-coverage
 phase: 9
-status: in-progress   # not-started | in-progress | blocked | done
+status: done   # not-started | in-progress | blocked | done
 owner: Yoany
 created: 2026-06-25
-updated: 2026-06-25
+updated: 2026-07-01
 ---
 
 # 040 — Core-flow test coverage + believable seeder

--- a/specs/phase-9-polish/README.md
+++ b/specs/phase-9-polish/README.md
@@ -28,7 +28,7 @@ docs alone.
 | 037 | Reliability hardening — job retry/backoff, rate-limit response handling, webhook retry UI | 🟢 |
 | 038 | Nexus self-monitoring — internal alerts (queue / GitHub-rate / webhook / agent failures) + observability slice | 🟢 |
 | 039 | Security audit — token encryption pass, Horizon production allow-list, agent fingerprinting opt-in, rate-limit coverage | 🟢 |
-| 040 | Core-flow test coverage — auth → project → repo sync → webhook → alert → resolve, plus seeding-quality fixtures | ⬜ |
+| 040 | Core-flow test coverage — auth → project → repo sync → webhook → alert → resolve, plus seeding-quality fixtures | 🟢 |
 | 041 | Production docs — installation guide, deployment playbook (supervisor / systemd), backup strategy, `.env.production.example` | ⬜ |
 
 ## Acceptance criteria (phase-level)


### PR DESCRIPTION
Spec 040 (#118 / PR #119) merged. Bookkeeping: spec frontmatter → `done`, Phase 9 README row → 🟢, master tracker → 5/6 specs done.

Also gitignores `.atl/` (editor artifacts).

Only spec 041 (production docs — installation guide, deployment playbook, backup strategy, `.env.production.example`) remains to close Phase 9.