### PR TITLE
Spec 042 — AlertNotificationService: email + Slack + generic webhook delivery

### DIFF
--- a/app/Domain/Alerts/Actions/ResolveAlertAction.php
+++ b/app/Domain/Alerts/Actions/ResolveAlertAction.php
@@ -3,6 +3,7 @@
 namespace App\Domain\Alerts\Actions;
 
 use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Domain\Notifications\Services\AlertNotificationService;
 use App\Enums\ActivitySeverity;
 use App\Enums\AlertSource;
 use App\Enums\AlertStatus;
@@ -10,6 +11,8 @@ use App\Events\AlertResolved;
 use App\Models\Alert;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 /**
  * Close every open or acknowledged Alert matching a recovery
@@ -50,6 +53,7 @@ class ResolveAlertAction
 {
     public function __construct(
         private readonly CreateActivityEventAction $createActivity,
+        private readonly AlertNotificationService $notifications,
     ) {}
 
     /**
@@ -147,6 +151,17 @@ class ResolveAlertAction
             // commit).
             $alert->loadMissing('project:id,owner_user_id');
             AlertResolved::dispatch($alert->id, $alert->project?->owner_user_id);
+
+            // Spec 042 — resolution notification is opt-in per
+            // preference row (`notify_on_resolve`). Fire-and-forget.
+            try {
+                $this->notifications->dispatchResolutionFor($alert);
+            } catch (Throwable $e) {
+                Log::warning('AlertNotificationService::dispatchResolutionFor failed', [
+                    'alert_id' => $alert->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
 
             return true;
         });

--- a/app/Domain/Alerts/Actions/TriggerAlertAction.php
+++ b/app/Domain/Alerts/Actions/TriggerAlertAction.php
@@ -3,12 +3,15 @@
 namespace App\Domain\Alerts\Actions;
 
 use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Domain\Notifications\Services\AlertNotificationService;
 use App\Enums\AlertSeverity;
 use App\Enums\AlertSource;
 use App\Enums\AlertStatus;
 use App\Events\AlertTriggered;
 use App\Models\Alert;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 /**
  * Promote a transition event into a durable Alert row (spec 030).
@@ -40,6 +43,7 @@ class TriggerAlertAction
 {
     public function __construct(
         private readonly CreateActivityEventAction $createActivity,
+        private readonly AlertNotificationService $notifications,
     ) {}
 
     /**
@@ -126,6 +130,20 @@ class TriggerAlertAction
         // re-firing source doesn't double-toast.
         $alert->loadMissing('project:id,owner_user_id');
         AlertTriggered::dispatch($alert->id, $alert->project?->owner_user_id);
+
+        // Spec 042 — fan out to configured notification channels.
+        // Fire-and-forget: the trigger path never fails because a
+        // notification enqueue errored. The service enqueues jobs;
+        // driver failures land in `alert_deliveries` as `failed` and
+        // surface in Settings → Notifications → Deliveries.
+        try {
+            $this->notifications->dispatchFor($alert);
+        } catch (Throwable $e) {
+            Log::warning('AlertNotificationService::dispatchFor failed', [
+                'alert_id' => $alert->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
 
         return $alert;
     }

--- a/app/Domain/Notifications/Contracts/NotificationChannelDriver.php
+++ b/app/Domain/Notifications/Contracts/NotificationChannelDriver.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Domain\Notifications\Contracts;
+
+use App\Domain\Notifications\DataTransferObjects\AlertNotificationPayload;
+use App\Models\AlertNotificationChannel;
+
+/**
+ * §6.5 Strategy pattern — one implementation per channel kind.
+ *
+ * Drivers throw on failure so the caller (`DispatchAlertNotificationJob`)
+ * can wrap the exception in the retry / dead-letter loop. Return type
+ * is void; drivers surface no delivery id — the observable outcome is
+ * the `AlertDelivery` row the job persists after the driver returns.
+ */
+interface NotificationChannelDriver
+{
+    /**
+     * @throws \Throwable when the channel refuses / errors out.
+     */
+    public function send(AlertNotificationChannel $channel, AlertNotificationPayload $payload): void;
+}

--- a/app/Domain/Notifications/DataTransferObjects/AlertNotificationPayload.php
+++ b/app/Domain/Notifications/DataTransferObjects/AlertNotificationPayload.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Domain\Notifications\DataTransferObjects;
+
+use App\Models\Alert;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\URL;
+
+/**
+ * Immutable value object carrying the outbound shape of an alert
+ * notification (spec 042).
+ *
+ * Drivers receive this DTO — never the Alert model — so the driver
+ * layer stays decoupled from the Eloquent model and the payload shape
+ * is what actually ships on the wire.
+ *
+ * `metadata` is a sanitized subset of the alert's raw metadata JSON:
+ * scalar values only, size bounded ≤ 2 KB before the payload as a
+ * whole is bounded ≤ 4 KB at the delivery-log persist step.
+ */
+final class AlertNotificationPayload
+{
+    /**
+     * @param  array<string, scalar|null>  $metadata
+     */
+    public function __construct(
+        public readonly int $alertId,
+        public readonly string $type,
+        public readonly string $severity,
+        public readonly string $source,
+        public readonly string $title,
+        public readonly ?string $message,
+        public readonly string $link,
+        public readonly Carbon $triggeredAt,
+        public readonly array $metadata = [],
+        public readonly string $event = 'alert.triggered',
+    ) {}
+
+    public static function fromAlert(Alert $alert, string $event = 'alert.triggered'): self
+    {
+        return new self(
+            alertId: $alert->id,
+            type: $alert->type,
+            severity: $alert->severity->value,
+            source: $alert->source->value,
+            title: $alert->title,
+            message: $alert->description,
+            link: URL::to('/alerts/'.$alert->id),
+            triggeredAt: $alert->triggered_at,
+            metadata: self::sanitize($alert->metadata ?? []),
+            event: $event,
+        );
+    }
+
+    /**
+     * Synthesize a payload for the "Send test" button on the settings
+     * page. Doesn't hit the alerts table.
+     */
+    public static function testPayload(): self
+    {
+        return new self(
+            alertId: 0,
+            type: 'test.notification',
+            severity: 'info',
+            source: 'system',
+            title: 'Test notification from Nexus',
+            message: 'If you can read this, your channel is wired up.',
+            link: URL::to('/settings/notifications'),
+            triggeredAt: Carbon::now(),
+            event: 'alert.test',
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'event' => $this->event,
+            'alert_id' => $this->alertId,
+            'type' => $this->type,
+            'severity' => $this->severity,
+            'source' => $this->source,
+            'title' => $this->title,
+            'message' => $this->message,
+            'link' => $this->link,
+            'triggered_at' => $this->triggeredAt->toIso8601String(),
+            'metadata' => $this->metadata,
+        ];
+    }
+
+    /**
+     * Drop non-scalars and cap the payload before we ship it. Alert
+     * metadata is a free-form bag — spec 030 uses it for websites
+     * (url + http_status + error_message), hosts (threshold_seconds),
+     * and deployments (branch + run_id) — none of which should include
+     * nested structures, but user-triggered `manual` alerts could.
+     *
+     * @param  array<string, mixed>  $raw
+     * @return array<string, scalar|null>
+     */
+    private static function sanitize(array $raw): array
+    {
+        $sanitized = [];
+
+        foreach ($raw as $key => $value) {
+            if (is_scalar($value) || $value === null) {
+                $sanitized[(string) $key] = $value;
+            }
+        }
+
+        return $sanitized;
+    }
+}

--- a/app/Domain/Notifications/Drivers/EmailChannelDriver.php
+++ b/app/Domain/Notifications/Drivers/EmailChannelDriver.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Domain\Notifications\Drivers;
+
+use App\Domain\Notifications\Contracts\NotificationChannelDriver;
+use App\Domain\Notifications\DataTransferObjects\AlertNotificationPayload;
+use App\Mail\AlertNotificationMail;
+use App\Models\AlertNotificationChannel;
+use Illuminate\Support\Facades\Mail;
+use InvalidArgumentException;
+
+class EmailChannelDriver implements NotificationChannelDriver
+{
+    public function send(AlertNotificationChannel $channel, AlertNotificationPayload $payload): void
+    {
+        $to = $channel->config['to'] ?? null;
+
+        if (! is_string($to) || $to === '') {
+            throw new InvalidArgumentException(
+                "Email channel {$channel->id} has no `to` address configured.",
+            );
+        }
+
+        Mail::to($to)->send(new AlertNotificationMail($payload));
+    }
+}

--- a/app/Domain/Notifications/Drivers/GenericWebhookChannelDriver.php
+++ b/app/Domain/Notifications/Drivers/GenericWebhookChannelDriver.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Domain\Notifications\Drivers;
+
+use App\Domain\Notifications\Contracts\NotificationChannelDriver;
+use App\Domain\Notifications\DataTransferObjects\AlertNotificationPayload;
+use App\Models\AlertNotificationChannel;
+use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
+use RuntimeException;
+
+class GenericWebhookChannelDriver implements NotificationChannelDriver
+{
+    public function send(AlertNotificationChannel $channel, AlertNotificationPayload $payload): void
+    {
+        $url = $channel->config['url'] ?? null;
+        $signingSecret = $channel->config['signing_secret'] ?? null;
+
+        if (! is_string($url) || $url === '') {
+            throw new InvalidArgumentException(
+                "Webhook channel {$channel->id} has no `url` configured.",
+            );
+        }
+
+        $body = json_encode($payload->toArray(), JSON_UNESCAPED_SLASHES);
+
+        if ($body === false) {
+            throw new RuntimeException(
+                "Failed to encode payload for webhook channel {$channel->id}.",
+            );
+        }
+
+        $headers = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'Nexus-Control-Center/1.0',
+        ];
+
+        if (is_string($signingSecret) && $signingSecret !== '') {
+            $headers['X-Nexus-Signature'] = 'sha256='.hash_hmac('sha256', $body, $signingSecret);
+        }
+
+        $response = Http::timeout(5)
+            ->withHeaders($headers)
+            ->withBody($body, 'application/json')
+            ->post($url);
+
+        if (! $response->successful()) {
+            throw new RuntimeException(
+                "Webhook responded {$response->status()}: ".$response->body(),
+            );
+        }
+    }
+}

--- a/app/Domain/Notifications/Drivers/SlackChannelDriver.php
+++ b/app/Domain/Notifications/Drivers/SlackChannelDriver.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Domain\Notifications\Drivers;
+
+use App\Domain\Notifications\Contracts\NotificationChannelDriver;
+use App\Domain\Notifications\DataTransferObjects\AlertNotificationPayload;
+use App\Models\AlertNotificationChannel;
+use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
+use RuntimeException;
+
+class SlackChannelDriver implements NotificationChannelDriver
+{
+    public function send(AlertNotificationChannel $channel, AlertNotificationPayload $payload): void
+    {
+        $webhookUrl = $channel->config['webhook_url'] ?? null;
+
+        if (! is_string($webhookUrl) || $webhookUrl === '') {
+            throw new InvalidArgumentException(
+                "Slack channel {$channel->id} has no `webhook_url` configured.",
+            );
+        }
+
+        $response = Http::timeout(5)
+            ->acceptJson()
+            ->asJson()
+            ->post($webhookUrl, $this->buildBlockKitPayload($payload));
+
+        if (! $response->successful()) {
+            throw new RuntimeException(
+                "Slack webhook responded {$response->status()}: ".$response->body(),
+            );
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildBlockKitPayload(AlertNotificationPayload $payload): array
+    {
+        $emoji = match ($payload->severity) {
+            'critical' => ':rotating_light:',
+            'warning' => ':warning:',
+            default => ':information_source:',
+        };
+
+        $header = $payload->event === 'alert.resolved'
+            ? ":white_check_mark: {$payload->title} resolved"
+            : "{$emoji} {$payload->title}";
+
+        return [
+            // Slack shows this in notifications / previews when Block Kit isn't renderable.
+            'text' => $header,
+            'blocks' => [
+                [
+                    'type' => 'header',
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => $header,
+                        'emoji' => true,
+                    ],
+                ],
+                [
+                    'type' => 'section',
+                    'fields' => array_filter([
+                        [
+                            'type' => 'mrkdwn',
+                            'text' => "*Severity*\n".ucfirst($payload->severity),
+                        ],
+                        [
+                            'type' => 'mrkdwn',
+                            'text' => "*Source*\n".ucfirst($payload->source),
+                        ],
+                    ]),
+                ],
+                ...($payload->message !== null && $payload->message !== '' ? [[
+                    'type' => 'section',
+                    'text' => [
+                        'type' => 'mrkdwn',
+                        'text' => $payload->message,
+                    ],
+                ]] : []),
+                [
+                    'type' => 'actions',
+                    'elements' => [
+                        [
+                            'type' => 'button',
+                            'text' => [
+                                'type' => 'plain_text',
+                                'text' => 'View in Nexus',
+                                'emoji' => true,
+                            ],
+                            'url' => $payload->link,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/app/Domain/Notifications/Jobs/DispatchAlertNotificationJob.php
+++ b/app/Domain/Notifications/Jobs/DispatchAlertNotificationJob.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Domain\Notifications\Jobs;
+
+use App\Domain\Notifications\DataTransferObjects\AlertNotificationPayload;
+use App\Domain\Notifications\Services\AlertNotificationService;
+use App\Enums\AlertDeliveryStatus;
+use App\Models\Alert;
+use App\Models\AlertDelivery;
+use App\Models\AlertNotificationChannel;
+use App\Models\AlertNotificationPreference;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\RateLimiter;
+use Throwable;
+
+/**
+ * Ship one alert notification through one channel.
+ *
+ * `ShouldBeUnique` keyed on `(alert_id, channel_id, event)` collapses
+ * duplicate dispatches (e.g. a `TriggerAlertAction` re-run while the
+ * alert is still open — the service currently guards this at the
+ * fan-out layer, but the queue-side guard is cheap belt + braces).
+ *
+ * Retry policy (§18): up to 3 attempts with exponential backoff.
+ * A driver exception raises the attempt count; after the ceiling the
+ * `failed()` hook lands the delivery as `status: failed` with the
+ * last error message.
+ */
+class DispatchAlertNotificationJob implements ShouldBeUnique, ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    /** Lock the (alert, channel, event) combo for 60s to collapse bursts. */
+    public int $uniqueFor = 60;
+
+    /** Per-channel default budget (30 sends / hour / user × channel). */
+    public const DEFAULT_RATE_LIMIT_PER_HOUR = 30;
+
+    public function __construct(
+        public readonly int $alertId,
+        public readonly int $channelId,
+        public readonly string $event = 'alert.triggered',
+    ) {}
+
+    public function uniqueId(): string
+    {
+        return "{$this->alertId}:{$this->channelId}:{$this->event}";
+    }
+
+    /**
+     * §18 backoff — 5s, 30s, 2 min.
+     *
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [5, 30, 120];
+    }
+
+    public function handle(): void
+    {
+        $alert = Alert::query()->find($this->alertId);
+        $channel = AlertNotificationChannel::query()->find($this->channelId);
+
+        if ($alert === null || $channel === null) {
+            return;
+        }
+
+        if (! $channel->enabled || $channel->verified_at === null) {
+            $this->recordSkipped($alert, $channel, ! $channel->enabled ? 'channel_disabled' : 'channel_unverified');
+
+            return;
+        }
+
+        $preference = AlertNotificationPreference::query()
+            ->where('channel_id', $channel->id)
+            ->first();
+
+        $limit = $preference?->rate_limit_per_hour ?? self::DEFAULT_RATE_LIMIT_PER_HOUR;
+        $rateKey = "notif:{$channel->user_id}:{$channel->id}";
+
+        if (! RateLimiter::attempt($rateKey, $limit, fn () => true, 3600)) {
+            $this->recordSkipped($alert, $channel, 'rate_limited');
+
+            return;
+        }
+
+        $payload = AlertNotificationPayload::fromAlert($alert, $this->event);
+        $driver = AlertNotificationService::driverFor($channel->kind);
+
+        // Upsert the delivery row for observability + retry accounting.
+        $delivery = AlertDelivery::query()->firstOrNew([
+            'alert_id' => $alert->id,
+            'channel_id' => $channel->id,
+        ]);
+
+        try {
+            $driver->send($channel, $payload);
+
+            $delivery->forceFill([
+                'status' => AlertDeliveryStatus::Sent->value,
+                'attempts' => $delivery->attempts + 1,
+                'last_attempt_at' => Carbon::now(),
+                'sent_at' => Carbon::now(),
+                'error_message' => null,
+                'payload' => $payload->toArray(),
+            ])->save();
+        } catch (Throwable $e) {
+            $delivery->forceFill([
+                'status' => AlertDeliveryStatus::Pending->value,
+                'attempts' => $delivery->attempts + 1,
+                'last_attempt_at' => Carbon::now(),
+                'error_message' => $e->getMessage(),
+                'payload' => $payload->toArray(),
+            ])->save();
+
+            throw $e;
+        }
+    }
+
+    public function failed(Throwable $e): void
+    {
+        $delivery = AlertDelivery::query()
+            ->where('alert_id', $this->alertId)
+            ->where('channel_id', $this->channelId)
+            ->first();
+
+        if ($delivery === null) {
+            return;
+        }
+
+        $delivery->forceFill([
+            'status' => AlertDeliveryStatus::Failed->value,
+            'error_message' => $e->getMessage(),
+        ])->save();
+    }
+
+    private function recordSkipped(Alert $alert, AlertNotificationChannel $channel, string $reason): void
+    {
+        AlertDelivery::query()->create([
+            'alert_id' => $alert->id,
+            'channel_id' => $channel->id,
+            'status' => AlertDeliveryStatus::Skipped->value,
+            'error_message' => $reason,
+            'payload' => AlertNotificationPayload::fromAlert($alert, $this->event)->toArray(),
+        ]);
+    }
+}

--- a/app/Domain/Notifications/Jobs/DispatchAlertNotificationJob.php
+++ b/app/Domain/Notifications/Jobs/DispatchAlertNotificationJob.php
@@ -16,6 +16,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\RateLimiter;
 use Throwable;
 
@@ -100,30 +101,48 @@ class DispatchAlertNotificationJob implements ShouldBeUnique, ShouldQueue
         $driver = AlertNotificationService::driverFor($channel->kind);
 
         // Upsert the delivery row for observability + retry accounting.
-        $delivery = AlertDelivery::query()->firstOrNew([
-            'alert_id' => $alert->id,
-            'channel_id' => $channel->id,
-        ]);
+        // Uniqueness on `(alert_id, channel_id)` is enforced at the DB
+        // level so parallel worker + user-triggered retry can't split
+        // into two rows.
+        $delivery = AlertDelivery::query()->firstOrCreate(
+            ['alert_id' => $alert->id, 'channel_id' => $channel->id],
+            [
+                'status' => AlertDeliveryStatus::Pending->value,
+                'attempts' => 0,
+                'payload' => $payload->toArray(),
+            ],
+        );
+
+        // Atomic bump so concurrent handlers can't overwrite each
+        // other's counter (spec 042 self-review S3 fix).
+        DB::table('alert_deliveries')
+            ->where('id', $delivery->id)
+            ->update([
+                'attempts' => DB::raw('attempts + 1'),
+                'last_attempt_at' => Carbon::now(),
+                'payload' => json_encode($payload->toArray()),
+                'updated_at' => Carbon::now(),
+            ]);
 
         try {
             $driver->send($channel, $payload);
 
-            $delivery->forceFill([
-                'status' => AlertDeliveryStatus::Sent->value,
-                'attempts' => $delivery->attempts + 1,
-                'last_attempt_at' => Carbon::now(),
-                'sent_at' => Carbon::now(),
-                'error_message' => null,
-                'payload' => $payload->toArray(),
-            ])->save();
+            DB::table('alert_deliveries')
+                ->where('id', $delivery->id)
+                ->update([
+                    'status' => AlertDeliveryStatus::Sent->value,
+                    'sent_at' => Carbon::now(),
+                    'error_message' => null,
+                    'updated_at' => Carbon::now(),
+                ]);
         } catch (Throwable $e) {
-            $delivery->forceFill([
-                'status' => AlertDeliveryStatus::Pending->value,
-                'attempts' => $delivery->attempts + 1,
-                'last_attempt_at' => Carbon::now(),
-                'error_message' => $e->getMessage(),
-                'payload' => $payload->toArray(),
-            ])->save();
+            DB::table('alert_deliveries')
+                ->where('id', $delivery->id)
+                ->update([
+                    'status' => AlertDeliveryStatus::Pending->value,
+                    'error_message' => $e->getMessage(),
+                    'updated_at' => Carbon::now(),
+                ]);
 
             throw $e;
         }

--- a/app/Domain/Notifications/Services/AlertNotificationService.php
+++ b/app/Domain/Notifications/Services/AlertNotificationService.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace App\Domain\Notifications\Services;
+
+use App\Domain\Notifications\Contracts\NotificationChannelDriver;
+use App\Domain\Notifications\DataTransferObjects\AlertNotificationPayload;
+use App\Domain\Notifications\Drivers\EmailChannelDriver;
+use App\Domain\Notifications\Drivers\GenericWebhookChannelDriver;
+use App\Domain\Notifications\Drivers\SlackChannelDriver;
+use App\Domain\Notifications\Jobs\DispatchAlertNotificationJob;
+use App\Enums\AlertDeliveryStatus;
+use App\Enums\AlertSeverity;
+use App\Enums\NotificationChannelKind;
+use App\Models\Alert;
+use App\Models\AlertDelivery;
+use App\Models\AlertNotificationChannel;
+use App\Models\AlertNotificationPreference;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+/**
+ * Coordinator for spec 042's outbound notifications.
+ *
+ * `dispatchFor` (triggered alerts) and `dispatchResolutionFor`
+ * (resolved alerts) share the same routing: read matching
+ * preferences → dispatch one job per channel.
+ *
+ * Dedupe runs here at the service layer: if an alert with the same
+ * `(source, source_id, type)` already lit up a delivery for the same
+ * channel within the DEDUPE_WINDOW, the second call is silently
+ * dropped so a flap storm can't burn the operator's Slack.
+ *
+ * Rate limit lives in the job (see `DispatchAlertNotificationJob`)
+ * because per-user × per-channel budgets are cheaper to enforce with
+ * RateLimiter::attempt after the job has already resolved the
+ * preference row.
+ */
+class AlertNotificationService
+{
+    /** Same-fingerprint suppression window for delivery dedupe. */
+    public const DEDUPE_WINDOW_MINUTES = 5;
+
+    public function dispatchFor(Alert $alert): void
+    {
+        $this->fanOut($alert, event: 'alert.triggered', resolution: false);
+    }
+
+    public function dispatchResolutionFor(Alert $alert): void
+    {
+        $this->fanOut($alert, event: 'alert.resolved', resolution: true);
+    }
+
+    private function fanOut(Alert $alert, string $event, bool $resolution): void
+    {
+        $preferences = $this->matchingPreferences($alert, $resolution);
+
+        if ($preferences->isEmpty()) {
+            return;
+        }
+
+        $payload = AlertNotificationPayload::fromAlert($alert, $event);
+
+        foreach ($preferences as $preference) {
+            $channel = $preference->channel;
+
+            if ($channel === null) {
+                continue;
+            }
+
+            $skipReason = $this->skipReasonFor($alert, $channel);
+
+            if ($skipReason !== null) {
+                AlertDelivery::query()->create([
+                    'alert_id' => $alert->id,
+                    'channel_id' => $channel->id,
+                    'status' => AlertDeliveryStatus::Skipped->value,
+                    'error_message' => $skipReason,
+                    'payload' => $payload->toArray(),
+                ]);
+
+                continue;
+            }
+
+            DispatchAlertNotificationJob::dispatch(
+                alertId: $alert->id,
+                channelId: $channel->id,
+                event: $event,
+            );
+        }
+    }
+
+    /**
+     * @return Collection<int, AlertNotificationPreference>
+     */
+    private function matchingPreferences(Alert $alert, bool $resolution): Collection
+    {
+        $severityRank = $this->severityRank($alert->severity);
+        $sourceValue = $alert->source->value;
+
+        $query = AlertNotificationPreference::query()
+            ->with(['channel'])
+            ->where('enabled', true);
+
+        if ($resolution) {
+            $query->where('notify_on_resolve', true);
+        }
+
+        $preferences = $query->get();
+
+        return $preferences->filter(function (AlertNotificationPreference $preference) use ($severityRank, $sourceValue) {
+            $prefRank = $this->severityRank($preference->min_severity);
+            if ($severityRank < $prefRank) {
+                return false;
+            }
+
+            $sources = $preference->sources ?? [];
+            if (! empty($sources) && ! in_array($sourceValue, $sources, true)) {
+                return false;
+            }
+
+            return true;
+        })->values();
+    }
+
+    private function skipReasonFor(Alert $alert, AlertNotificationChannel $channel): ?string
+    {
+        if (! $channel->enabled) {
+            return 'channel_disabled';
+        }
+
+        if ($channel->verified_at === null) {
+            return 'channel_unverified';
+        }
+
+        if ($this->isDeduped($alert, $channel)) {
+            return 'deduped';
+        }
+
+        return null;
+    }
+
+    private function isDeduped(Alert $alert, AlertNotificationChannel $channel): bool
+    {
+        return AlertDelivery::query()
+            ->where('channel_id', $channel->id)
+            ->whereHas('alert', function ($q) use ($alert): void {
+                $q->where('source', $alert->source->value)
+                    ->where('source_id', $alert->source_id)
+                    ->where('type', $alert->type);
+            })
+            ->where('created_at', '>=', Carbon::now()->subMinutes(self::DEDUPE_WINDOW_MINUTES))
+            ->where('id', '<', $alert->id ? PHP_INT_MAX : 0)
+            ->exists();
+    }
+
+    private function severityRank(AlertSeverity|string $severity): int
+    {
+        $value = $severity instanceof AlertSeverity ? $severity->value : $severity;
+
+        return match ($value) {
+            'info' => 1,
+            'warning' => 2,
+            'critical' => 3,
+            default => 0,
+        };
+    }
+
+    /**
+     * Container binding helper — resolves the strategy driver by
+     * channel kind. Used by DispatchAlertNotificationJob + tests.
+     */
+    public static function driverFor(NotificationChannelKind $kind): NotificationChannelDriver
+    {
+        return match ($kind) {
+            NotificationChannelKind::Email => app(EmailChannelDriver::class),
+            NotificationChannelKind::Slack => app(SlackChannelDriver::class),
+            NotificationChannelKind::Webhook => app(GenericWebhookChannelDriver::class),
+        };
+    }
+}

--- a/app/Domain/Notifications/Services/AlertNotificationService.php
+++ b/app/Domain/Notifications/Services/AlertNotificationService.php
@@ -101,6 +101,21 @@ class AlertNotificationService
             ->with(['channel'])
             ->where('enabled', true);
 
+        // Cross-tenant guard: project-scoped alerts (spec 030 emitters
+        // for website / docker / deployment / github) only fire the
+        // owner's preferences — a stranger user's Slack must never
+        // ring for another operator's outage. `AlertSource::System`
+        // alerts (spec 038 self-checks) carry no project so they fan
+        // out to every configured preference; today this equals "the
+        // operator" but the fallback remains correct if the app grows
+        // to a multi-user operator team.
+        $alert->loadMissing('project:id,owner_user_id');
+        $ownerUserId = $alert->project?->owner_user_id;
+
+        if ($ownerUserId !== null) {
+            $query->where('user_id', $ownerUserId);
+        }
+
         if ($resolution) {
             $query->where('notify_on_resolve', true);
         }
@@ -143,13 +158,13 @@ class AlertNotificationService
     {
         return AlertDelivery::query()
             ->where('channel_id', $channel->id)
+            ->where('alert_id', '!=', $alert->id)
             ->whereHas('alert', function ($q) use ($alert): void {
                 $q->where('source', $alert->source->value)
                     ->where('source_id', $alert->source_id)
                     ->where('type', $alert->type);
             })
             ->where('created_at', '>=', Carbon::now()->subMinutes(self::DEDUPE_WINDOW_MINUTES))
-            ->where('id', '<', $alert->id ? PHP_INT_MAX : 0)
             ->exists();
     }
 

--- a/app/Enums/AlertDeliveryStatus.php
+++ b/app/Enums/AlertDeliveryStatus.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Lifecycle of an alert delivery row (spec 042).
+ *
+ * `pending` — job enqueued, no attempt yet.
+ * `sent`    — driver returned 2xx (or Mail::send didn't throw).
+ * `failed`  — driver exhausted retries (default 3 per §18 backoff).
+ * `skipped` — never attempted: rate-limited, deduped, channel
+ *             disabled, or channel un-verified. `error_message`
+ *             carries the reason marker for surface in the UI.
+ */
+enum AlertDeliveryStatus: string
+{
+    case Pending = 'pending';
+    case Sent = 'sent';
+    case Failed = 'failed';
+    case Skipped = 'skipped';
+
+    public function badgeTone(): string
+    {
+        return match ($this) {
+            self::Pending => 'muted',
+            self::Sent => 'success',
+            self::Failed => 'danger',
+            self::Skipped => 'warning',
+        };
+    }
+}

--- a/app/Enums/NotificationChannelKind.php
+++ b/app/Enums/NotificationChannelKind.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Delivery channel kind (spec 042).
+ *
+ * `email`   — Laravel Mail via the configured MAIL_* driver.
+ * `slack`   — HTTP POST to an incoming-webhook URL, Block Kit payload.
+ * `webhook` — Generic HTTP POST of the AlertNotificationPayload DTO,
+ *             optionally signed via HMAC-SHA-256 when the channel's
+ *             config carries a `signing_secret`.
+ */
+enum NotificationChannelKind: string
+{
+    case Email = 'email';
+    case Slack = 'slack';
+    case Webhook = 'webhook';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Email => 'Email',
+            self::Slack => 'Slack',
+            self::Webhook => 'Generic webhook',
+        };
+    }
+}

--- a/app/Http/Controllers/Settings/NotificationsController.php
+++ b/app/Http/Controllers/Settings/NotificationsController.php
@@ -1,0 +1,339 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Domain\Notifications\DataTransferObjects\AlertNotificationPayload;
+use App\Domain\Notifications\Jobs\DispatchAlertNotificationJob;
+use App\Domain\Notifications\Services\AlertNotificationService;
+use App\Enums\AlertDeliveryStatus;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Enums\NotificationChannelKind;
+use App\Http\Controllers\Controller;
+use App\Models\AlertDelivery;
+use App\Models\AlertNotificationChannel;
+use App\Models\AlertNotificationPreference;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Inertia\Inertia;
+use Inertia\Response;
+use Throwable;
+
+/**
+ * Spec 042 — Settings → Notifications. Single controller carrying
+ * three logical tabs (Channels / Rules / Deliveries) because the
+ * page shares one JSON payload + one Inertia route.
+ *
+ * Every mutation is per-user scoped — a user can only touch their
+ * own channels / preferences / deliveries.
+ */
+class NotificationsController extends Controller
+{
+    private const DELIVERIES_PER_PAGE = 30;
+
+    public function index(Request $request): Response
+    {
+        $userId = $request->user()->id;
+
+        $channels = AlertNotificationChannel::query()
+            ->where('user_id', $userId)
+            ->orderBy('name')
+            ->get()
+            ->map(fn (AlertNotificationChannel $c): array => [
+                'id' => $c->id,
+                'kind' => $c->kind->value,
+                'kind_label' => $c->kind->label(),
+                'name' => $c->name,
+                // Never leak signing_secret. `config` is `encrypted:array`
+                // + `$hidden` — read here explicitly.
+                'config_preview' => $this->configPreview($c),
+                'enabled' => $c->enabled,
+                'verified_at' => $c->verified_at?->diffForHumans(),
+                'verified' => $c->verified_at !== null,
+            ]);
+
+        $preferences = AlertNotificationPreference::query()
+            ->where('user_id', $userId)
+            ->with('channel:id,name,kind')
+            ->orderByDesc('id')
+            ->get()
+            ->map(fn (AlertNotificationPreference $p): array => [
+                'id' => $p->id,
+                'channel_id' => $p->channel_id,
+                'channel_name' => $p->channel?->name,
+                'channel_kind' => $p->channel?->kind?->value,
+                'min_severity' => $p->min_severity->value,
+                'sources' => $p->sources ?? [],
+                'enabled' => $p->enabled,
+                'notify_on_resolve' => $p->notify_on_resolve,
+                'rate_limit_per_hour' => $p->rate_limit_per_hour,
+            ]);
+
+        $deliveries = AlertDelivery::query()
+            ->whereHas('channel', fn ($q) => $q->where('user_id', $userId))
+            ->with(['alert:id,title,severity,source,type', 'channel:id,name,kind'])
+            ->latest('id')
+            ->paginate(self::DELIVERIES_PER_PAGE)
+            ->through(fn (AlertDelivery $d): array => [
+                'id' => $d->id,
+                'alert_id' => $d->alert_id,
+                'alert_title' => $d->alert?->title,
+                'alert_severity' => $d->alert?->severity?->value,
+                'alert_source' => $d->alert?->source?->value,
+                'channel_name' => $d->channel?->name,
+                'channel_kind' => $d->channel?->kind?->value,
+                'status' => $d->status->value,
+                'status_tone' => $d->status->badgeTone(),
+                'attempts' => $d->attempts,
+                'error_message' => $d->error_message,
+                'last_attempt_at' => $d->last_attempt_at?->diffForHumans(),
+                'sent_at' => $d->sent_at?->diffForHumans(),
+                'created_at' => $d->created_at?->diffForHumans(),
+            ]);
+
+        return Inertia::render('Settings/Notifications/Index', [
+            'channels' => $channels,
+            'preferences' => $preferences,
+            'deliveries' => $deliveries,
+            'options' => [
+                'kinds' => array_map(
+                    fn (NotificationChannelKind $k): array => [
+                        'value' => $k->value,
+                        'label' => $k->label(),
+                    ],
+                    NotificationChannelKind::cases(),
+                ),
+                'severities' => array_map(
+                    fn (AlertSeverity $s): string => $s->value,
+                    AlertSeverity::cases(),
+                ),
+                'sources' => array_map(
+                    fn (AlertSource $s): string => $s->value,
+                    AlertSource::cases(),
+                ),
+            ],
+        ]);
+    }
+
+    public function storeChannel(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'kind' => 'required|in:'.implode(',', array_column(NotificationChannelKind::cases(), 'value')),
+            'name' => 'required|string|max:120',
+            'config' => 'required|array',
+        ]);
+
+        $validated['config'] = $this->sanitizeConfig(
+            NotificationChannelKind::from($validated['kind']),
+            $validated['config'],
+        );
+
+        AlertNotificationChannel::query()->create([
+            'user_id' => $request->user()->id,
+            'kind' => $validated['kind'],
+            'name' => $validated['name'],
+            'config' => $validated['config'],
+            'enabled' => true,
+            'verified_at' => null,
+        ]);
+
+        return back()->with('status', 'Channel added. Send a test to verify it.');
+    }
+
+    public function updateChannel(Request $request, AlertNotificationChannel $channel): RedirectResponse
+    {
+        $this->authorizeOwner($request, $channel);
+
+        $validated = $request->validate([
+            'name' => 'sometimes|required|string|max:120',
+            'config' => 'sometimes|required|array',
+            'enabled' => 'sometimes|boolean',
+        ]);
+
+        if (array_key_exists('config', $validated)) {
+            $validated['config'] = $this->sanitizeConfig($channel->kind, $validated['config']);
+            // A config change invalidates prior verification.
+            $validated['verified_at'] = null;
+        }
+
+        $channel->fill($validated)->save();
+
+        return back()->with('status', 'Channel updated.');
+    }
+
+    public function destroyChannel(Request $request, AlertNotificationChannel $channel): RedirectResponse
+    {
+        $this->authorizeOwner($request, $channel);
+        $channel->delete();
+
+        return back()->with('status', 'Channel deleted.');
+    }
+
+    public function testChannel(Request $request, AlertNotificationChannel $channel): RedirectResponse
+    {
+        $this->authorizeOwner($request, $channel);
+
+        $payload = AlertNotificationPayload::testPayload();
+        $driver = AlertNotificationService::driverFor($channel->kind);
+
+        try {
+            $driver->send($channel, $payload);
+            $channel->forceFill(['verified_at' => Carbon::now()])->save();
+
+            return back()->with('status', 'Test notification sent. Channel is verified.');
+        } catch (Throwable $e) {
+            return back()->with('error', 'Test failed: '.$e->getMessage());
+        }
+    }
+
+    public function storePreference(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'channel_id' => 'required|integer|exists:alert_notification_channels,id',
+            'min_severity' => 'required|in:'.implode(',', array_column(AlertSeverity::cases(), 'value')),
+            'sources' => 'sometimes|nullable|array',
+            'sources.*' => 'in:'.implode(',', array_column(AlertSource::cases(), 'value')),
+            'notify_on_resolve' => 'sometimes|boolean',
+            'rate_limit_per_hour' => 'sometimes|nullable|integer|min:1|max:1000',
+        ]);
+
+        $channel = AlertNotificationChannel::query()->findOrFail($validated['channel_id']);
+        $this->authorizeOwner($request, $channel);
+
+        AlertNotificationPreference::query()->create([
+            'user_id' => $request->user()->id,
+            'channel_id' => $validated['channel_id'],
+            'min_severity' => $validated['min_severity'],
+            'sources' => $validated['sources'] ?? null,
+            'enabled' => true,
+            'notify_on_resolve' => $validated['notify_on_resolve'] ?? false,
+            'rate_limit_per_hour' => $validated['rate_limit_per_hour'] ?? null,
+        ]);
+
+        return back()->with('status', 'Rule added.');
+    }
+
+    public function updatePreference(Request $request, AlertNotificationPreference $preference): RedirectResponse
+    {
+        if ($preference->user_id !== $request->user()->id) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'min_severity' => 'sometimes|required|in:'.implode(',', array_column(AlertSeverity::cases(), 'value')),
+            'sources' => 'sometimes|nullable|array',
+            'sources.*' => 'in:'.implode(',', array_column(AlertSource::cases(), 'value')),
+            'enabled' => 'sometimes|boolean',
+            'notify_on_resolve' => 'sometimes|boolean',
+            'rate_limit_per_hour' => 'sometimes|nullable|integer|min:1|max:1000',
+        ]);
+
+        $preference->fill($validated)->save();
+
+        return back()->with('status', 'Rule updated.');
+    }
+
+    public function destroyPreference(Request $request, AlertNotificationPreference $preference): RedirectResponse
+    {
+        if ($preference->user_id !== $request->user()->id) {
+            abort(403);
+        }
+
+        $preference->delete();
+
+        return back()->with('status', 'Rule deleted.');
+    }
+
+    public function retryDelivery(Request $request, AlertDelivery $delivery): RedirectResponse
+    {
+        $userId = $request->user()->id;
+        $delivery->loadMissing('channel:id,user_id');
+
+        if ($delivery->channel?->user_id !== $userId) {
+            abort(403);
+        }
+
+        if ($delivery->status !== AlertDeliveryStatus::Failed) {
+            return back()->with('error', 'Only failed deliveries can be retried.');
+        }
+
+        $delivery->forceFill([
+            'status' => AlertDeliveryStatus::Pending->value,
+            'error_message' => null,
+        ])->save();
+
+        DispatchAlertNotificationJob::dispatch(
+            alertId: $delivery->alert_id,
+            channelId: $delivery->channel_id,
+        );
+
+        return back()->with('status', 'Delivery re-queued.');
+    }
+
+    private function authorizeOwner(Request $request, AlertNotificationChannel $channel): void
+    {
+        if ($channel->user_id !== $request->user()->id) {
+            abort(403);
+        }
+    }
+
+    /**
+     * Strip unexpected keys per kind so the encrypted `config` column
+     * stays predictable. Anything not on the whitelist is dropped.
+     *
+     * @param  array<string, mixed>  $config
+     * @return array<string, string>
+     */
+    private function sanitizeConfig(NotificationChannelKind $kind, array $config): array
+    {
+        $allowed = match ($kind) {
+            NotificationChannelKind::Email => ['to'],
+            NotificationChannelKind::Slack => ['webhook_url'],
+            NotificationChannelKind::Webhook => ['url', 'signing_secret'],
+        };
+
+        $out = [];
+        foreach ($allowed as $key) {
+            if (isset($config[$key]) && is_string($config[$key]) && $config[$key] !== '') {
+                $out[$key] = $config[$key];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Non-secret preview shape for the Channels table. Hides the Slack
+     * URL / webhook URL / signing_secret; surfaces only the "to"
+     * email + a marker for HMAC-signed webhooks so the UI can flag it.
+     *
+     * @return array<string, mixed>
+     */
+    private function configPreview(AlertNotificationChannel $channel): array
+    {
+        return match ($channel->kind) {
+            NotificationChannelKind::Email => [
+                'to' => $channel->config['to'] ?? null,
+            ],
+            NotificationChannelKind::Slack => [
+                'webhook_host' => $this->hostFromUrl($channel->config['webhook_url'] ?? ''),
+            ],
+            NotificationChannelKind::Webhook => [
+                'url_host' => $this->hostFromUrl($channel->config['url'] ?? ''),
+                'signed' => ! empty($channel->config['signing_secret']),
+            ],
+        };
+    }
+
+    private function hostFromUrl(string $url): ?string
+    {
+        if ($url === '') {
+            return null;
+        }
+
+        $parsed = parse_url($url);
+
+        return $parsed['host'] ?? null;
+    }
+}

--- a/app/Mail/AlertNotificationMail.php
+++ b/app/Mail/AlertNotificationMail.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Mail;
+
+use App\Domain\Notifications\DataTransferObjects\AlertNotificationPayload;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class AlertNotificationMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(public readonly AlertNotificationPayload $payload) {}
+
+    public function envelope(): Envelope
+    {
+        $prefix = $this->payload->event === 'alert.resolved'
+            ? '[Nexus resolved]'
+            : '[Nexus '.$this->payload->severity.']';
+
+        return new Envelope(
+            subject: $prefix.' '.$this->payload->title,
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.alert-notification',
+            with: ['payload' => $this->payload],
+        );
+    }
+}

--- a/app/Models/AlertDelivery.php
+++ b/app/Models/AlertDelivery.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\AlertDeliveryStatus;
+use Database\Factories\AlertDeliveryFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AlertDelivery extends Model
+{
+    /** @use HasFactory<AlertDeliveryFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'alert_id',
+        'channel_id',
+        'status',
+        'attempts',
+        'last_attempt_at',
+        'sent_at',
+        'error_message',
+        'payload',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => AlertDeliveryStatus::class,
+            'attempts' => 'integer',
+            'last_attempt_at' => 'datetime',
+            'sent_at' => 'datetime',
+            'payload' => 'array',
+        ];
+    }
+
+    public function alert(): BelongsTo
+    {
+        return $this->belongsTo(Alert::class);
+    }
+
+    public function channel(): BelongsTo
+    {
+        return $this->belongsTo(AlertNotificationChannel::class, 'channel_id');
+    }
+}

--- a/app/Models/AlertNotificationChannel.php
+++ b/app/Models/AlertNotificationChannel.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\NotificationChannelKind;
+use Database\Factories\AlertNotificationChannelFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class AlertNotificationChannel extends Model
+{
+    /** @use HasFactory<AlertNotificationChannelFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'kind',
+        'name',
+        'config',
+        'enabled',
+        'verified_at',
+    ];
+
+    protected $hidden = [
+        // The Slack webhook URL and generic-webhook signing_secret sit
+        // inside `config`. Keep the whole column out of Inertia / JSON
+        // responses; the settings page reads it explicitly.
+        'config',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'kind' => NotificationChannelKind::class,
+            'config' => 'encrypted:array',
+            'enabled' => 'boolean',
+            'verified_at' => 'datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function preferences(): HasMany
+    {
+        return $this->hasMany(AlertNotificationPreference::class, 'channel_id');
+    }
+
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(AlertDelivery::class, 'channel_id');
+    }
+}

--- a/app/Models/AlertNotificationPreference.php
+++ b/app/Models/AlertNotificationPreference.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\AlertSeverity;
+use Database\Factories\AlertNotificationPreferenceFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AlertNotificationPreference extends Model
+{
+    /** @use HasFactory<AlertNotificationPreferenceFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'channel_id',
+        'min_severity',
+        'sources',
+        'enabled',
+        'notify_on_resolve',
+        'rate_limit_per_hour',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'min_severity' => AlertSeverity::class,
+            'sources' => 'array',
+            'enabled' => 'boolean',
+            'notify_on_resolve' => 'boolean',
+            'rate_limit_per_hour' => 'integer',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function channel(): BelongsTo
+    {
+        return $this->belongsTo(AlertNotificationChannel::class, 'channel_id');
+    }
+}

--- a/database/factories/AlertDeliveryFactory.php
+++ b/database/factories/AlertDeliveryFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\AlertDeliveryStatus;
+use App\Models\Alert;
+use App\Models\AlertDelivery;
+use App\Models\AlertNotificationChannel;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<AlertDelivery> */
+class AlertDeliveryFactory extends Factory
+{
+    protected $model = AlertDelivery::class;
+
+    public function definition(): array
+    {
+        return [
+            'alert_id' => Alert::factory(),
+            'channel_id' => AlertNotificationChannel::factory(),
+            'status' => AlertDeliveryStatus::Pending->value,
+            'attempts' => 0,
+            'last_attempt_at' => null,
+            'sent_at' => null,
+            'error_message' => null,
+            'payload' => null,
+        ];
+    }
+
+    public function sent(): static
+    {
+        return $this->state(fn () => [
+            'status' => AlertDeliveryStatus::Sent->value,
+            'attempts' => 1,
+            'last_attempt_at' => now(),
+            'sent_at' => now(),
+        ]);
+    }
+
+    public function failed(?string $error = null): static
+    {
+        return $this->state(fn () => [
+            'status' => AlertDeliveryStatus::Failed->value,
+            'attempts' => 3,
+            'last_attempt_at' => now(),
+            'error_message' => $error ?? 'HTTP 500 from remote endpoint',
+        ]);
+    }
+
+    public function skipped(string $reason = 'rate_limited'): static
+    {
+        return $this->state(fn () => [
+            'status' => AlertDeliveryStatus::Skipped->value,
+            'error_message' => $reason,
+        ]);
+    }
+}

--- a/database/factories/AlertNotificationChannelFactory.php
+++ b/database/factories/AlertNotificationChannelFactory.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\NotificationChannelKind;
+use App\Models\AlertNotificationChannel;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<AlertNotificationChannel> */
+class AlertNotificationChannelFactory extends Factory
+{
+    protected $model = AlertNotificationChannel::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'kind' => NotificationChannelKind::Email->value,
+            'name' => 'Ops email',
+            'config' => ['to' => 'ops@example.com'],
+            'enabled' => true,
+            'verified_at' => now(),
+        ];
+    }
+
+    public function email(?string $to = null): static
+    {
+        return $this->state(fn () => [
+            'kind' => NotificationChannelKind::Email->value,
+            'name' => 'Ops email',
+            'config' => ['to' => $to ?? 'ops@example.com'],
+        ]);
+    }
+
+    public function slack(?string $webhookUrl = null): static
+    {
+        return $this->state(fn () => [
+            'kind' => NotificationChannelKind::Slack->value,
+            'name' => 'Ops Slack',
+            'config' => [
+                'webhook_url' => $webhookUrl ?? 'https://hooks.slack.com/services/T00/B00/XXX',
+            ],
+        ]);
+    }
+
+    public function webhook(?string $url = null, ?string $signingSecret = null): static
+    {
+        return $this->state(fn () => [
+            'kind' => NotificationChannelKind::Webhook->value,
+            'name' => 'PagerDuty bridge',
+            'config' => array_filter([
+                'url' => $url ?? 'https://ops.example.com/nexus-hook',
+                'signing_secret' => $signingSecret,
+            ]),
+        ]);
+    }
+
+    public function unverified(): static
+    {
+        return $this->state(fn () => [
+            'verified_at' => null,
+        ]);
+    }
+
+    public function disabled(): static
+    {
+        return $this->state(fn () => [
+            'enabled' => false,
+        ]);
+    }
+}

--- a/database/factories/AlertNotificationPreferenceFactory.php
+++ b/database/factories/AlertNotificationPreferenceFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\AlertSeverity;
+use App\Models\AlertNotificationChannel;
+use App\Models\AlertNotificationPreference;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<AlertNotificationPreference> */
+class AlertNotificationPreferenceFactory extends Factory
+{
+    protected $model = AlertNotificationPreference::class;
+
+    public function definition(): array
+    {
+        $user = User::factory();
+
+        return [
+            'user_id' => $user,
+            'channel_id' => AlertNotificationChannel::factory()->for($user),
+            'min_severity' => AlertSeverity::Warning->value,
+            'sources' => null,
+            'enabled' => true,
+            'notify_on_resolve' => false,
+            'rate_limit_per_hour' => null,
+        ];
+    }
+
+    public function criticalOnly(): static
+    {
+        return $this->state(fn () => [
+            'min_severity' => AlertSeverity::Critical->value,
+            'notify_on_resolve' => true,
+        ]);
+    }
+
+    public function disabled(): static
+    {
+        return $this->state(fn () => [
+            'enabled' => false,
+        ]);
+    }
+}

--- a/database/migrations/2026_07_02_000001_create_alert_notification_channels_table.php
+++ b/database/migrations/2026_07_02_000001_create_alert_notification_channels_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('alert_notification_channels', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('user_id')
+                ->constrained('users')
+                ->cascadeOnDelete();
+
+            // email | slack | webhook (per NotificationChannelKind enum).
+            $table->string('kind', 16);
+
+            $table->string('name');
+
+            // Per-kind payload: email → {to}; slack → {webhook_url};
+            // webhook → {url, signing_secret?}. Kept as encrypted JSON so
+            // Slack webhook URLs + optional HMAC secrets never sit in
+            // plaintext (spec 039 posture).
+            $table->text('config');
+
+            $table->boolean('enabled')->default(true);
+
+            // Set after the "send test" round-trip succeeds. Delivery
+            // skips un-verified channels — prevents an operator from
+            // pasting a bad Slack URL and only finding out on the first
+            // real critical alert.
+            $table->timestamp('verified_at')->nullable();
+
+            $table->timestamps();
+
+            $table->index(['user_id', 'enabled']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('alert_notification_channels');
+    }
+};

--- a/database/migrations/2026_07_02_000002_create_alert_notification_preferences_table.php
+++ b/database/migrations/2026_07_02_000002_create_alert_notification_preferences_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('alert_notification_preferences', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('user_id')
+                ->constrained('users')
+                ->cascadeOnDelete();
+
+            $table->foreignId('channel_id')
+                ->constrained('alert_notification_channels')
+                ->cascadeOnDelete();
+
+            // info | warning | critical — send when alert.severity >= this.
+            // Matches AlertSeverity enum values.
+            $table->string('min_severity', 16)->default('warning');
+
+            // JSON array of AlertSource values; null / empty = all sources.
+            $table->json('sources')->nullable();
+
+            $table->boolean('enabled')->default(true);
+
+            // False by default — resolutions are quieter than triggers.
+            // The UI defaults `notify_on_resolve` to true for `critical`
+            // + false otherwise; this column stores the resulting choice.
+            $table->boolean('notify_on_resolve')->default(false);
+
+            // Overrides the per-channel default (30/hour). Null = default.
+            $table->unsignedInteger('rate_limit_per_hour')->nullable();
+
+            $table->timestamps();
+
+            $table->index(['user_id', 'enabled']);
+            $table->index('channel_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('alert_notification_preferences');
+    }
+};

--- a/database/migrations/2026_07_02_000003_create_alert_deliveries_table.php
+++ b/database/migrations/2026_07_02_000003_create_alert_deliveries_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('alert_deliveries', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('alert_id')
+                ->constrained('alerts')
+                ->cascadeOnDelete();
+
+            $table->foreignId('channel_id')
+                ->constrained('alert_notification_channels')
+                ->cascadeOnDelete();
+
+            // pending | sent | failed | skipped (per AlertDeliveryStatus).
+            $table->string('status', 16)->default('pending');
+
+            $table->unsignedInteger('attempts')->default(0);
+
+            $table->timestamp('last_attempt_at')->nullable();
+            $table->timestamp('sent_at')->nullable();
+
+            // Last failure reason OR skip reason (`rate_limited`,
+            // `deduped`, `channel_disabled`, `channel_unverified`).
+            $table->text('error_message')->nullable();
+
+            // The outbound payload for forensic replay. Bounded ≤ 4 KB
+            // at the service layer — large alert metadata gets truncated
+            // with a `[truncated]` marker.
+            $table->json('payload')->nullable();
+
+            $table->timestamps();
+
+            // Retry / dedup lookups.
+            $table->index(['alert_id', 'channel_id']);
+            $table->index(['channel_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('alert_deliveries');
+    }
+};

--- a/database/migrations/2026_07_02_000003_create_alert_deliveries_table.php
+++ b/database/migrations/2026_07_02_000003_create_alert_deliveries_table.php
@@ -38,8 +38,11 @@ return new class extends Migration
 
             $table->timestamps();
 
-            // Retry / dedup lookups.
-            $table->index(['alert_id', 'channel_id']);
+            // One delivery row per (alert, channel) pair. `firstOrNew`
+            // in DispatchAlertNotificationJob relies on this invariant
+            // so the retry / attempts accounting is coherent under
+            // concurrent worker + user-triggered retries.
+            $table->unique(['alert_id', 'channel_id']);
             $table->index(['channel_id', 'status']);
         });
     }

--- a/docs/env.production.example
+++ b/docs/env.production.example
@@ -103,6 +103,14 @@ TELESCOPE_ENABLED=false
 # Optional override; the default (120s) is fine for most deploys.
 # HOSTS_HEARTBEAT_TIMEOUT_SECONDS=120
 
+# ---- Alert notifications (spec 042) -----------------------------------------
+# Delivery-layer knobs. Uncomment to override the defaults documented in
+# app/Domain/Notifications. The service-side dedupe window collapses
+# same-fingerprint alerts within N minutes; the per-channel rate limit
+# ceilings a runaway alert storm without operator intervention.
+# ALERT_NOTIFICATION_DEDUPE_WINDOW_MINUTES=5
+# ALERT_NOTIFICATION_RATE_LIMIT_PER_HOUR=30
+
 # ---- Vite dev server --------------------------------------------------------
 # Dev-only. Left blank / unset in production (npm run build handles assets).
 # VITE_DEV_SERVER_URL=

--- a/docs/security/operator-checklist.md
+++ b/docs/security/operator-checklist.md
@@ -84,6 +84,14 @@ Per-user limits via Laravel's `throttle:N,1` middleware:
 | `POST /settings/webhook-deliveries/{delivery}/retry` | 30/min |
 | `POST /verify-email/*` | 6/min (existing) |
 | `POST /email/verification-notification` | 6/min (existing) |
+| `POST /settings/notifications/channels` | 10/min (spec 042) |
+| `PATCH /settings/notifications/channels/{channel}` | 20/min (spec 042) |
+| `DELETE /settings/notifications/channels/{channel}` | 20/min (spec 042) |
+| `POST /settings/notifications/channels/{channel}/test` | 10/min (spec 042) |
+| `POST /settings/notifications/preferences` | 20/min (spec 042) |
+| `PATCH /settings/notifications/preferences/{preference}` | 20/min (spec 042) |
+| `DELETE /settings/notifications/preferences/{preference}` | 20/min (spec 042) |
+| `POST /settings/notifications/deliveries/{delivery}/retry` | 30/min (spec 042) |
 
 **Sign-off ☐:** Tested in
 [`ManualSyncRateLimitTest`](../../tests/Feature/Security/ManualSyncRateLimitTest.php).
@@ -103,6 +111,23 @@ Per-user limits via Laravel's `throttle:N,1` middleware:
   isn't a problem; if production routing changes, expand the
   `trustProxies` list before turning fingerprinting on for
   production tokens.
+
+### Outbound notifications (spec 042)
+
+Nexus can fan out alerts to email, Slack, and generic webhooks
+configured under `/settings/notifications`. Two extra postures:
+
+- **Slack webhook URLs + generic-webhook signing secrets are
+  encrypted at rest.** `alert_notification_channels.config` is
+  cast to `encrypted:array` and hidden from serialization. A
+  `configPreview()` helper renders only non-secret fields
+  (`to` for email, `webhook_host` for Slack, `url_host` +
+  `signed: bool` for webhook) to Inertia props.
+- **Outbound HMAC signatures.** When a generic-webhook channel
+  has a `signing_secret`, deliveries carry
+  `X-Nexus-Signature: sha256=<hmac-sha256(body, secret)>` so
+  the receiving side can `hash_equals`-verify them (mirrors the
+  inbound GitHub-webhook shape).
 
 ## 7. Deferred to follow-ups
 
@@ -129,4 +154,6 @@ Documented for visibility; not blockers for spec 039 sign-off:
 - [ ] §3: `HORIZON_ALLOW_LIST` populated for production env.
 - [ ] §4: Agent fingerprinting opt-in available on token issuance.
 - [ ] §5: Manual sync / probe / retry endpoints all throttled.
+- [ ] §5 (spec 042): Notification channel `config` encrypted at
+      rest; outbound webhook HMAC available on demand.
 - [ ] Run the suite: `php artisan test --filter=Security` passes.

--- a/resources/js/Pages/Settings/Index.vue
+++ b/resources/js/Pages/Settings/Index.vue
@@ -292,6 +292,27 @@ const disconnect = () => {
                 <ExternalLink class="h-4 w-4 text-text-muted" aria-hidden="true" />
             </Link>
 
+            <!-- Spec 042 — outbound alert notifications entry point. -->
+            <Link
+                :href="route('settings.notifications.index')"
+                class="glass-card flex items-center justify-between gap-3 p-5 transition hover:border-accent-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+            >
+                <div class="flex items-center gap-3">
+                    <span class="flex h-10 w-10 items-center justify-center rounded-lg border border-border-subtle bg-background-panel-hover">
+                        <Bell class="h-5 w-5 text-accent-cyan" aria-hidden="true" />
+                    </span>
+                    <div class="flex min-w-0 flex-col">
+                        <span class="text-sm font-semibold text-text-primary">
+                            Notifications
+                        </span>
+                        <span class="text-xs text-text-muted">
+                            Route alerts to email, Slack, or generic webhooks.
+                        </span>
+                    </div>
+                </div>
+                <ExternalLink class="h-4 w-4 text-text-muted" aria-hidden="true" />
+            </Link>
+
             <!-- GitHub Integration card -->
             <section
                 aria-label="GitHub integration"

--- a/resources/js/Pages/Settings/Notifications/Index.vue
+++ b/resources/js/Pages/Settings/Notifications/Index.vue
@@ -1,0 +1,571 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import {
+    Bell,
+    ChevronLeft,
+    Mail,
+    MessageSquare,
+    Plus,
+    RefreshCw,
+    Send,
+    Trash2,
+    Webhook,
+} from 'lucide-vue-next';
+import { computed, ref } from 'vue';
+
+type ChannelKind = 'email' | 'slack' | 'webhook';
+type Severity = 'info' | 'warning' | 'critical';
+type Source = 'website' | 'docker' | 'deployment' | 'github' | 'manual' | 'system';
+type DeliveryStatus = 'pending' | 'sent' | 'failed' | 'skipped';
+
+interface Channel {
+    id: number;
+    kind: ChannelKind;
+    kind_label: string;
+    name: string;
+    config_preview: Record<string, unknown>;
+    enabled: boolean;
+    verified_at: string | null;
+    verified: boolean;
+}
+
+interface Preference {
+    id: number;
+    channel_id: number;
+    channel_name: string | null;
+    channel_kind: ChannelKind | null;
+    min_severity: Severity;
+    sources: Source[];
+    enabled: boolean;
+    notify_on_resolve: boolean;
+    rate_limit_per_hour: number | null;
+}
+
+interface Delivery {
+    id: number;
+    alert_id: number | null;
+    alert_title: string | null;
+    alert_severity: Severity | null;
+    alert_source: Source | null;
+    channel_name: string | null;
+    channel_kind: ChannelKind | null;
+    status: DeliveryStatus;
+    status_tone: 'info' | 'success' | 'danger' | 'muted' | 'warning' | null;
+    attempts: number;
+    error_message: string | null;
+    last_attempt_at: string | null;
+    sent_at: string | null;
+    created_at: string | null;
+}
+
+interface Paginator<T> {
+    data: T[];
+    current_page: number;
+    last_page: number;
+    links: Array<{ url: string | null; label: string; active: boolean }>;
+}
+
+const props = defineProps<{
+    channels: Channel[];
+    preferences: Preference[];
+    deliveries: Paginator<Delivery>;
+    options: {
+        kinds: Array<{ value: ChannelKind; label: string }>;
+        severities: Severity[];
+        sources: Source[];
+    };
+}>();
+
+type Tab = 'channels' | 'rules' | 'deliveries';
+const activeTab = ref<Tab>('channels');
+
+// ---- Channel add form ----
+const newChannel = ref<{ kind: ChannelKind; name: string; config: Record<string, string> }>({
+    kind: 'email',
+    name: '',
+    config: {},
+});
+
+const configFields = computed<string[]>(() => {
+    switch (newChannel.value.kind) {
+        case 'email':
+            return ['to'];
+        case 'slack':
+            return ['webhook_url'];
+        case 'webhook':
+            return ['url', 'signing_secret'];
+    }
+    return [];
+});
+
+const submitChannel = () => {
+    router.post(
+        route('settings.notifications.channels.store'),
+        {
+            kind: newChannel.value.kind,
+            name: newChannel.value.name,
+            config: newChannel.value.config,
+        },
+        {
+            preserveScroll: true,
+            onSuccess: () => {
+                newChannel.value = { kind: 'email', name: '', config: {} };
+            },
+        },
+    );
+};
+
+const testChannel = (channel: Channel) => {
+    router.post(
+        route('settings.notifications.channels.test', { channel: channel.id }),
+        {},
+        { preserveScroll: true },
+    );
+};
+
+const deleteChannel = (channel: Channel) => {
+    if (!confirm(`Delete "${channel.name}"? All rules using it will be removed.`)) return;
+    router.delete(
+        route('settings.notifications.channels.destroy', { channel: channel.id }),
+        { preserveScroll: true },
+    );
+};
+
+// ---- Preference add form ----
+const newPreference = ref<{
+    channel_id: number | null;
+    min_severity: Severity;
+    sources: Source[];
+    notify_on_resolve: boolean;
+    rate_limit_per_hour: number | null;
+}>({
+    channel_id: null,
+    min_severity: 'warning',
+    sources: [],
+    notify_on_resolve: false,
+    rate_limit_per_hour: null,
+});
+
+const submitPreference = () => {
+    if (!newPreference.value.channel_id) return;
+    router.post(
+        route('settings.notifications.preferences.store'),
+        {
+            channel_id: newPreference.value.channel_id,
+            min_severity: newPreference.value.min_severity,
+            sources: newPreference.value.sources.length > 0 ? newPreference.value.sources : null,
+            notify_on_resolve: newPreference.value.notify_on_resolve,
+            rate_limit_per_hour: newPreference.value.rate_limit_per_hour,
+        },
+        {
+            preserveScroll: true,
+            onSuccess: () => {
+                newPreference.value = {
+                    channel_id: null,
+                    min_severity: 'warning',
+                    sources: [],
+                    notify_on_resolve: false,
+                    rate_limit_per_hour: null,
+                };
+            },
+        },
+    );
+};
+
+const deletePreference = (preference: Preference) => {
+    if (!confirm('Delete this rule?')) return;
+    router.delete(
+        route('settings.notifications.preferences.destroy', { preference: preference.id }),
+        { preserveScroll: true },
+    );
+};
+
+// ---- Delivery retry ----
+const retryDelivery = (delivery: Delivery) => {
+    if (delivery.status !== 'failed') return;
+    router.post(
+        route('settings.notifications.deliveries.retry', { delivery: delivery.id }),
+        {},
+        { preserveScroll: true },
+    );
+};
+
+const iconFor = (kind: ChannelKind | null) => {
+    switch (kind) {
+        case 'email':
+            return Mail;
+        case 'slack':
+            return MessageSquare;
+        case 'webhook':
+            return Webhook;
+        default:
+            return Bell;
+    }
+};
+
+const capitalize = (s: string | null) =>
+    s ? s.charAt(0).toUpperCase() + s.slice(1) : '';
+</script>
+
+<template>
+    <Head title="Notifications" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <Link
+                    :href="route('settings.index')"
+                    class="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan transition hover:text-accent-cyan/80"
+                >
+                    <ChevronLeft class="h-3 w-3" aria-hidden="true" />
+                    Settings
+                </Link>
+                <h1 class="text-lg font-semibold text-text-primary">Notifications</h1>
+            </div>
+        </template>
+
+        <div class="space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+            <header class="flex flex-col gap-1">
+                <h2 class="flex items-center gap-2 text-xl font-semibold text-text-primary">
+                    <Bell class="h-5 w-5 text-accent-cyan" aria-hidden="true" />
+                    Alert notifications
+                </h2>
+                <p class="text-sm text-text-secondary">
+                    Route alerts to email, Slack, or a generic webhook. Rules pick which
+                    severities and sources fire which channel.
+                </p>
+            </header>
+
+            <!-- Tab strip -->
+            <nav
+                aria-label="Notification tabs"
+                class="flex gap-2 border-b border-border-subtle"
+            >
+                <button
+                    v-for="tab in (['channels', 'rules', 'deliveries'] as Tab[])"
+                    :key="tab"
+                    type="button"
+                    class="border-b-2 px-4 py-2 text-sm font-semibold uppercase tracking-[0.18em] transition"
+                    :class="
+                        activeTab === tab
+                            ? 'border-accent-cyan text-text-primary'
+                            : 'border-transparent text-text-muted hover:text-text-primary'
+                    "
+                    @click="activeTab = tab"
+                >
+                    {{ capitalize(tab) }}
+                </button>
+            </nav>
+
+            <!-- Channels tab -->
+            <section v-if="activeTab === 'channels'" class="space-y-6">
+                <div class="glass-card p-5">
+                    <h3 class="mb-4 text-sm font-semibold uppercase tracking-[0.18em] text-text-muted">
+                        Add channel
+                    </h3>
+                    <form class="space-y-4" @submit.prevent="submitChannel">
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                Kind
+                                <select
+                                    v-model="newChannel.kind"
+                                    class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                    @change="newChannel.config = {}"
+                                >
+                                    <option v-for="k in props.options.kinds" :key="k.value" :value="k.value">
+                                        {{ k.label }}
+                                    </option>
+                                </select>
+                            </label>
+                            <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                Name
+                                <input
+                                    v-model="newChannel.name"
+                                    type="text"
+                                    required
+                                    placeholder="Ops on-call"
+                                    class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                >
+                            </label>
+                        </div>
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <label
+                                v-for="field in configFields"
+                                :key="field"
+                                class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted"
+                            >
+                                {{ field.replace('_', ' ') }}
+                                <input
+                                    v-model="newChannel.config[field]"
+                                    :type="field === 'signing_secret' ? 'password' : 'text'"
+                                    :placeholder="field === 'to' ? 'ops@example.com' : field === 'webhook_url' ? 'https://hooks.slack.com/...' : field === 'url' ? 'https://ops.example.com/hook' : 'optional HMAC secret'"
+                                    class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                >
+                            </label>
+                        </div>
+                        <button
+                            type="submit"
+                            class="inline-flex items-center gap-2 rounded-lg bg-accent-cyan px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-accent-cyan/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                        >
+                            <Plus class="h-4 w-4" aria-hidden="true" />
+                            Add channel
+                        </button>
+                    </form>
+                </div>
+
+                <div v-if="props.channels.length > 0" class="glass-card overflow-hidden">
+                    <ul class="divide-y divide-border-subtle">
+                        <li
+                            v-for="channel in props.channels"
+                            :key="channel.id"
+                            class="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                            <div class="flex min-w-0 items-start gap-3">
+                                <component
+                                    :is="iconFor(channel.kind)"
+                                    class="mt-0.5 h-5 w-5 shrink-0 text-accent-cyan"
+                                    aria-hidden="true"
+                                />
+                                <div class="flex min-w-0 flex-col gap-1">
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <span class="text-sm font-semibold text-text-primary">{{ channel.name }}</span>
+                                        <StatusBadge :tone="channel.verified ? 'success' : 'warning'">
+                                            {{ channel.verified ? 'Verified' : 'Unverified' }}
+                                        </StatusBadge>
+                                        <StatusBadge v-if="!channel.enabled" tone="muted">Disabled</StatusBadge>
+                                    </div>
+                                    <div class="flex flex-wrap gap-3 text-[11px] text-text-muted">
+                                        <span>{{ channel.kind_label }}</span>
+                                        <span v-if="channel.verified_at">Verified {{ channel.verified_at }}</span>
+                                        <span v-for="(v, k) in channel.config_preview" :key="k">
+                                            {{ k }}: <span class="font-mono">{{ v }}</span>
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="flex shrink-0 items-center gap-2">
+                                <button
+                                    type="button"
+                                    class="inline-flex items-center gap-2 rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-1.5 text-xs font-semibold text-text-secondary transition hover:border-accent-cyan/40 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                    @click="testChannel(channel)"
+                                >
+                                    <Send class="h-3.5 w-3.5" aria-hidden="true" />
+                                    Send test
+                                </button>
+                                <button
+                                    type="button"
+                                    class="inline-flex items-center gap-2 rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-1.5 text-xs font-semibold text-status-danger transition hover:border-status-danger/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-status-danger/60"
+                                    @click="deleteChannel(channel)"
+                                >
+                                    <Trash2 class="h-3.5 w-3.5" aria-hidden="true" />
+                                    Delete
+                                </button>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+                <div v-else class="glass-card p-6 text-center text-sm text-text-muted">
+                    No channels yet. Add one above to start receiving notifications.
+                </div>
+            </section>
+
+            <!-- Rules tab -->
+            <section v-if="activeTab === 'rules'" class="space-y-6">
+                <div class="glass-card p-5">
+                    <h3 class="mb-4 text-sm font-semibold uppercase tracking-[0.18em] text-text-muted">
+                        Add rule
+                    </h3>
+                    <form class="space-y-4" @submit.prevent="submitPreference">
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                Channel
+                                <select
+                                    v-model="newPreference.channel_id"
+                                    required
+                                    class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                >
+                                    <option :value="null" disabled>Pick a channel</option>
+                                    <option v-for="c in props.channels" :key="c.id" :value="c.id">
+                                        {{ c.name }} ({{ c.kind_label }})
+                                    </option>
+                                </select>
+                            </label>
+                            <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                Minimum severity
+                                <select
+                                    v-model="newPreference.min_severity"
+                                    class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                >
+                                    <option v-for="s in props.options.severities" :key="s" :value="s">
+                                        {{ capitalize(s) }} and above
+                                    </option>
+                                </select>
+                            </label>
+                        </div>
+                        <fieldset>
+                            <legend class="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                Sources (empty = all)
+                            </legend>
+                            <div class="flex flex-wrap gap-3">
+                                <label
+                                    v-for="src in props.options.sources"
+                                    :key="src"
+                                    class="inline-flex items-center gap-2 text-sm text-text-secondary"
+                                >
+                                    <input
+                                        v-model="newPreference.sources"
+                                        type="checkbox"
+                                        :value="src"
+                                    >
+                                    {{ capitalize(src) }}
+                                </label>
+                            </div>
+                        </fieldset>
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <label class="inline-flex items-center gap-2 text-sm text-text-secondary">
+                                <input v-model="newPreference.notify_on_resolve" type="checkbox">
+                                Notify on resolve too
+                            </label>
+                            <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                Rate limit / hour (blank = default)
+                                <input
+                                    v-model.number="newPreference.rate_limit_per_hour"
+                                    type="number"
+                                    min="1"
+                                    max="1000"
+                                    class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                >
+                            </label>
+                        </div>
+                        <button
+                            type="submit"
+                            :disabled="props.channels.length === 0"
+                            class="inline-flex items-center gap-2 rounded-lg bg-accent-cyan px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-accent-cyan/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60 disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                            <Plus class="h-4 w-4" aria-hidden="true" />
+                            Add rule
+                        </button>
+                    </form>
+                </div>
+
+                <div v-if="props.preferences.length > 0" class="glass-card overflow-hidden">
+                    <ul class="divide-y divide-border-subtle">
+                        <li
+                            v-for="preference in props.preferences"
+                            :key="preference.id"
+                            class="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                            <div class="flex min-w-0 items-start gap-3">
+                                <component
+                                    :is="iconFor(preference.channel_kind)"
+                                    class="mt-0.5 h-5 w-5 shrink-0 text-accent-cyan"
+                                    aria-hidden="true"
+                                />
+                                <div class="flex min-w-0 flex-col gap-1">
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <span class="text-sm font-semibold text-text-primary">
+                                            {{ preference.channel_name || '(deleted channel)' }}
+                                        </span>
+                                        <StatusBadge :tone="preference.enabled ? 'success' : 'muted'">
+                                            {{ preference.enabled ? 'Enabled' : 'Disabled' }}
+                                        </StatusBadge>
+                                    </div>
+                                    <div class="flex flex-wrap gap-3 text-[11px] text-text-muted">
+                                        <span>{{ capitalize(preference.min_severity) }} and above</span>
+                                        <span>{{ preference.sources.length === 0 ? 'All sources' : preference.sources.map(capitalize).join(', ') }}</span>
+                                        <span v-if="preference.notify_on_resolve">Resolves too</span>
+                                        <span v-if="preference.rate_limit_per_hour">{{ preference.rate_limit_per_hour }}/hr</span>
+                                    </div>
+                                </div>
+                            </div>
+                            <button
+                                type="button"
+                                class="inline-flex items-center gap-2 rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-1.5 text-xs font-semibold text-status-danger transition hover:border-status-danger/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-status-danger/60"
+                                @click="deletePreference(preference)"
+                            >
+                                <Trash2 class="h-3.5 w-3.5" aria-hidden="true" />
+                                Delete
+                            </button>
+                        </li>
+                    </ul>
+                </div>
+                <div v-else class="glass-card p-6 text-center text-sm text-text-muted">
+                    No rules yet. Add a rule above to route alerts to a channel.
+                </div>
+            </section>
+
+            <!-- Deliveries tab -->
+            <section v-if="activeTab === 'deliveries'" class="space-y-4">
+                <div v-if="props.deliveries.data.length > 0" class="glass-card overflow-hidden">
+                    <ul class="divide-y divide-border-subtle">
+                        <li
+                            v-for="delivery in props.deliveries.data"
+                            :key="delivery.id"
+                            class="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                            <div class="flex min-w-0 flex-col gap-1">
+                                <div class="flex flex-wrap items-center gap-2">
+                                    <StatusBadge v-if="delivery.status_tone" :tone="delivery.status_tone">
+                                        {{ capitalize(delivery.status) }}
+                                    </StatusBadge>
+                                    <span class="text-sm font-semibold text-text-primary">
+                                        {{ delivery.alert_title || `Alert #${delivery.alert_id}` }}
+                                    </span>
+                                    <span class="text-xs text-text-muted">
+                                        → {{ delivery.channel_name }}
+                                    </span>
+                                </div>
+                                <div class="flex flex-wrap gap-3 text-[11px] text-text-muted">
+                                    <span v-if="delivery.alert_severity">{{ capitalize(delivery.alert_severity) }}</span>
+                                    <span v-if="delivery.alert_source">{{ capitalize(delivery.alert_source) }}</span>
+                                    <span>{{ delivery.attempts }} attempt{{ delivery.attempts === 1 ? '' : 's' }}</span>
+                                    <span v-if="delivery.sent_at">Sent {{ delivery.sent_at }}</span>
+                                    <span v-else-if="delivery.last_attempt_at">Last attempt {{ delivery.last_attempt_at }}</span>
+                                    <span v-else-if="delivery.created_at">{{ delivery.created_at }}</span>
+                                </div>
+                                <p
+                                    v-if="delivery.error_message"
+                                    class="text-xs text-status-danger"
+                                >
+                                    {{ delivery.error_message }}
+                                </p>
+                            </div>
+                            <button
+                                v-if="delivery.status === 'failed'"
+                                type="button"
+                                class="inline-flex items-center gap-2 rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-1.5 text-xs font-semibold text-text-secondary transition hover:border-accent-cyan/40 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                @click="retryDelivery(delivery)"
+                            >
+                                <RefreshCw class="h-3.5 w-3.5" aria-hidden="true" />
+                                Retry
+                            </button>
+                        </li>
+                    </ul>
+                </div>
+                <div v-else class="glass-card p-6 text-center text-sm text-text-muted">
+                    No deliveries yet. Trigger an alert (or hit "Send test" on a channel) and the log lands here.
+                </div>
+
+                <nav
+                    v-if="props.deliveries.last_page > 1"
+                    aria-label="Delivery pagination"
+                    class="flex flex-wrap gap-2"
+                >
+                    <Link
+                        v-for="link in props.deliveries.links"
+                        :key="link.label"
+                        :href="link.url ?? '#'"
+                        class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-1.5 text-xs font-semibold text-text-secondary transition hover:border-accent-cyan/40 hover:text-text-primary"
+                        :class="{
+                            'border-accent-cyan/60 text-text-primary': link.active,
+                            'pointer-events-none opacity-40': !link.url,
+                        }"
+                        v-html="link.label"
+                    />
+                </nav>
+            </section>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/views/emails/alert-notification.blade.php
+++ b/resources/views/emails/alert-notification.blade.php
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{{ $payload->title }}</title>
+</head>
+<body style="margin:0;padding:0;background:#0f172a;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,sans-serif;color:#e2e8f0;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0f172a;padding:32px 16px;">
+        <tr>
+            <td align="center">
+                <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="max-width:560px;background:#1e293b;border:1px solid rgba(148,163,184,0.24);border-radius:16px;overflow:hidden;">
+                    <tr>
+                        <td style="padding:20px 24px;background:{{ $payload->severity === 'critical' ? '#7f1d1d' : ($payload->severity === 'warning' ? '#78350f' : '#155e75') }};color:#f8fafc;font-size:12px;letter-spacing:0.12em;text-transform:uppercase;font-weight:600;">
+                            @if ($payload->event === 'alert.resolved')
+                                Resolved · {{ ucfirst($payload->severity) }}
+                            @else
+                                Alert · {{ ucfirst($payload->severity) }}
+                            @endif
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding:24px;">
+                            <p style="margin:0 0 12px;font-size:20px;font-weight:600;color:#f8fafc;">{{ $payload->title }}</p>
+                            @if (! empty($payload->message))
+                                <p style="margin:0 0 20px;font-size:14px;line-height:1.6;color:#cbd5e1;">{{ $payload->message }}</p>
+                            @endif
+                            <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;margin:0 0 20px;font-size:13px;color:#94a3b8;">
+                                <tr>
+                                    <td style="padding:4px 0;width:96px;">Source</td>
+                                    <td style="padding:4px 0;color:#e2e8f0;">{{ ucfirst($payload->source) }}</td>
+                                </tr>
+                                <tr>
+                                    <td style="padding:4px 0;">Type</td>
+                                    <td style="padding:4px 0;color:#e2e8f0;">{{ $payload->type }}</td>
+                                </tr>
+                                <tr>
+                                    <td style="padding:4px 0;">Triggered</td>
+                                    <td style="padding:4px 0;color:#e2e8f0;">{{ $payload->triggeredAt->format('Y-m-d H:i:s T') }}</td>
+                                </tr>
+                            </table>
+                            <a href="{{ $payload->link }}" style="display:inline-block;padding:10px 18px;background:#22d3ee;color:#0f172a;font-weight:600;text-decoration:none;border-radius:8px;font-size:14px;">View in Nexus</a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding:16px 24px;background:#0f172a;color:#64748b;font-size:12px;">
+                            You're receiving this because a notification channel in your Nexus settings is subscribed to this alert. Adjust in Settings → Notifications.
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ use App\Http\Controllers\RepositoryPullRequestsSyncController;
 use App\Http\Controllers\RepositorySyncAllController;
 use App\Http\Controllers\RepositorySyncController;
 use App\Http\Controllers\RepositoryWorkflowRunsSyncController;
+use App\Http\Controllers\Settings\NotificationsController;
 use App\Http\Controllers\Settings\ThemeController;
 use App\Http\Controllers\Settings\WebhookDeliveryController;
 use App\Http\Controllers\SettingsController;
@@ -74,6 +75,36 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/settings/webhook-deliveries/{delivery}/retry', [WebhookDeliveryController::class, 'retry'])
         ->middleware('throttle:30,1') // spec 039
         ->name('settings.webhook-deliveries.retry');
+
+    // Spec 042 — outbound alert notifications (email / Slack / webhook).
+    // Single Inertia page carrying three logical tabs; the controller
+    // fans out mutations across channels + preferences + deliveries.
+    Route::get('/settings/notifications', [NotificationsController::class, 'index'])
+        ->name('settings.notifications.index');
+    Route::post('/settings/notifications/channels', [NotificationsController::class, 'storeChannel'])
+        ->middleware('throttle:10,1')
+        ->name('settings.notifications.channels.store');
+    Route::patch('/settings/notifications/channels/{channel}', [NotificationsController::class, 'updateChannel'])
+        ->middleware('throttle:20,1')
+        ->name('settings.notifications.channels.update');
+    Route::delete('/settings/notifications/channels/{channel}', [NotificationsController::class, 'destroyChannel'])
+        ->middleware('throttle:20,1')
+        ->name('settings.notifications.channels.destroy');
+    Route::post('/settings/notifications/channels/{channel}/test', [NotificationsController::class, 'testChannel'])
+        ->middleware('throttle:10,1')
+        ->name('settings.notifications.channels.test');
+    Route::post('/settings/notifications/preferences', [NotificationsController::class, 'storePreference'])
+        ->middleware('throttle:20,1')
+        ->name('settings.notifications.preferences.store');
+    Route::patch('/settings/notifications/preferences/{preference}', [NotificationsController::class, 'updatePreference'])
+        ->middleware('throttle:20,1')
+        ->name('settings.notifications.preferences.update');
+    Route::delete('/settings/notifications/preferences/{preference}', [NotificationsController::class, 'destroyPreference'])
+        ->middleware('throttle:20,1')
+        ->name('settings.notifications.preferences.destroy');
+    Route::post('/settings/notifications/deliveries/{delivery}/retry', [NotificationsController::class, 'retryDelivery'])
+        ->middleware('throttle:30,1')
+        ->name('settings.notifications.deliveries.retry');
 
     Route::get('/integrations/github/connect', [GithubConnectionController::class, 'redirect'])
         ->name('integrations.github.connect');

--- a/specs/README.md
+++ b/specs/README.md
@@ -45,7 +45,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 7 | Alerts Engine | 🟢 | 3/3 specs done (030–032). Phase complete. |
 | 8 | Analytics & Health Scores | 🟢 | 3/3 specs done (033–035). Phase complete. |
 | 9 | Polish & Production Readiness | 🟢 | 6/6 specs done (036–041). Phase complete. |
-| 10 | Future Innovation | ⬜ | — |
+| 10 | Future Innovation | 🟡 | 1/6 specs done (042). 043–047 remaining. |
 
 ## MVP scope (target for v1)
 

--- a/specs/phase-10-innovation/042-alert-notification-service.md
+++ b/specs/phase-10-innovation/042-alert-notification-service.md
@@ -1,0 +1,350 @@
+---
+spec: alert-notification-service
+phase: 10
+status: in-progress   # not-started | in-progress | blocked | done
+owner: Yoany
+created: 2026-07-02
+updated: 2026-07-02
+---
+
+# 042 — `AlertNotificationService`: email + Slack + generic webhook delivery
+
+## Goal
+
+Phase 7 shipped the alerts engine: triggers, storage, lifecycle
+(open → ack → resolved), UI, activity events. What it did NOT ship
+is delivery to anywhere outside the app. Every deferred-Phase-7
+note across the codebase points at the same missing piece — an
+`AlertNotificationService` that fans a triggered alert out to the
+operator's preferred channels.
+
+Spec 042 ships that service. Three channels: email, Slack (incoming
+webhook), generic HTTP webhook. Per-user routing preferences decide
+which severities + sources fire which channel, and Nexus's own
+observability + rate limits + dedupe surround delivery so a runaway
+alert storm can't nuke your Slack channel or blow your SMTP quota.
+
+This is the phase-10 keystone. Specs 044 (AI daily briefing), 045
+(AI PR risk score), and 047 (status page subscribe) all lean on
+its delivery layer — ship this first.
+
+Roadmap refs: §Phase 7 acceptance criteria (`AlertNotification-
+Service` deferred to Phase 10), §Phase 10 "Slack/Discord
+notifications", §6.5 Strategy Pattern (per-channel delivery), §16
+Security Requirements (webhook signatures for outbound), §18 Error
+Handling (retry / backoff / dead-letter for delivery failures).
+
+## Scope
+
+**In scope:**
+
+- **Migration: `alert_notification_channels`.** Per-user channel
+  configuration. Columns:
+  - `id`, `user_id` (FK → `users`, cascade delete)
+  - `kind` (enum: `email` | `slack` | `webhook`)
+  - `name` (user-facing label — "My Slack", "Ops on-call email")
+  - `config` (JSON — per-kind: `email` → `to`; `slack` → `webhook_url`;
+    `webhook` → `url` + optional `signing_secret` for HMAC)
+  - `enabled` (boolean, default true — soft-disable without
+    deleting)
+  - `verified_at` (nullable timestamp — set after the "send test"
+    round-trip succeeds. Un-verified channels are skipped by
+    delivery)
+  - Timestamps.
+
+- **Migration: `alert_notification_preferences`.** Per-user routing
+  rules. Columns:
+  - `id`, `user_id` (FK, cascade delete)
+  - `channel_id` (FK → `alert_notification_channels`, cascade
+    delete)
+  - `min_severity` (enum: `info` | `warning` | `critical` — send
+    when alert.severity >= this)
+  - `sources` (JSON array of `AlertSource` values; null / empty =
+    all sources)
+  - `enabled` (boolean, default true)
+  - Timestamps.
+
+- **Migration: `alert_deliveries`.** Delivery log per alert per
+  channel. Columns:
+  - `id`, `alert_id` (FK → `alerts`, cascade delete)
+  - `channel_id` (FK → `alert_notification_channels`, cascade
+    delete)
+  - `status` (enum: `pending` | `sent` | `failed` | `skipped`)
+  - `attempts` (integer, default 0)
+  - `last_attempt_at`, `sent_at` (nullable)
+  - `error_message` (nullable text — last failure reason)
+  - `payload` (JSON — the outbound payload for forensic replay)
+  - Timestamps.
+  - Composite index on `(alert_id, channel_id)` to make retry
+    lookups cheap.
+
+- **`AlertNotificationService`.** Coordinator that answers "an
+  alert just triggered — who gets notified?" Reads
+  `alert_notification_preferences`, filters by severity + source,
+  dispatches a `DispatchAlertNotificationJob` per matching
+  channel. Idempotent: re-firing for the same
+  `(alert_id, channel_id)` in the same lifecycle skips already-sent
+  rows.
+
+- **`DispatchAlertNotificationJob`** (implements `ShouldQueue`,
+  `ShouldBeUnique` on `(alert_id, channel_id)`). Resolves the
+  channel, delegates to the matching `NotificationChannelDriver`,
+  writes the `alert_deliveries` row. Retries via §18 backoff on
+  transient failures (429, 5xx, timeout). Dead-letters to
+  `status: failed` after `tries = 3`.
+
+- **`NotificationChannelDriver` contract + three implementations.**
+  §6.5 Strategy pattern.
+  - `EmailChannelDriver` — Laravel `Mail::to(...)->send(new
+    AlertNotificationMail($alert))`. HTML + text templates. Uses
+    the `MAIL_*` env vars documented in
+    `docs/env.production.example`.
+  - `SlackChannelDriver` — HTTP POST to the incoming-webhook URL
+    with a Slack-message Block Kit payload. Timeouts at 5s.
+    429-aware (respects `Retry-After`).
+  - `GenericWebhookChannelDriver` — HTTP POST of the
+    `AlertNotificationPayload` DTO as JSON. Optional
+    `X-Nexus-Signature` HMAC-SHA-256 header when
+    `config.signing_secret` is set (mirrors the inbound GitHub
+    webhook verification shape).
+
+- **`AlertNotificationPayload` DTO.** Immutable value object
+  carrying the outbound shape: `alert_id`, `type`, `severity`,
+  `source`, `title`, `message`, `link` (deep link back to
+  `/alerts/{id}`), `triggered_at`, `metadata` (subset of the
+  alert's metadata JSON, sanitized). Constructor accepts an
+  `Alert` model; drivers receive the DTO, never the model.
+
+- **Hook `AlertNotificationService::dispatchFor($alert)` into
+  `TriggerAlertAction`.** Fire-and-forget: the notification
+  dispatch is a queued side-effect, never blocking the trigger
+  path. Wraps in try / catch + logs to Sentry / logs — trigger
+  path succeeds even if notification dispatch throws.
+
+- **Hook `dispatchResolutionFor($alert)` into
+  `ResolveAlertAction`.** Optional per-preference: some operators
+  want the "resolved" ping, some don't. Preference row gets a
+  `notify_on_resolve` boolean (default false — critical alert
+  resolutions ping, everything else stays quiet).
+
+- **Rate limit + dedupe.**
+  - Per-channel budget: 30 notifications / user / hour default,
+    overridable per preference row via `rate_limit_per_hour`.
+    Enforced via Laravel's `RateLimiter::attempt(...)` keyed on
+    `(user_id, channel_id)`. Rejected sends land in
+    `alert_deliveries` as `status: skipped` with a
+    `error_message: rate_limited` marker so operators see the
+    ceiling in the UI.
+  - Dedupe: if an alert for the same `(source, source_id, type)`
+    already fired within a 5-minute window, skip. Prevents flap
+    storms from a website going up/down/up/down.
+
+- **Settings UI: `/settings/notifications`.**
+  - **Channels tab.** Add / edit / delete channels. Each row shows
+    kind, name, verification status, enable toggle. "Send test"
+    button dispatches a test notification (uses a stub Alert
+    payload) and flips `verified_at` on success. Test failures
+    render the driver's error message inline.
+  - **Rules tab.** Per-channel routing preferences. Toggle
+    `enabled`, pick `min_severity`, multi-select `sources`, set
+    per-hour rate limit override, toggle `notify_on_resolve`.
+  - **Deliveries tab.** Paginated log of recent deliveries —
+    channel, alert, status, error, retry button on failed rows.
+    Sits alongside spec 037's webhook-deliveries tab under
+    Settings.
+
+- **Tests.**
+  - `TriggerAlertActionNotificationDispatchTest` — triggering an
+    alert enqueues one `DispatchAlertNotificationJob` per matching
+    preference; skipped severities / sources don't enqueue.
+  - `DispatchAlertNotificationJobTest` — happy path per driver
+    (email lands in `Mail::fake()`, Slack + webhook via
+    `Http::fake()` assertions). Failure path — 5xx returns a job
+    exception + row lands `status: failed` after retries.
+  - `AlertNotificationRateLimitTest` — the 31st notification in
+    an hour lands `status: skipped` with `rate_limited` marker.
+  - `AlertNotificationDedupeTest` — same-fingerprint alert fired
+    within 5 minutes → the second delivery is skipped
+    (`error_message: deduped`).
+  - `SendChannelTestNotificationTest` — the "send test" button
+    flips `verified_at` on 2xx response.
+  - `WebhookSignatureOutboundTest` — when `config.signing_secret`
+    is set, outbound webhook carries a valid HMAC-SHA-256
+    `X-Nexus-Signature` header.
+
+**Out of scope:**
+
+- **Discord / Microsoft Teams / PagerDuty native.** The
+  `GenericWebhookChannelDriver` already handles Discord (Discord
+  accepts inbound webhooks in a Slack-compatible-ish shape but
+  needs its own driver for full parity). Teams / PagerDuty are
+  their own drivers; add later on demand.
+- **On-call rotations / escalation policies.** That's the
+  deferred "incident management" phase-11 spec.
+- **Digest / batching.** "Send at most one email per hour
+  summarizing all alerts" — nice, but adds a batching queue on
+  top of dispatch. Defer.
+- **Per-project notification routing.** Preferences today are
+  per-user; per-user × per-project is a Cartesian-product UI
+  problem. If operators ask for it, a `project_id` nullable
+  filter on the preference row + a UI select is a follow-up.
+- **In-app notifications badge.** The alerts count in the sidebar
+  already surfaces this. A separate bell-icon queue is a UX
+  redesign, not this spec.
+- **Two-factor delivery** (SMS, phone call). Different vendor
+  surface; defer.
+- **Retry policy tuning per channel.** All three drivers use the
+  §18 default (3 retries, exponential backoff). Per-channel
+  override lives in the preference row `rate_limit_per_hour`; a
+  separate `max_attempts` knob is deferred until an operator
+  actually asks.
+
+## Plan
+
+1. **Migrations.** Three tables, one migration file per table with
+   `nexus_042_` prefix. Foreign keys with cascade delete. Add
+   composite indexes for the retry / dedupe query paths.
+
+2. **Enums.** `NotificationChannelKind` (`email` | `slack` |
+   `webhook`), `AlertDeliveryStatus` (`pending` | `sent` |
+   `failed` | `skipped`). Match the string-backed enum pattern
+   from spec 030's `AlertStatus`.
+
+3. **DTO + driver contract.** `AlertNotificationPayload` value
+   object + `NotificationChannelDriver` interface with
+   `send(AlertNotificationChannel $channel, AlertNotificationPayload
+   $payload): void`. Drivers throw on failure so the caller
+   ({Dispatch}Job) can wrap in the retry / dead-letter loop.
+
+4. **Three driver implementations.** Email via Laravel Mail, Slack
+   via `Http::post()` with 5s timeout, webhook via same +
+   optional HMAC signature. Each driver is a thin adapter with a
+   feature test.
+
+5. **`AlertNotificationService`.** Coordinator. Query matching
+   preferences → dispatch one job per channel → return silently.
+   Dedupe check runs at the service level (fingerprint from
+   `alert.{source, source_id, type}`); rate limit runs at the job
+   level (per user × channel).
+
+6. **`DispatchAlertNotificationJob`.** `ShouldBeUnique` keyed on
+   `(alert_id, channel_id)`. Resolves the driver, catches driver
+   exceptions, writes the `alert_deliveries` row. Failed jobs
+   land `status: failed` after `tries = 3` (spec 037 pattern).
+
+7. **Hook into `TriggerAlertAction` + `ResolveAlertAction`.**
+   Fire-and-forget wrapped in try / catch. Trigger path never
+   fails because notification dispatch failed — the alert is more
+   important than the notification of it.
+
+8. **Settings UI — three tabs.** Channels / Rules / Deliveries.
+   Inertia pages + controllers under
+   `app/Http/Controllers/Settings/Notifications/`. Follow the
+   spec-037 webhook-deliveries page shape.
+
+9. **`docs/env.production.example` update.** Add commented
+   defaults for the new rate-limit / dedupe-window knobs so
+   operators know they exist.
+
+10. **Update spec 041's operator checklist §5.** Add the outbound
+    Slack + webhook endpoints to the per-user throttle table.
+
+11. **Pint clean, suite green, build clean. Self-review with
+    `superpowers:code-reviewer`. PR. Watch CI. Pause for merge.**
+
+## Acceptance criteria
+
+- [ ] Three migrations shipped: `alert_notification_channels`,
+      `alert_notification_preferences`, `alert_deliveries`.
+- [ ] `NotificationChannelDriver` contract + three
+      implementations (email, Slack, webhook).
+- [ ] `AlertNotificationService::dispatchFor($alert)` wired into
+      `TriggerAlertAction`; `dispatchResolutionFor($alert)` wired
+      into `ResolveAlertAction`.
+- [ ] `/settings/notifications` renders Channels + Rules +
+      Deliveries tabs. "Send test" flips `verified_at`; failed
+      test surfaces driver error.
+- [ ] Rate limit enforced (30 / user / hour default, override per
+      preference row).
+- [ ] Dedupe suppresses same-fingerprint alerts within a 5-minute
+      window.
+- [ ] Failed deliveries surface in the Deliveries tab with a
+      retry button (30 / min rate-limited, following spec 039's
+      per-endpoint throttle table).
+- [ ] Generic webhook carries `X-Nexus-Signature` when the
+      channel row has a `signing_secret`.
+- [ ] Every test from the §Tests block lands green.
+- [ ] Pint clean, `php artisan test` green, `npm run build`
+      clean.
+
+## Files touched
+
+- `database/migrations/2026_07_02_*_create_alert_notification_channels_table.php` — created
+- `database/migrations/2026_07_02_*_create_alert_notification_preferences_table.php` — created
+- `database/migrations/2026_07_02_*_create_alert_deliveries_table.php` — created
+- `app/Enums/NotificationChannelKind.php` — created
+- `app/Enums/AlertDeliveryStatus.php` — created
+- `app/Models/AlertNotificationChannel.php` — created
+- `app/Models/AlertNotificationPreference.php` — created
+- `app/Models/AlertDelivery.php` — created
+- `app/Domain/Notifications/Actions/DispatchAlertNotificationAction.php` — created (coordinator)
+- `app/Domain/Notifications/DataTransferObjects/AlertNotificationPayload.php` — created
+- `app/Domain/Notifications/Contracts/NotificationChannelDriver.php` — created
+- `app/Domain/Notifications/Drivers/EmailChannelDriver.php` — created
+- `app/Domain/Notifications/Drivers/SlackChannelDriver.php` — created
+- `app/Domain/Notifications/Drivers/GenericWebhookChannelDriver.php` — created
+- `app/Domain/Notifications/Jobs/DispatchAlertNotificationJob.php` — created
+- `app/Domain/Notifications/Services/AlertNotificationService.php` — created
+- `app/Mail/AlertNotificationMail.php` — created
+- `resources/views/emails/alert-notification.blade.php` — created
+- `app/Domain/Alerts/Actions/TriggerAlertAction.php` — hook into notification dispatch
+- `app/Domain/Alerts/Actions/ResolveAlertAction.php` — hook into resolution dispatch
+- `app/Http/Controllers/Settings/Notifications/ChannelsController.php` — created
+- `app/Http/Controllers/Settings/Notifications/PreferencesController.php` — created
+- `app/Http/Controllers/Settings/Notifications/DeliveriesController.php` — created
+- `resources/js/Pages/Settings/Notifications/{Channels,Rules,Deliveries}.vue` — created
+- `routes/web.php` — new notification settings routes (throttled)
+- `tests/Feature/Notifications/*.php` — 6 feature tests per §Tests block
+- `docs/security/operator-checklist.md` — extend §5 with outbound throttle rows
+- `docs/env.production.example` — commented defaults for rate-limit / dedupe
+
+## Work log
+
+Dated notes as work progresses.
+
+### 2026-07-02
+- Drafted from `_template.md`. Keystone spec for Phase 10 —
+  specs 044/045/047 rely on the delivery layer this ships.
+- Three drivers via §6.5 Strategy pattern; queue-side dispatch
+  keeps the alert trigger path never blocked on external calls.
+- Rate limit + dedupe are in scope from the start (not a
+  follow-up) because a runaway alert storm without them is
+  worse than no notifications at all.
+- Branch `spec/042-alert-notification-service` cut off main.
+- Tracking issue #123.
+- Phase 10 folder + README created in the same commit.
+
+## Open questions / blockers
+
+- **Slack Block Kit vs. plain text.** Block Kit gives a richer
+  card with severity color + button links; plain text is simpler
+  and Discord-compatible. Ship Block Kit for the Slack driver
+  (severity color + "View in Nexus" button); plain text fallback
+  lives inside `text:` for the notification preview.
+- **Email HTML template scope.** Ship a minimal
+  branded HTML template (product name + severity badge + alert
+  title + message + view button). Real email design polish is a
+  separate spec if operators ask.
+- **Test notification payload shape.** The "send test" button
+  synthesizes an `Alert` with `type: 'test.notification'`,
+  `severity: info`, and a fixed message. Doesn't hit the alerts
+  table — pure in-memory model → payload → driver.
+- **`notify_on_resolve` default.** False for `info` +
+  `warning`, true for `critical` — operators generally want to
+  know when a page came back up but don't need a
+  Slack ping every time a webhook backlog cleared. Encoded as a
+  per-severity default at preference creation; user can flip.
+- **`payload` JSON size on `alert_deliveries`.** Keep it bounded
+  (≤ 4 KB per row). Large `alert.metadata` blobs get truncated
+  with a `[truncated]` marker so the deliveries table doesn't
+  bloat.

--- a/specs/phase-10-innovation/042-alert-notification-service.md
+++ b/specs/phase-10-innovation/042-alert-notification-service.md
@@ -1,7 +1,7 @@
 ---
 spec: alert-notification-service
 phase: 10
-status: in-progress   # not-started | in-progress | blocked | done
+status: done   # not-started | in-progress | blocked | done
 owner: Yoany
 created: 2026-07-02
 updated: 2026-07-02
@@ -323,6 +323,25 @@ Dated notes as work progresses.
 - Branch `spec/042-alert-notification-service` cut off main.
 - Tracking issue #123.
 - Phase 10 folder + README created in the same commit.
+- Self-review caught two real bugs pre-push:
+  - **Cross-tenant leak** — `matchingPreferences()` didn't scope
+    by user. Fixed: project-scoped alerts now filter preferences
+    by `project.owner_user_id`; system alerts (no project) still
+    fan out to every configured preference. Added two regression
+    tests (`project_scoped_alert_never_fires_a_stranger_users_preference`,
+    `system_alert_with_no_project_fans_out_to_every_configured_preference`).
+  - **Dead clause in `isDeduped`** — `->where('id', '<',
+    PHP_INT_MAX)` was a no-op that looked load-bearing; the
+    intent (exclude the current alert's own row) required
+    `alert_id != $alert->id`. Fixed.
+- Also fixed pre-push: atomic `attempts` increment via
+  `DB::raw('attempts + 1')` to prevent concurrent retry drift,
+  unique constraint on `(alert_id, channel_id)` to make the
+  `firstOrCreate` invariant enforceable, and added the missing
+  `docs/env.production.example` + `docs/security/operator-checklist.md`
+  updates the spec plan called for.
+- Added `ResolveAlertActionNotificationDispatchTest` (2 cases)
+  pinning the `notify_on_resolve` gating that had no test.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/README.md
+++ b/specs/phase-10-innovation/README.md
@@ -1,0 +1,100 @@
+# Phase 10 — Future Innovation
+
+Source: [roadmap §Phase 10](../../nexus_control_center_roadmap.md#phase-10--future-innovation).
+
+## Phase goal
+Phases 0–9 shipped a complete operator-facing product: auth, projects,
+GitHub integration, webhooks + activity feed, deployments + CI/CD,
+website monitoring, Docker host agent, alerts engine, analytics +
+health scores, and production polish. Phase 10 pushes past
+"complete" into "innovative." The roadmap lists 16 candidate features;
+Phase 10 slices six of them into shippable specs and defers the rest
+to future phases that need their own brainstorming before they can be
+scoped as anything but a wishlist.
+
+Phase 10 closes when notifications reach operators outside the app,
+the command palette works, LLM-powered signal shows up on the
+Overview + PR pages, health-score weights are user-tunable + the
+alert engine gets its second half, and a public status page is
+live.
+
+## Tasks
+
+| # | Task | Status |
+|---|------|--------|
+| 042 | `AlertNotificationService` — email + Slack + generic webhook channels, per-user routing preferences (severity, source, channel), rate-limit + dedupe, delivery observability | ⬜ |
+| 043 | Global command palette — `Cmd+K` fuzzy search across routes + entities (projects, repos, alerts, hosts, websites) via a shared indexer, keyboard-only navigation, recent actions | ⬜ |
+| 044 | AI daily briefing — LLM-generated morning digest ("yesterday: X new issues, Y merged PRs, Z alerts, N things that look off"), delivered via spec 042, per-user opt-in + delivery time | ⬜ |
+| 045 | AI PR risk score + project health explanation — LLM-scored PR risk tag on webhook arrival, natural-language "why" overlay on Phase 8 health-score card | ⬜ |
+| 046 | User-tunable health-score weights + metric-driven alert rules — settings page for Phase 8's formula, §6.8 specification pattern for alert evaluators (queue backlog trend, deploy frequency drop, uptime slope) | ⬜ |
+| 047 | Public status page generator — unauthenticated `/status/{slug}` aggregating monitoring uptime + system alerts + subscribe form; per-project toggle in Settings | ⬜ |
+
+## Acceptance criteria (phase-level)
+- [ ] Operators receive alerts via at least one channel outside the
+      app (email, Slack, generic webhook). Per-user routing decides
+      which severities / sources fire which channel.
+- [ ] `Cmd+K` opens a palette from any page; fuzzy-searches routes +
+      user-scoped entities; keyboard-only navigation works.
+- [ ] A morning digest arrives on schedule (per-user configurable
+      hour + timezone) summarizing yesterday's activity. Delivery
+      rides on spec 042.
+- [ ] Every incoming PR gets an LLM-derived risk tag surfaced on the
+      Work Items queue + PR drawer. Each project health-score card
+      carries a natural-language "why" explanation.
+- [ ] Health-score weights are editable per-user (falls back to
+      defaults). At least two metric-driven `AlertRule` evaluators
+      ship (queue backlog trend + one other).
+- [ ] Public `/status/{slug}` renders monitoring uptime + open
+      system alerts for opted-in projects. Rate-limited, cacheable.
+- [ ] Pint clean, tests green, build clean. CI green for each spec PR.
+
+## Scope notes
+
+### Deferred to Phase 11+ (each is its own multi-spec initiative)
+
+These roadmap items warrant a brainstorming session before they can
+land in a phase README:
+
+- **Custom dashboard builder** — user-configurable widget layout
+  persistence. Needs a layout format + a drag-drop UI + a
+  per-widget config schema. Multi-spec effort.
+- **Widget marketplace** — plugin runtime with sandboxing +
+  installation + versioning. Enormous surface; needs a threat model.
+- **Native mobile app** — separate codebase; requires an API layer
+  the Inertia-first app deliberately doesn't have.
+- **Kubernetes support** — K8s-API-based agent (not the Phase 6
+  Docker-agent shape). Multi-spec: manifest, ingestion, UI.
+- **Cloud provider integrations** — AWS/GCP/Azure resource
+  discovery. Each provider is its own spec; API surfaces don't
+  overlap.
+- **Synthetic browser checks + screenshot monitoring** — headless
+  Chromium infra. Runs somewhere with GPU/memory constraints the
+  Phase 5 HTTP probe doesn't have.
+- **Dedicated incident management** — PagerDuty-lite (on-call
+  rotations, escalation policies, acks). Overlaps with spec 042 but
+  is a distinct product surface.
+- **Team reports** — weekly PDF/HTML digest. Depends on spec 042's
+  delivery channel; adds a heavy template rendering surface.
+
+### LLM dependencies (specs 044 + 045)
+
+Both AI specs require an LLM API key + a config knob. The reference
+provider is Anthropic (matches the surrounding codebase's AI usage);
+implementations should keep the provider swappable via a
+`config('services.llm.*')` block. Each spec ships behind an
+`AI_FEATURES_ENABLED=true` env gate so operators can decide.
+
+### AlertNotificationService is the keystone
+
+Spec 042 unblocks specs 044 (delivers the daily briefing), 045
+(delivers the PR risk score notification), and 047 (delivers the
+public status page subscribe-form notifications). Ship it first.
+
+### What NOT to scope into Phase 10
+
+- **Complete rewrite of Alerts UI.** Phase 7 delivered it; Phase 10
+  extends the delivery layer, not the storage / display.
+- **Multi-tenant migration.** Still deferred; each spec here
+  assumes the current single-tenant / per-user shape.
+- **Real-time delivery to mobile push.** Requires the mobile app,
+  which is Phase 11+.

--- a/specs/phase-10-innovation/README.md
+++ b/specs/phase-10-innovation/README.md
@@ -22,7 +22,7 @@ live.
 
 | # | Task | Status |
 |---|------|--------|
-| 042 | `AlertNotificationService` — email + Slack + generic webhook channels, per-user routing preferences (severity, source, channel), rate-limit + dedupe, delivery observability | ⬜ |
+| 042 | `AlertNotificationService` — email + Slack + generic webhook channels, per-user routing preferences (severity, source, channel), rate-limit + dedupe, delivery observability | 🟢 |
 | 043 | Global command palette — `Cmd+K` fuzzy search across routes + entities (projects, repos, alerts, hosts, websites) via a shared indexer, keyboard-only navigation, recent actions | ⬜ |
 | 044 | AI daily briefing — LLM-generated morning digest ("yesterday: X new issues, Y merged PRs, Z alerts, N things that look off"), delivered via spec 042, per-user opt-in + delivery time | ⬜ |
 | 045 | AI PR risk score + project health explanation — LLM-scored PR risk tag on webhook arrival, natural-language "why" overlay on Phase 8 health-score card | ⬜ |

--- a/tests/Feature/Notifications/AlertNotificationDedupeTest.php
+++ b/tests/Feature/Notifications/AlertNotificationDedupeTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature\Notifications;
+
+use App\Domain\Notifications\Jobs\DispatchAlertNotificationJob;
+use App\Domain\Notifications\Services\AlertNotificationService;
+use App\Enums\AlertDeliveryStatus;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Models\Alert;
+use App\Models\AlertDelivery;
+use App\Models\AlertNotificationChannel;
+use App\Models\AlertNotificationPreference;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+/**
+ * Spec 042 — same-fingerprint alerts within DEDUPE_WINDOW_MINUTES
+ * skip delivery. Fingerprint = `(source, source_id, type)`.
+ */
+class AlertNotificationDedupeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_same_fingerprint_alert_within_window_lands_skipped_with_deduped(): void
+    {
+        Bus::fake();
+
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $channel = AlertNotificationChannel::factory()->slack()->for($user)->create();
+
+        AlertNotificationPreference::factory()
+            ->for($user)
+            ->for($channel, 'channel')
+            ->create(['min_severity' => AlertSeverity::Warning->value]);
+
+        // First alert lights up delivery normally.
+        $firstAlert = Alert::factory()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website->value,
+            'source_id' => 42,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical->value,
+        ]);
+        AlertDelivery::factory()
+            ->for($firstAlert)
+            ->for($channel, 'channel')
+            ->sent()
+            ->create();
+
+        // Second alert with the same fingerprint arrives 30s later.
+        $secondAlert = Alert::factory()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website->value,
+            'source_id' => 42,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical->value,
+        ]);
+
+        app(AlertNotificationService::class)->dispatchFor($secondAlert);
+
+        $skipped = AlertDelivery::query()
+            ->where('alert_id', $secondAlert->id)
+            ->where('channel_id', $channel->id)
+            ->firstOrFail();
+
+        $this->assertSame(AlertDeliveryStatus::Skipped, $skipped->status);
+        $this->assertSame('deduped', $skipped->error_message);
+        Bus::assertNotDispatched(DispatchAlertNotificationJob::class);
+    }
+}

--- a/tests/Feature/Notifications/AlertNotificationRateLimitTest.php
+++ b/tests/Feature/Notifications/AlertNotificationRateLimitTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Notifications;
+
+use App\Domain\Notifications\Jobs\DispatchAlertNotificationJob;
+use App\Enums\AlertDeliveryStatus;
+use App\Models\Alert;
+use App\Models\AlertDelivery;
+use App\Models\AlertNotificationChannel;
+use App\Models\AlertNotificationPreference;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\RateLimiter;
+use Tests\TestCase;
+
+/**
+ * Spec 042 — per-user × per-channel rate limit. Default 30/hour; the
+ * 31st send in the same hour writes a `skipped` delivery with
+ * `error_message = rate_limited`.
+ */
+class AlertNotificationRateLimitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        RateLimiter::clear('notif:*');
+        Http::fake(['*' => Http::response('ok', 200)]);
+    }
+
+    public function test_send_at_the_ceiling_lands_skipped_with_rate_limited(): void
+    {
+        $user = User::factory()->create();
+        $channel = AlertNotificationChannel::factory()
+            ->webhook('https://ops.example.com/hook')
+            ->for($user)
+            ->create();
+
+        // Custom low ceiling makes the test cheap.
+        AlertNotificationPreference::factory()
+            ->for($user)
+            ->for($channel, 'channel')
+            ->create(['rate_limit_per_hour' => 3]);
+
+        // 3 sends succeed.
+        for ($i = 0; $i < 3; $i++) {
+            $alert = Alert::factory()->create();
+            (new DispatchAlertNotificationJob($alert->id, $channel->id))->handle();
+        }
+
+        // 4th send: rate-limited.
+        $blockedAlert = Alert::factory()->create();
+        (new DispatchAlertNotificationJob($blockedAlert->id, $channel->id))->handle();
+
+        $delivery = AlertDelivery::query()
+            ->where('alert_id', $blockedAlert->id)
+            ->where('channel_id', $channel->id)
+            ->firstOrFail();
+
+        $this->assertSame(AlertDeliveryStatus::Skipped, $delivery->status);
+        $this->assertSame('rate_limited', $delivery->error_message);
+    }
+}

--- a/tests/Feature/Notifications/DispatchAlertNotificationJobTest.php
+++ b/tests/Feature/Notifications/DispatchAlertNotificationJobTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Feature\Notifications;
+
+use App\Domain\Notifications\Jobs\DispatchAlertNotificationJob;
+use App\Enums\AlertDeliveryStatus;
+use App\Mail\AlertNotificationMail;
+use App\Models\Alert;
+use App\Models\AlertDelivery;
+use App\Models\AlertNotificationChannel;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Mail;
+use RuntimeException;
+use Tests\TestCase;
+
+class DispatchAlertNotificationJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_email_driver_sends_and_marks_delivery_sent(): void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create();
+        $channel = AlertNotificationChannel::factory()->email('ops@example.com')->for($user)->create();
+        $alert = Alert::factory()->create();
+
+        (new DispatchAlertNotificationJob($alert->id, $channel->id))->handle();
+
+        Mail::assertSent(AlertNotificationMail::class);
+        $this->assertDatabaseHas('alert_deliveries', [
+            'alert_id' => $alert->id,
+            'channel_id' => $channel->id,
+            'status' => AlertDeliveryStatus::Sent->value,
+        ]);
+    }
+
+    public function test_slack_driver_posts_to_webhook_url_and_marks_delivery_sent(): void
+    {
+        Http::fake([
+            'hooks.slack.com/*' => Http::response('ok', 200),
+        ]);
+
+        $user = User::factory()->create();
+        $channel = AlertNotificationChannel::factory()
+            ->slack('https://hooks.slack.com/services/T00/B00/XXX')
+            ->for($user)
+            ->create();
+        $alert = Alert::factory()->create(['severity' => 'critical']);
+
+        (new DispatchAlertNotificationJob($alert->id, $channel->id))->handle();
+
+        Http::assertSent(fn ($req) => str_contains($req->url(), 'hooks.slack.com')
+            && is_array($req['blocks']));
+        $this->assertDatabaseHas('alert_deliveries', [
+            'alert_id' => $alert->id,
+            'channel_id' => $channel->id,
+            'status' => AlertDeliveryStatus::Sent->value,
+        ]);
+    }
+
+    public function test_generic_webhook_driver_posts_json_body(): void
+    {
+        Http::fake([
+            'ops.example.com/*' => Http::response('', 202),
+        ]);
+
+        $user = User::factory()->create();
+        $channel = AlertNotificationChannel::factory()
+            ->webhook('https://ops.example.com/hook')
+            ->for($user)
+            ->create();
+        $alert = Alert::factory()->create();
+
+        (new DispatchAlertNotificationJob($alert->id, $channel->id))->handle();
+
+        Http::assertSent(fn ($req) => str_contains($req->url(), 'ops.example.com')
+            && $req->hasHeader('Content-Type', 'application/json')
+            && ! $req->hasHeader('X-Nexus-Signature'));
+
+        $this->assertDatabaseHas('alert_deliveries', [
+            'alert_id' => $alert->id,
+            'channel_id' => $channel->id,
+            'status' => AlertDeliveryStatus::Sent->value,
+        ]);
+    }
+
+    public function test_5xx_response_raises_exception_and_lands_delivery_pending_with_error(): void
+    {
+        Http::fake([
+            'ops.example.com/*' => Http::response('down for maintenance', 503),
+        ]);
+
+        $user = User::factory()->create();
+        $channel = AlertNotificationChannel::factory()
+            ->webhook('https://ops.example.com/hook')
+            ->for($user)
+            ->create();
+        $alert = Alert::factory()->create();
+
+        try {
+            (new DispatchAlertNotificationJob($alert->id, $channel->id))->handle();
+            $this->fail('Expected RuntimeException.');
+        } catch (RuntimeException $e) {
+            $this->assertStringContainsString('503', $e->getMessage());
+        }
+
+        $delivery = AlertDelivery::query()
+            ->where('alert_id', $alert->id)
+            ->where('channel_id', $channel->id)
+            ->firstOrFail();
+
+        $this->assertSame(AlertDeliveryStatus::Pending, $delivery->status);
+        $this->assertSame(1, $delivery->attempts);
+        $this->assertStringContainsString('503', $delivery->error_message);
+    }
+
+    public function test_failed_hook_lands_delivery_status_failed(): void
+    {
+        $user = User::factory()->create();
+        $channel = AlertNotificationChannel::factory()->email()->for($user)->create();
+        $alert = Alert::factory()->create();
+
+        AlertDelivery::factory()
+            ->for($alert)
+            ->for($channel, 'channel')
+            ->create(['status' => AlertDeliveryStatus::Pending->value, 'attempts' => 3]);
+
+        (new DispatchAlertNotificationJob($alert->id, $channel->id))
+            ->failed(new RuntimeException('SMTP timeout after 3 attempts'));
+
+        $this->assertDatabaseHas('alert_deliveries', [
+            'alert_id' => $alert->id,
+            'channel_id' => $channel->id,
+            'status' => AlertDeliveryStatus::Failed->value,
+            'error_message' => 'SMTP timeout after 3 attempts',
+        ]);
+    }
+}

--- a/tests/Feature/Notifications/ResolveAlertActionNotificationDispatchTest.php
+++ b/tests/Feature/Notifications/ResolveAlertActionNotificationDispatchTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\Notifications;
+
+use App\Domain\Alerts\Actions\ResolveAlertAction;
+use App\Domain\Notifications\Jobs\DispatchAlertNotificationJob;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
+use App\Models\Alert;
+use App\Models\AlertNotificationChannel;
+use App\Models\AlertNotificationPreference;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+/**
+ * Spec 042 — resolution notifications are opt-in per preference row
+ * (`notify_on_resolve`). A resolve-flow must only dispatch to
+ * preferences whose row has the flag set to true.
+ */
+class ResolveAlertActionNotificationDispatchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_resolve_dispatches_only_to_preferences_with_notify_on_resolve_true(): void
+    {
+        Bus::fake();
+
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        // Two channels + two preferences: one opts in for resolve
+        // notifications, one doesn't. Only the opt-in should fire.
+        $slack = AlertNotificationChannel::factory()->slack()->for($user)->create();
+        $webhook = AlertNotificationChannel::factory()->webhook()->for($user)->create();
+
+        AlertNotificationPreference::factory()
+            ->for($user)
+            ->for($slack, 'channel')
+            ->create([
+                'min_severity' => AlertSeverity::Warning->value,
+                'notify_on_resolve' => true,
+            ]);
+
+        AlertNotificationPreference::factory()
+            ->for($user)
+            ->for($webhook, 'channel')
+            ->create([
+                'min_severity' => AlertSeverity::Warning->value,
+                'notify_on_resolve' => false,
+            ]);
+
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website->value,
+            'source_id' => 7,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+
+        app(ResolveAlertAction::class)->execute([
+            'source' => AlertSource::Website,
+            'source_id' => 7,
+            'type' => 'website.down',
+        ]);
+
+        Bus::assertDispatchedTimes(DispatchAlertNotificationJob::class, 1);
+        Bus::assertDispatched(
+            DispatchAlertNotificationJob::class,
+            fn (DispatchAlertNotificationJob $job): bool => $job->channelId === $slack->id
+                && $job->event === 'alert.resolved',
+        );
+    }
+
+    public function test_resolve_dispatches_nothing_when_no_preference_opts_in(): void
+    {
+        Bus::fake();
+
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $slack = AlertNotificationChannel::factory()->slack()->for($user)->create();
+
+        AlertNotificationPreference::factory()
+            ->for($user)
+            ->for($slack, 'channel')
+            ->create([
+                'min_severity' => AlertSeverity::Warning->value,
+                'notify_on_resolve' => false,
+            ]);
+
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Docker->value,
+            'source_id' => 9,
+            'type' => 'host.offline',
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+
+        app(ResolveAlertAction::class)->execute([
+            'source' => AlertSource::Docker,
+            'source_id' => 9,
+            'type' => 'host.offline',
+        ]);
+
+        Bus::assertNotDispatched(DispatchAlertNotificationJob::class);
+    }
+}

--- a/tests/Feature/Notifications/SendChannelTestNotificationTest.php
+++ b/tests/Feature/Notifications/SendChannelTestNotificationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature\Notifications;
+
+use App\Models\AlertNotificationChannel;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * Spec 042 — the "Send test" button synthesizes a test payload +
+ * pushes through the driver. On 2xx, `verified_at` gets stamped.
+ */
+class SendChannelTestNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_send_test_flips_verified_at_on_success(): void
+    {
+        Http::fake([
+            'hooks.slack.com/*' => Http::response('ok', 200),
+        ]);
+
+        $user = User::factory()->create();
+        $channel = AlertNotificationChannel::factory()
+            ->slack('https://hooks.slack.com/services/T00/B00/XXX')
+            ->unverified()
+            ->for($user)
+            ->create();
+
+        $this->assertNull($channel->verified_at);
+
+        $this->actingAs($user)
+            ->post(route('settings.notifications.channels.test', ['channel' => $channel->id]))
+            ->assertRedirect();
+
+        $this->assertNotNull($channel->fresh()->verified_at);
+    }
+
+    public function test_send_test_leaves_verified_at_null_on_failure(): void
+    {
+        Http::fake([
+            'hooks.slack.com/*' => Http::response('bad token', 401),
+        ]);
+
+        $user = User::factory()->create();
+        $channel = AlertNotificationChannel::factory()
+            ->slack('https://hooks.slack.com/services/T00/B00/XXX')
+            ->unverified()
+            ->for($user)
+            ->create();
+
+        $this->actingAs($user)
+            ->post(route('settings.notifications.channels.test', ['channel' => $channel->id]))
+            ->assertRedirect();
+
+        $this->assertNull($channel->fresh()->verified_at);
+    }
+
+    public function test_send_test_rejects_other_users_channel(): void
+    {
+        $ownerUser = User::factory()->create();
+        $strangerUser = User::factory()->create();
+        $channel = AlertNotificationChannel::factory()->email()->for($ownerUser)->create();
+
+        $this->actingAs($strangerUser)
+            ->post(route('settings.notifications.channels.test', ['channel' => $channel->id]))
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Notifications/TriggerAlertActionNotificationDispatchTest.php
+++ b/tests/Feature/Notifications/TriggerAlertActionNotificationDispatchTest.php
@@ -110,4 +110,62 @@ class TriggerAlertActionNotificationDispatchTest extends TestCase
 
         Bus::assertNotDispatched(DispatchAlertNotificationJob::class);
     }
+
+    public function test_project_scoped_alert_never_fires_a_stranger_users_preference(): void
+    {
+        Bus::fake();
+
+        $owner = User::factory()->create();
+        $stranger = User::factory()->create();
+        $ownerProject = Project::factory()->create(['owner_user_id' => $owner->id]);
+
+        // Stranger has a preference matching the alert's severity + source.
+        // It must NOT be dispatched — the alert belongs to $owner's project.
+        $strangerSlack = AlertNotificationChannel::factory()->slack()->for($stranger)->create();
+        AlertNotificationPreference::factory()
+            ->for($stranger)
+            ->for($strangerSlack, 'channel')
+            ->create(['min_severity' => AlertSeverity::Info->value]);
+
+        // Owner has NO preferences → no dispatches, but we're not
+        // testing that here. We're testing that the stranger's
+        // preferences are excluded from cross-tenant fan-out.
+
+        app(TriggerAlertAction::class)->execute([
+            'project_id' => $ownerProject->id,
+            'source' => AlertSource::Website,
+            'source_id' => 1,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical,
+            'title' => 'Owner site down',
+        ]);
+
+        Bus::assertNotDispatched(DispatchAlertNotificationJob::class);
+    }
+
+    public function test_system_alert_with_no_project_fans_out_to_every_configured_preference(): void
+    {
+        Bus::fake();
+
+        // Spec 038 — AlertSource::System alerts have no project. They
+        // still need to notify the operator; the service falls back to
+        // matching every enabled preference in that case.
+        $operator = User::factory()->create();
+        $slack = AlertNotificationChannel::factory()->slack()->for($operator)->create();
+        AlertNotificationPreference::factory()
+            ->for($operator)
+            ->for($slack, 'channel')
+            ->create(['min_severity' => AlertSeverity::Warning->value]);
+
+        app(TriggerAlertAction::class)->execute([
+            'project_id' => null,
+            'source' => AlertSource::System,
+            'source_id' => null,
+            'type' => 'queue.backlog',
+            'severity' => AlertSeverity::Critical,
+            'title' => 'Queue backlog exceeded threshold',
+        ]);
+
+        Bus::assertDispatchedTimes(DispatchAlertNotificationJob::class, 1);
+    }
 }

--- a/tests/Feature/Notifications/TriggerAlertActionNotificationDispatchTest.php
+++ b/tests/Feature/Notifications/TriggerAlertActionNotificationDispatchTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature\Notifications;
+
+use App\Domain\Alerts\Actions\TriggerAlertAction;
+use App\Domain\Notifications\Jobs\DispatchAlertNotificationJob;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Models\AlertNotificationChannel;
+use App\Models\AlertNotificationPreference;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+/**
+ * Spec 042 — triggering an alert fans out via
+ * `AlertNotificationService::dispatchFor` and enqueues one
+ * `DispatchAlertNotificationJob` per matching preference. Preferences
+ * whose `min_severity` filters the alert out (or whose `sources` list
+ * doesn't include it) are silently skipped.
+ */
+class TriggerAlertActionNotificationDispatchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_triggering_an_alert_enqueues_one_job_per_matching_preference(): void
+    {
+        Bus::fake();
+
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        $slack = AlertNotificationChannel::factory()->slack()->for($user)->create();
+        $webhook = AlertNotificationChannel::factory()->webhook()->for($user)->create();
+
+        AlertNotificationPreference::factory()
+            ->for($user)
+            ->for($slack, 'channel')
+            ->create(['min_severity' => AlertSeverity::Warning->value]);
+
+        AlertNotificationPreference::factory()
+            ->for($user)
+            ->for($webhook, 'channel')
+            ->create(['min_severity' => AlertSeverity::Warning->value]);
+
+        app(TriggerAlertAction::class)->execute([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website,
+            'source_id' => 1,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical,
+            'title' => 'Site down',
+        ]);
+
+        Bus::assertDispatchedTimes(DispatchAlertNotificationJob::class, 2);
+    }
+
+    public function test_preference_severity_filter_skips_below_threshold(): void
+    {
+        Bus::fake();
+
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $slack = AlertNotificationChannel::factory()->slack()->for($user)->create();
+
+        AlertNotificationPreference::factory()
+            ->for($user)
+            ->for($slack, 'channel')
+            ->create(['min_severity' => AlertSeverity::Critical->value]);
+
+        app(TriggerAlertAction::class)->execute([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website,
+            'source_id' => 1,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Warning,
+            'title' => 'Slow site',
+        ]);
+
+        Bus::assertNotDispatched(DispatchAlertNotificationJob::class);
+    }
+
+    public function test_preference_source_filter_narrows_dispatch(): void
+    {
+        Bus::fake();
+
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $slack = AlertNotificationChannel::factory()->slack()->for($user)->create();
+
+        AlertNotificationPreference::factory()
+            ->for($user)
+            ->for($slack, 'channel')
+            ->create([
+                'min_severity' => AlertSeverity::Warning->value,
+                'sources' => [AlertSource::Docker->value],
+            ]);
+
+        // Website alert → source filter excludes it.
+        app(TriggerAlertAction::class)->execute([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website,
+            'source_id' => 1,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical,
+            'title' => 'Site down',
+        ]);
+
+        Bus::assertNotDispatched(DispatchAlertNotificationJob::class);
+    }
+}

--- a/tests/Feature/Notifications/WebhookSignatureOutboundTest.php
+++ b/tests/Feature/Notifications/WebhookSignatureOutboundTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Notifications;
+
+use App\Domain\Notifications\Jobs\DispatchAlertNotificationJob;
+use App\Models\Alert;
+use App\Models\AlertNotificationChannel;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * Spec 042 — outbound webhook signing. When the channel's config
+ * carries a `signing_secret`, the driver attaches an
+ * `X-Nexus-Signature: sha256=<hmac>` header computed against the
+ * raw JSON body. This mirrors the inbound GitHub webhook signature
+ * shape so operators can reuse familiar tooling on the receiving end.
+ */
+class WebhookSignatureOutboundTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_outbound_webhook_carries_hmac_sha256_signature_when_secret_is_set(): void
+    {
+        $secret = 'super-secret';
+        Http::fake([
+            'ops.example.com/*' => Http::response('', 202),
+        ]);
+
+        $user = User::factory()->create();
+        $channel = AlertNotificationChannel::factory()
+            ->webhook('https://ops.example.com/hook', $secret)
+            ->for($user)
+            ->create();
+        $alert = Alert::factory()->create();
+
+        (new DispatchAlertNotificationJob($alert->id, $channel->id))->handle();
+
+        Http::assertSent(function ($request) use ($secret): bool {
+            $signatureHeader = $request->header('X-Nexus-Signature')[0] ?? null;
+
+            if ($signatureHeader === null) {
+                return false;
+            }
+
+            if (! str_starts_with($signatureHeader, 'sha256=')) {
+                return false;
+            }
+
+            $expected = 'sha256='.hash_hmac('sha256', $request->body(), $secret);
+
+            return hash_equals($expected, $signatureHeader);
+        });
+    }
+
+    public function test_outbound_webhook_carries_no_signature_when_no_secret(): void
+    {
+        Http::fake([
+            'ops.example.com/*' => Http::response('', 202),
+        ]);
+
+        $user = User::factory()->create();
+        $channel = AlertNotificationChannel::factory()
+            ->webhook('https://ops.example.com/hook')
+            ->for($user)
+            ->create();
+        $alert = Alert::factory()->create();
+
+        (new DispatchAlertNotificationJob($alert->id, $channel->id))->handle();
+
+        Http::assertSent(fn ($req) => ! $req->hasHeader('X-Nexus-Signature'));
+    }
+}


### PR DESCRIPTION
Closes #123

Spec: \`specs/phase-10-innovation/042-alert-notification-service.md\`

## Summary
- Ships \`AlertNotificationService\` — the deferred-from-Phase-7 delivery layer that fans triggered alerts out to email / Slack / generic webhook channels via §6.5 Strategy pattern. Three drivers, one contract, three tables (\`alert_notification_channels\` / \`alert_notification_preferences\` / \`alert_deliveries\`), per-user routing preferences (severity + source + rate limit + \`notify_on_resolve\`), 5-minute same-fingerprint dedupe, per-user × per-channel rate limit (30/hour default).
- Wired into \`TriggerAlertAction::execute\` + \`ResolveAlertAction::closeIfStillActionable\` as fire-and-forget — the alert lifecycle never fails because notification dispatch failed. Failed deliveries land in \`alert_deliveries\` with the failure reason + a retry button in the UI.
- Settings UI at \`/settings/notifications\` with 3 tabs (Channels + Rules + Deliveries). Every mutation is per-user scoped; channel configs (Slack URLs + webhook signing secrets) are encrypted at rest via \`encrypted:array\` + \`\$hidden\` and never leak through Inertia props.
- Outbound webhooks sign with \`X-Nexus-Signature: sha256=<hmac>\` when the channel carries a \`signing_secret\` — mirrors the inbound GitHub webhook shape.
- Downstream Phase 10 specs 044 (AI daily briefing), 045 (AI PR risk score), and 047 (public status page) all depend on this delivery layer.

## Test plan
- [x] Three migrations shipped + unique constraint on \`(alert_id, channel_id)\`.
- [x] \`NotificationChannelDriver\` contract + 3 implementations (email/slack/webhook).
- [x] Trigger + Resolve actions dispatch fire-and-forget; failures logged, never propagated.
- [x] \`/settings/notifications\` Channels + Rules + Deliveries tabs; "Send test" flips \`verified_at\` on 2xx, leaves null on failure.
- [x] Rate limit enforced (default 30/user/hour × channel; per-preference override).
- [x] Dedupe suppresses same-fingerprint alerts within a 5-minute window.
- [x] Failed deliveries land \`status=failed\` after 3 retries; retry endpoint 30/min throttled.
- [x] Outbound HMAC \`X-Nexus-Signature\` when \`signing_secret\` is set.
- [x] All routes rate-limited per §5 of the operator checklist.
- [x] Pint clean. \`php artisan test\` 805/805 green. \`npm run build\` clean.

## Self-review notes
Ran \`superpowers:code-reviewer\` over the full diff. Findings and their disposition:

**Blockers (fixed pre-push):**
- **Cross-tenant notification leak.** \`AlertNotificationService::matchingPreferences\` initially had no user scoping — every user's preferences matched every alert. A UserB website outage would ring UserA's Slack. Fixed: project-scoped alerts (spec 030 emitters for website/docker/deployment/github) now filter preferences by \`alert.project.owner_user_id\`; \`AlertSource::System\` alerts (spec 038 self-checks, no project) still fan out to every configured preference. Added \`project_scoped_alert_never_fires_a_stranger_users_preference\` + \`system_alert_with_no_project_fans_out_to_every_configured_preference\` regression tests.
- **Missing doc updates.** Spec plan called for extending \`docs/env.production.example\` with the rate-limit / dedupe knobs and \`docs/security/operator-checklist.md\` §5 with the outbound throttle rows. Both landed in the fix commit.

**Should-fixes (all fixed):**
- **Dead clause in \`isDeduped\`.** \`->where('id', '<', PHP_INT_MAX)\` was a no-op that looked load-bearing. The intent (exclude the current alert's own delivery row from the lookup) requires \`->where('alert_id', '!=', \$alert->id)\`. Corrected.
- **Missing \`notify_on_resolve\` test.** The whole \`ResolveAlertAction → dispatchResolutionFor\` branch had no test. Added \`ResolveAlertActionNotificationDispatchTest\` with 2 cases pinning the opt-in gating.
- **\`attempts\` counter drift under concurrent retries.** Moved from \`firstOrNew\` + \`\$delivery->attempts + 1\` to \`firstOrCreate\` + \`DB::raw('attempts + 1')\`, so parallel worker + user-triggered retries can't overwrite each other.
- **Missing unique constraint on \`(alert_id, channel_id)\`.** Migration now enforces the invariant \`firstOrCreate\` assumes.

**Nits (surfaced for visibility):**
- Slack \`configPreview\` shows \`webhook_host\` (usually \`hooks.slack.com\`) — reveals nothing useful. Left alone; harmless.
- Driver exception messages get stored raw into \`alert_deliveries.error_message\` — cURL errors can leak the target hostname. Fine for the operator's own rows.
- Email template correctly uses Blade \`{{ }}\` throughout — no \`{!! !!}\` slipped in.
- Outbound HMAC shape uses \`hash_hmac('sha256', ...)\` on the sender side; the receiver test verifies via \`hash_equals\` — correct timing-safe posture.

**Test coverage:** 19 tests (originally 15 in the spec §Tests block, plus 4 added post-review for cross-tenant + notify_on_resolve regressions).

## Bookkeeping
Spec + tracker flips ride inside this PR:
- Spec 042 frontmatter → \`status: done\`.
- \`specs/phase-10-innovation/README.md\` task 042 → 🟢.
- \`specs/README.md\` Phase 10 row → 🟡 1/6 specs done.

Phase 10 remaining: 043 (command palette), 044 (AI daily briefing), 045 (AI PR risk + health explanation), 046 (health-score weights + metric-driven alert rules), 047 (public status page).