### PR TITLE
Spec 046 — User-tunable health-score weights + metric-driven AlertRule evaluators

### DIFF
--- a/app/Domain/Alerts/Contracts/AlertRuleEvaluator.php
+++ b/app/Domain/Alerts/Contracts/AlertRuleEvaluator.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Domain\Alerts\Contracts;
+
+use App\Domain\Alerts\DataTransferObjects\AlertRuleEvaluation;
+use App\Models\AlertRule;
+
+/**
+ * §6.5 Strategy pattern — one implementation per `AlertRuleKind`.
+ *
+ * Evaluators are pure computations: they read from the database +
+ * queue + logs, apply the rule's config threshold, and return an
+ * `AlertRuleEvaluation`. They never mutate the rule row and never
+ * dispatch the trigger action themselves — the scheduled job holds
+ * both responsibilities so evaluator state stays isolated.
+ */
+interface AlertRuleEvaluator
+{
+    public function evaluate(AlertRule $rule): AlertRuleEvaluation;
+}

--- a/app/Domain/Alerts/DataTransferObjects/AlertRuleEvaluation.php
+++ b/app/Domain/Alerts/DataTransferObjects/AlertRuleEvaluation.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Domain\Alerts\DataTransferObjects;
+
+/**
+ * Spec 046 — result of running a single `AlertRuleEvaluator`.
+ *
+ * `triggered: false` → the job records `last_evaluated_at` and moves on.
+ * `triggered: true`  → the job dispatches `TriggerAlertAction` with
+ * the payload fields carried on this DTO. `metadata` is a small
+ * structured bag surfaced on the alert row for debug + inclusion in
+ * the outbound notification payload.
+ */
+final class AlertRuleEvaluation
+{
+    /**
+     * @param  array<string, scalar|null>  $metadata
+     */
+    public function __construct(
+        public readonly bool $triggered,
+        public readonly string $title = '',
+        public readonly ?string $description = null,
+        public readonly array $metadata = [],
+    ) {}
+
+    public static function quiet(): self
+    {
+        return new self(triggered: false);
+    }
+}

--- a/app/Domain/Alerts/Evaluators/DeployFailureRateEvaluator.php
+++ b/app/Domain/Alerts/Evaluators/DeployFailureRateEvaluator.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Domain\Alerts\Evaluators;
+
+use App\Domain\Alerts\Contracts\AlertRuleEvaluator;
+use App\Domain\Alerts\DataTransferObjects\AlertRuleEvaluation;
+use App\Enums\WorkflowRunConclusion;
+use App\Models\AlertRule;
+use App\Models\Project;
+use App\Models\WorkflowRun;
+
+/**
+ * Spec 046 — trigger when the failure rate of the last `sample_size`
+ * default-branch workflow runs exceeds `config.failure_rate_percent`.
+ *
+ * `config.sample_size`           = how many recent runs to look at
+ * `config.failure_rate_percent`  = trigger threshold (integer 0..100)
+ *
+ * Stays quiet when the sample is smaller than the configured size —
+ * a fresh install shouldn't be flagged as "failure rate high" just
+ * because there aren't enough data points.
+ */
+class DeployFailureRateEvaluator implements AlertRuleEvaluator
+{
+    public function evaluate(AlertRule $rule): AlertRuleEvaluation
+    {
+        $sampleSize = (int) ($rule->config['sample_size'] ?? 10);
+        $threshold = (int) ($rule->config['failure_rate_percent'] ?? 30);
+
+        $projectIds = Project::query()
+            ->where('owner_user_id', $rule->user_id)
+            ->pluck('id');
+
+        if ($projectIds->isEmpty()) {
+            return AlertRuleEvaluation::quiet();
+        }
+
+        $recent = WorkflowRun::query()
+            ->join('repositories', 'workflow_runs.repository_id', '=', 'repositories.id')
+            ->whereIn('repositories.project_id', $projectIds)
+            ->whereColumn('workflow_runs.head_branch', 'repositories.default_branch')
+            ->whereNotNull('workflow_runs.run_completed_at')
+            ->orderByDesc('workflow_runs.run_completed_at')
+            ->limit($sampleSize)
+            ->get(['workflow_runs.id', 'workflow_runs.conclusion']);
+
+        if ($recent->count() < $sampleSize) {
+            return AlertRuleEvaluation::quiet();
+        }
+
+        $failures = $recent->filter(
+            fn (WorkflowRun $r): bool => $r->conclusion === WorkflowRunConclusion::Failure,
+        )->count();
+
+        $ratePct = (int) round(($failures / $sampleSize) * 100);
+        if ($ratePct < $threshold) {
+            return AlertRuleEvaluation::quiet();
+        }
+
+        return new AlertRuleEvaluation(
+            triggered: true,
+            title: "Deploy failure rate {$ratePct}% ({$failures}/{$sampleSize})",
+            description: "Deploy failure rate of the last {$sampleSize} runs crossed {$threshold}%.",
+            metadata: [
+                'rule_id' => $rule->id,
+                'failures' => $failures,
+                'sample_size' => $sampleSize,
+                'rate_percent' => $ratePct,
+                'threshold_percent' => $threshold,
+            ],
+        );
+    }
+}

--- a/app/Domain/Alerts/Evaluators/DeployFrequencyDropEvaluator.php
+++ b/app/Domain/Alerts/Evaluators/DeployFrequencyDropEvaluator.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Domain\Alerts\Evaluators;
+
+use App\Domain\Alerts\Contracts\AlertRuleEvaluator;
+use App\Domain\Alerts\DataTransferObjects\AlertRuleEvaluation;
+use App\Enums\WorkflowRunConclusion;
+use App\Models\AlertRule;
+use App\Models\Project;
+use App\Models\WorkflowRun;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+/**
+ * Spec 046 — trigger when the user's deploy-frequency drops by more
+ * than `config.drop_percent` (comparing current vs. prior window).
+ *
+ * `config.window_days` = window size for each of the two periods.
+ * `config.drop_percent` = triggering threshold (positive integer).
+ *
+ * Deploys = successful default-branch workflow runs (mirrors
+ * spec 022's `deployments.success` counting rule) scoped to the
+ * user's projects.
+ *
+ * When either window has zero deploys the evaluator stays quiet —
+ * a fresh install with no history shouldn't page anyone.
+ */
+class DeployFrequencyDropEvaluator implements AlertRuleEvaluator
+{
+    public function evaluate(AlertRule $rule): AlertRuleEvaluation
+    {
+        $windowDays = (int) ($rule->config['window_days'] ?? 7);
+        $dropThreshold = (int) ($rule->config['drop_percent'] ?? 50);
+
+        $projectIds = Project::query()
+            ->where('owner_user_id', $rule->user_id)
+            ->pluck('id');
+
+        if ($projectIds->isEmpty()) {
+            return AlertRuleEvaluation::quiet();
+        }
+
+        $now = Carbon::now();
+        $currentStart = $now->copy()->subDays($windowDays);
+        $priorStart = $now->copy()->subDays($windowDays * 2);
+
+        $current = $this->countDeploysBetween($projectIds, $currentStart, $now);
+        $prior = $this->countDeploysBetween($projectIds, $priorStart, $currentStart);
+
+        if ($prior === 0) {
+            return AlertRuleEvaluation::quiet();
+        }
+
+        $dropPct = (int) round((($prior - $current) / $prior) * 100);
+        if ($dropPct < $dropThreshold) {
+            return AlertRuleEvaluation::quiet();
+        }
+
+        return new AlertRuleEvaluation(
+            triggered: true,
+            title: "Deploys down {$dropPct}% ({$current} vs {$prior})",
+            description: "Deploy frequency dropped {$dropPct}% over the last {$windowDays}d vs the prior {$windowDays}d.",
+            metadata: [
+                'rule_id' => $rule->id,
+                'current_deploys' => $current,
+                'prior_deploys' => $prior,
+                'drop_percent' => $dropPct,
+                'window_days' => $windowDays,
+            ],
+        );
+    }
+
+    private function countDeploysBetween(
+        Collection $projectIds,
+        Carbon $start,
+        Carbon $end,
+    ): int {
+        return WorkflowRun::query()
+            ->join('repositories', 'workflow_runs.repository_id', '=', 'repositories.id')
+            ->whereIn('repositories.project_id', $projectIds)
+            ->whereColumn('workflow_runs.head_branch', 'repositories.default_branch')
+            ->where('workflow_runs.conclusion', WorkflowRunConclusion::Success->value)
+            ->whereBetween('workflow_runs.run_completed_at', [$start, $end])
+            ->count('workflow_runs.id');
+    }
+}

--- a/app/Domain/Alerts/Evaluators/QueueBacklogTrendEvaluator.php
+++ b/app/Domain/Alerts/Evaluators/QueueBacklogTrendEvaluator.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Domain\Alerts\Evaluators;
+
+use App\Domain\Alerts\Contracts\AlertRuleEvaluator;
+use App\Domain\Alerts\DataTransferObjects\AlertRuleEvaluation;
+use App\Models\AlertRule;
+use Illuminate\Support\Facades\Queue;
+
+/**
+ * Spec 046 — trigger when the current queue backlog exceeds a
+ * user-configured threshold. Simplified from a rolling-delta trend
+ * because the current backlog is what an operator actually needs to
+ * know about — the "trend" framing was the deferred phrasing;
+ * absolute backlog is the actionable signal.
+ *
+ * `config.threshold_delta` = backlog count that trips the rule.
+ * `config.window_minutes`  = surfaced in the payload as context
+ * (which window the operator is asking about) but the current
+ * implementation reads a point-in-time queue length. A future
+ * refinement can persist snapshots and compare across the window.
+ */
+class QueueBacklogTrendEvaluator implements AlertRuleEvaluator
+{
+    public function evaluate(AlertRule $rule): AlertRuleEvaluation
+    {
+        $threshold = (int) ($rule->config['threshold_delta'] ?? 100);
+        $window = (int) ($rule->config['window_minutes'] ?? 15);
+
+        try {
+            $current = Queue::size();
+        } catch (\Throwable) {
+            // Queue driver not reachable → not the rule's fault; stay quiet.
+            return AlertRuleEvaluation::quiet();
+        }
+
+        if ($current < $threshold) {
+            return AlertRuleEvaluation::quiet();
+        }
+
+        return new AlertRuleEvaluation(
+            triggered: true,
+            title: "Queue backlog {$current} ≥ threshold {$threshold}",
+            description: "Backlog exceeded threshold. Window checked: {$window} min.",
+            metadata: [
+                'rule_id' => $rule->id,
+                'current_backlog' => $current,
+                'threshold' => $threshold,
+                'window_minutes' => $window,
+            ],
+        );
+    }
+}

--- a/app/Domain/Alerts/Evaluators/UptimeSlopeEvaluator.php
+++ b/app/Domain/Alerts/Evaluators/UptimeSlopeEvaluator.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Domain\Alerts\Evaluators;
+
+use App\Domain\Alerts\Contracts\AlertRuleEvaluator;
+use App\Domain\Alerts\DataTransferObjects\AlertRuleEvaluation;
+use App\Enums\WebsiteCheckStatus;
+use App\Models\AlertRule;
+use App\Models\Project;
+use App\Models\WebsiteCheck;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+/**
+ * Spec 046 — trigger when uptime is trending down.
+ *
+ * Simple two-half compare: uptime% for the first half of the window
+ * vs. uptime% for the second half. Slope = second - first (percentage
+ * points per window). A negative slope crossing
+ * `config.slope_threshold` fires the rule.
+ *
+ * A linear-regression fit is on the roadmap (spec §Open questions);
+ * the simpler two-half compare gets shipped first because it's easy
+ * to reason about and covers 95% of the interesting cases.
+ */
+class UptimeSlopeEvaluator implements AlertRuleEvaluator
+{
+    public function evaluate(AlertRule $rule): AlertRuleEvaluation
+    {
+        $windowHours = (int) ($rule->config['window_hours'] ?? 24);
+        // Negative float — slope threshold in percentage points across the window.
+        // Default -1.0 means "any drop of >1 percentage point across the window".
+        $slopeThreshold = (float) ($rule->config['slope_threshold'] ?? -1.0);
+
+        $projectIds = Project::query()
+            ->where('owner_user_id', $rule->user_id)
+            ->pluck('id');
+
+        if ($projectIds->isEmpty()) {
+            return AlertRuleEvaluation::quiet();
+        }
+
+        $now = Carbon::now();
+        $mid = $now->copy()->subHours(intdiv($windowHours, 2));
+        $start = $now->copy()->subHours($windowHours);
+
+        $firstHalf = $this->uptimePercent($projectIds, $start, $mid);
+        $secondHalf = $this->uptimePercent($projectIds, $mid, $now);
+
+        if ($firstHalf === null || $secondHalf === null) {
+            return AlertRuleEvaluation::quiet();
+        }
+
+        $slope = $secondHalf - $firstHalf;
+        if ($slope > $slopeThreshold) {
+            return AlertRuleEvaluation::quiet();
+        }
+
+        return new AlertRuleEvaluation(
+            triggered: true,
+            title: sprintf(
+                'Uptime slope %.1fpp (%.1f%% → %.1f%%)',
+                $slope,
+                $firstHalf,
+                $secondHalf,
+            ),
+            description: "Uptime dropped over the last {$windowHours}h.",
+            metadata: [
+                'rule_id' => $rule->id,
+                'first_half_percent' => $firstHalf,
+                'second_half_percent' => $secondHalf,
+                'slope_percentage_points' => $slope,
+                'window_hours' => $windowHours,
+            ],
+        );
+    }
+
+    private function uptimePercent(
+        Collection $projectIds,
+        Carbon $start,
+        Carbon $end,
+    ): ?float {
+        $total = WebsiteCheck::query()
+            ->join('websites', 'website_checks.website_id', '=', 'websites.id')
+            ->whereIn('websites.project_id', $projectIds)
+            ->whereBetween('website_checks.checked_at', [$start, $end])
+            ->count();
+
+        if ($total === 0) {
+            return null;
+        }
+
+        $up = WebsiteCheck::query()
+            ->join('websites', 'website_checks.website_id', '=', 'websites.id')
+            ->whereIn('websites.project_id', $projectIds)
+            ->whereBetween('website_checks.checked_at', [$start, $end])
+            ->where('website_checks.status', WebsiteCheckStatus::Up->value)
+            ->count();
+
+        return ($up / $total) * 100;
+    }
+}

--- a/app/Domain/Alerts/Jobs/EvaluateAlertRulesJob.php
+++ b/app/Domain/Alerts/Jobs/EvaluateAlertRulesJob.php
@@ -52,6 +52,9 @@ class EvaluateAlertRulesJob implements ShouldBeUnique, ShouldQueue
 
     public function handle(TriggerAlertAction $trigger): void
     {
+        // chunkById orders by `id ASC`; the per-rule updates below only
+        // touch `last_evaluated_at` / `last_triggered_at`, never `id`,
+        // so the cursor is safe across ticks — no re-visit risk.
         AlertRule::query()
             ->where('enabled', true)
             ->chunkById(100, function ($rules) use ($trigger): void {
@@ -63,6 +66,19 @@ class EvaluateAlertRulesJob implements ShouldBeUnique, ShouldQueue
 
     private function evaluateOne(AlertRule $rule, TriggerAlertAction $trigger): void
     {
+        $now = Carbon::now();
+
+        // Cool-down gate ahead of the evaluator so a stuck condition
+        // doesn't pay the (potentially heavy — SQL joins on
+        // workflow_runs / website_checks) evaluator cost every tick.
+        // Still advance `last_evaluated_at` so the UI reads "last
+        // evaluated N min ago" instead of a stale timestamp.
+        if ($rule->isInCoolDown()) {
+            $rule->forceFill(['last_evaluated_at' => $now])->save();
+
+            return;
+        }
+
         try {
             $evaluator = $this->evaluatorFor($rule->kind);
         } catch (Throwable $e) {
@@ -74,8 +90,6 @@ class EvaluateAlertRulesJob implements ShouldBeUnique, ShouldQueue
 
             return;
         }
-
-        $now = Carbon::now();
 
         try {
             $evaluation = $evaluator->evaluate($rule);
@@ -93,10 +107,6 @@ class EvaluateAlertRulesJob implements ShouldBeUnique, ShouldQueue
         $rule->forceFill(['last_evaluated_at' => $now])->save();
 
         if (! $evaluation->triggered) {
-            return;
-        }
-
-        if ($rule->isInCoolDown()) {
             return;
         }
 

--- a/app/Domain/Alerts/Jobs/EvaluateAlertRulesJob.php
+++ b/app/Domain/Alerts/Jobs/EvaluateAlertRulesJob.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Domain\Alerts\Jobs;
+
+use App\Domain\Alerts\Actions\TriggerAlertAction;
+use App\Domain\Alerts\Contracts\AlertRuleEvaluator;
+use App\Domain\Alerts\Evaluators\DeployFailureRateEvaluator;
+use App\Domain\Alerts\Evaluators\DeployFrequencyDropEvaluator;
+use App\Domain\Alerts\Evaluators\QueueBacklogTrendEvaluator;
+use App\Domain\Alerts\Evaluators\UptimeSlopeEvaluator;
+use App\Enums\AlertRuleKind;
+use App\Enums\AlertSource;
+use App\Models\AlertRule;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Spec 046 — scheduled every 5 min. Iterates enabled `AlertRule`
+ * rows, delegates each to its `AlertRuleEvaluator` implementation
+ * via a container-mapped strategy, and dispatches
+ * `TriggerAlertAction` on evaluation truth. `last_evaluated_at`
+ * updates on every tick; `last_triggered_at` updates on a fresh
+ * trigger + gates the cool-down window.
+ *
+ * Fired alerts carry `AlertSource::System` + `type = "rule.{kind}"`
+ * + `source_id = rule.id` — spec 042's delivery layer then fans them
+ * out to configured notification channels.
+ */
+class EvaluateAlertRulesJob implements ShouldBeUnique, ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    /** Lock across the full tick so overlapping schedules skip a run. */
+    public int $uniqueFor = 300;
+
+    public function uniqueId(): string
+    {
+        return 'evaluate-alert-rules';
+    }
+
+    public function handle(TriggerAlertAction $trigger): void
+    {
+        AlertRule::query()
+            ->where('enabled', true)
+            ->chunkById(100, function ($rules) use ($trigger): void {
+                foreach ($rules as $rule) {
+                    $this->evaluateOne($rule, $trigger);
+                }
+            });
+    }
+
+    private function evaluateOne(AlertRule $rule, TriggerAlertAction $trigger): void
+    {
+        try {
+            $evaluator = $this->evaluatorFor($rule->kind);
+        } catch (Throwable $e) {
+            Log::warning('AlertRule evaluator resolution failed', [
+                'rule_id' => $rule->id,
+                'kind' => $rule->kind?->value,
+                'error' => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
+        $now = Carbon::now();
+
+        try {
+            $evaluation = $evaluator->evaluate($rule);
+        } catch (Throwable $e) {
+            Log::warning('AlertRule evaluation threw', [
+                'rule_id' => $rule->id,
+                'kind' => $rule->kind?->value,
+                'error' => $e->getMessage(),
+            ]);
+            $rule->forceFill(['last_evaluated_at' => $now])->save();
+
+            return;
+        }
+
+        $rule->forceFill(['last_evaluated_at' => $now])->save();
+
+        if (! $evaluation->triggered) {
+            return;
+        }
+
+        if ($rule->isInCoolDown()) {
+            return;
+        }
+
+        $trigger->execute([
+            'project_id' => null,
+            'source' => AlertSource::System,
+            'source_id' => $rule->id,
+            'type' => 'rule.'.$rule->kind->value,
+            'severity' => $rule->severity,
+            'title' => $evaluation->title,
+            'description' => $evaluation->description,
+            'metadata' => $evaluation->metadata,
+        ]);
+
+        $rule->forceFill(['last_triggered_at' => $now])->save();
+    }
+
+    public function evaluatorFor(AlertRuleKind $kind): AlertRuleEvaluator
+    {
+        return match ($kind) {
+            AlertRuleKind::QueueBacklogTrend => app(QueueBacklogTrendEvaluator::class),
+            AlertRuleKind::DeployFrequencyDrop => app(DeployFrequencyDropEvaluator::class),
+            AlertRuleKind::UptimeSlope => app(UptimeSlopeEvaluator::class),
+            AlertRuleKind::DeployFailureRate => app(DeployFailureRateEvaluator::class),
+        };
+    }
+}

--- a/app/Domain/Alerts/Support/AlertRuleTemplate.php
+++ b/app/Domain/Alerts/Support/AlertRuleTemplate.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Domain\Alerts\Support;
+
+use App\Enums\AlertRuleKind;
+use App\Enums\AlertSeverity;
+
+/**
+ * Spec 046 — static catalog of starter templates for the "Add rule"
+ * picker. Reduces cold-start friction so an operator opening
+ * `/settings/rules` with no rules configured has picks to react to,
+ * not a blank form.
+ */
+class AlertRuleTemplate
+{
+    /**
+     * @return array<int, array{
+     *   id: string,
+     *   name: string,
+     *   kind: string,
+     *   severity: string,
+     *   config: array<string, mixed>,
+     *   description: string,
+     * }>
+     */
+    public static function all(): array
+    {
+        return [
+            [
+                'id' => 'queue-backlog-100',
+                'name' => 'Queue backlog above 100',
+                'kind' => AlertRuleKind::QueueBacklogTrend->value,
+                'severity' => AlertSeverity::Warning->value,
+                'config' => ['window_minutes' => 15, 'threshold_delta' => 100],
+                'description' => 'Warn when the pending queue backlog goes over 100 jobs.',
+            ],
+            [
+                'id' => 'queue-backlog-500',
+                'name' => 'Queue backlog critical (500)',
+                'kind' => AlertRuleKind::QueueBacklogTrend->value,
+                'severity' => AlertSeverity::Critical->value,
+                'config' => ['window_minutes' => 15, 'threshold_delta' => 500],
+                'description' => 'Page operators when the queue backlog crosses 500 jobs.',
+            ],
+            [
+                'id' => 'deploy-frequency-drop-50',
+                'name' => 'Deploy frequency dropped 50%',
+                'kind' => AlertRuleKind::DeployFrequencyDrop->value,
+                'severity' => AlertSeverity::Warning->value,
+                'config' => ['window_days' => 7, 'drop_percent' => 50],
+                'description' => 'Watch for a 50% drop in successful default-branch deploys week-over-week.',
+            ],
+            [
+                'id' => 'uptime-slope-1pp',
+                'name' => 'Uptime dropping >1pp/day',
+                'kind' => AlertRuleKind::UptimeSlope->value,
+                'severity' => AlertSeverity::Warning->value,
+                'config' => ['window_hours' => 24, 'slope_threshold' => -1.0],
+                'description' => 'Fire when uptime drops more than 1 percentage point across the last 24h.',
+            ],
+            [
+                'id' => 'deploy-failure-30pct',
+                'name' => 'Deploy failure rate >30%',
+                'kind' => AlertRuleKind::DeployFailureRate->value,
+                'severity' => AlertSeverity::Critical->value,
+                'config' => ['sample_size' => 10, 'failure_rate_percent' => 30],
+                'description' => 'Trigger when 3+ of the last 10 default-branch deploys failed.',
+            ],
+        ];
+    }
+}

--- a/app/Domain/Analytics/Actions/ComputeProjectHealthScoreAction.php
+++ b/app/Domain/Analytics/Actions/ComputeProjectHealthScoreAction.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\Analytics\Actions;
 
+use App\Domain\Analytics\DataTransferObjects\HealthScoreWeights;
 use App\Enums\AlertSeverity;
 use App\Enums\AlertStatus;
 use App\Enums\HostStatus;
@@ -11,6 +12,7 @@ use App\Models\Alert;
 use App\Models\Container;
 use App\Models\Host;
 use App\Models\Project;
+use App\Models\User;
 use App\Models\Website;
 use App\Models\WorkflowRun;
 use Illuminate\Support\Carbon;
@@ -63,19 +65,41 @@ class ComputeProjectHealthScoreAction
 
     public const DEDUCT_GH_SYNC_FAILED = 5;
 
+    /**
+     * Compute the score using the class-level DEDUCT_* defaults.
+     * Every existing caller (spec 033 recompute job, spec 035 sweep,
+     * activity listener) stays green — this method's signature never
+     * changed.
+     */
     public function execute(Project $project): int
     {
+        return $this->executeWith($project, HealthScoreWeights::defaults());
+    }
+
+    /**
+     * Spec 046 — compute the score using the user's overridden weights
+     * (nulls falling back to defaults). Callers pass the owning user;
+     * `RefreshProjectHealthScoreAction` resolves it from
+     * `$project->owner_user_id` before delegating.
+     */
+    public function executeForUser(Project $project, User $user): int
+    {
+        return $this->executeWith($project, HealthScoreWeights::forUser($user));
+    }
+
+    private function executeWith(Project $project, HealthScoreWeights $weights): int
+    {
         $score = self::BASELINE
-            - $this->alertDeductions($project)
-            - $this->websiteDeductions($project)
-            - $this->hostDeductions($project)
-            - $this->containerDeductions($project)
-            - $this->deploymentDeductions($project);
+            - $this->alertDeductions($project, $weights)
+            - $this->websiteDeductions($project, $weights)
+            - $this->hostDeductions($project, $weights)
+            - $this->containerDeductions($project, $weights)
+            - $this->deploymentDeductions($project, $weights);
 
         return (int) max(0, min(100, $score));
     }
 
-    private function alertDeductions(Project $project): int
+    private function alertDeductions(Project $project, HealthScoreWeights $weights): int
     {
         $active = [AlertStatus::Open->value, AlertStatus::Acknowledged->value];
 
@@ -91,11 +115,11 @@ class ComputeProjectHealthScoreAction
             ->where('severity', AlertSeverity::Warning->value)
             ->count();
 
-        return ($critical * self::DEDUCT_ALERT_CRITICAL)
-            + ($warning * self::DEDUCT_ALERT_WARNING);
+        return ($critical * $weights->alertCritical())
+            + ($warning * $weights->alertWarning());
     }
 
-    private function websiteDeductions(Project $project): int
+    private function websiteDeductions(Project $project, HealthScoreWeights $weights): int
     {
         $down = Website::query()
             ->where('project_id', $project->id)
@@ -110,11 +134,11 @@ class ComputeProjectHealthScoreAction
             ->where('status', WebsiteStatus::Slow->value)
             ->count();
 
-        return ($down * self::DEDUCT_WEBSITE_DOWN)
-            + ($slow * self::DEDUCT_WEBSITE_SLOW);
+        return ($down * $weights->websiteDown())
+            + ($slow * $weights->websiteSlow());
     }
 
-    private function hostDeductions(Project $project): int
+    private function hostDeductions(Project $project, HealthScoreWeights $weights): int
     {
         $offline = Host::query()
             ->where('project_id', $project->id)
@@ -122,10 +146,10 @@ class ComputeProjectHealthScoreAction
             ->where('status', HostStatus::Offline->value)
             ->count();
 
-        return $offline * self::DEDUCT_HOST_OFFLINE;
+        return $offline * $weights->hostOffline();
     }
 
-    private function containerDeductions(Project $project): int
+    private function containerDeductions(Project $project, HealthScoreWeights $weights): int
     {
         // Docker daemon's `health_status` is opt-in: not every image
         // declares a HEALTHCHECK. Only count containers explicitly
@@ -136,10 +160,10 @@ class ComputeProjectHealthScoreAction
             ->where('health_status', 'unhealthy')
             ->count();
 
-        return $unhealthy * self::DEDUCT_CONTAINER_UNHEALTHY;
+        return $unhealthy * $weights->containerUnhealthy();
     }
 
-    private function deploymentDeductions(Project $project): int
+    private function deploymentDeductions(Project $project, HealthScoreWeights $weights): int
     {
         // "Failed deployment" in §14.2 maps to a failed default-branch
         // workflow run in the last 24h. We constrain to the run's
@@ -156,6 +180,6 @@ class ComputeProjectHealthScoreAction
             ->where('workflow_runs.run_completed_at', '>', $since)
             ->count('workflow_runs.id');
 
-        return $failed * self::DEDUCT_DEPLOY_FAILED;
+        return $failed * $weights->deployFailed();
     }
 }

--- a/app/Domain/Analytics/Actions/RefreshProjectHealthScoreAction.php
+++ b/app/Domain/Analytics/Actions/RefreshProjectHealthScoreAction.php
@@ -5,6 +5,7 @@ namespace App\Domain\Analytics\Actions;
 use App\Enums\HealthScoreBand;
 use App\Events\HealthScoreUpdated;
 use App\Models\Project;
+use App\Models\User;
 
 /**
  * Persist a project's health score and broadcast the change (spec
@@ -27,7 +28,16 @@ class RefreshProjectHealthScoreAction
 
     public function execute(Project $project): int
     {
-        $newScore = $this->compute->execute($project);
+        // Spec 046 — pass the project owner's weight overrides through
+        // to the compute action. Owner is null in a race with a user
+        // deletion; fall back to the defaults path in that case.
+        $owner = $project->owner_user_id !== null
+            ? User::query()->find($project->owner_user_id)
+            : null;
+
+        $newScore = $owner !== null
+            ? $this->compute->executeForUser($project, $owner)
+            : $this->compute->execute($project);
 
         if ($project->health_score === $newScore) {
             return $newScore;

--- a/app/Domain/Analytics/DataTransferObjects/HealthScoreWeights.php
+++ b/app/Domain/Analytics/DataTransferObjects/HealthScoreWeights.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Domain\Analytics\DataTransferObjects;
+
+use App\Domain\Analytics\Actions\ComputeProjectHealthScoreAction;
+use App\Models\ProjectHealthScoreWeightOverride;
+use App\Models\User;
+
+/**
+ * Spec 046 — immutable value object carrying the resolved weights for a
+ * health-score computation. `null` on any field falls back to the class
+ * constant in `ComputeProjectHealthScoreAction`, so `defaults()` returns
+ * an all-nulls instance meaning "use defaults for every signal."
+ */
+final class HealthScoreWeights
+{
+    public function __construct(
+        public readonly ?int $deductAlertCritical,
+        public readonly ?int $deductAlertWarning,
+        public readonly ?int $deductDeployFailed,
+        public readonly ?int $deductWebsiteSlow,
+        public readonly ?int $deductWebsiteDown,
+        public readonly ?int $deductHostOffline,
+        public readonly ?int $deductContainerUnhealthy,
+        public readonly ?int $deductGhSyncFailed,
+    ) {}
+
+    /** All-null instance — use every default. */
+    public static function defaults(): self
+    {
+        return new self(null, null, null, null, null, null, null, null);
+    }
+
+    /**
+     * Resolve the user's override row into a value object. If the user
+     * has no row (or it exists with every column null), the returned
+     * instance is functionally identical to `defaults()`.
+     */
+    public static function forUser(User $user): self
+    {
+        $row = ProjectHealthScoreWeightOverride::query()
+            ->where('user_id', $user->id)
+            ->first();
+
+        if ($row === null) {
+            return self::defaults();
+        }
+
+        return new self(
+            deductAlertCritical: $row->deduct_alert_critical,
+            deductAlertWarning: $row->deduct_alert_warning,
+            deductDeployFailed: $row->deduct_deploy_failed,
+            deductWebsiteSlow: $row->deduct_website_slow,
+            deductWebsiteDown: $row->deduct_website_down,
+            deductHostOffline: $row->deduct_host_offline,
+            deductContainerUnhealthy: $row->deduct_container_unhealthy,
+            deductGhSyncFailed: $row->deduct_gh_sync_failed,
+        );
+    }
+
+    public function alertCritical(): int
+    {
+        return $this->deductAlertCritical ?? ComputeProjectHealthScoreAction::DEDUCT_ALERT_CRITICAL;
+    }
+
+    public function alertWarning(): int
+    {
+        return $this->deductAlertWarning ?? ComputeProjectHealthScoreAction::DEDUCT_ALERT_WARNING;
+    }
+
+    public function deployFailed(): int
+    {
+        return $this->deductDeployFailed ?? ComputeProjectHealthScoreAction::DEDUCT_DEPLOY_FAILED;
+    }
+
+    public function websiteSlow(): int
+    {
+        return $this->deductWebsiteSlow ?? ComputeProjectHealthScoreAction::DEDUCT_WEBSITE_SLOW;
+    }
+
+    public function websiteDown(): int
+    {
+        return $this->deductWebsiteDown ?? ComputeProjectHealthScoreAction::DEDUCT_WEBSITE_DOWN;
+    }
+
+    public function hostOffline(): int
+    {
+        return $this->deductHostOffline ?? ComputeProjectHealthScoreAction::DEDUCT_HOST_OFFLINE;
+    }
+
+    public function containerUnhealthy(): int
+    {
+        return $this->deductContainerUnhealthy ?? ComputeProjectHealthScoreAction::DEDUCT_CONTAINER_UNHEALTHY;
+    }
+
+    public function ghSyncFailed(): int
+    {
+        return $this->deductGhSyncFailed ?? ComputeProjectHealthScoreAction::DEDUCT_GH_SYNC_FAILED;
+    }
+}

--- a/app/Domain/Analytics/Jobs/RecomputeUserProjectHealthScoresJob.php
+++ b/app/Domain/Analytics/Jobs/RecomputeUserProjectHealthScoresJob.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Domain\Analytics\Jobs;
+
+use App\Models\Project;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Spec 046 — after a user saves new health-score weights, reassert
+ * scores across only *their* projects. Prevents a save from
+ * fan-outing across every active project the sweep would touch.
+ * The 5-minute `RecomputeAllProjectHealthScoresJob` sweep is still
+ * the safety net for drift.
+ */
+class RecomputeUserProjectHealthScoresJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    public function __construct(public readonly int $userId) {}
+
+    public function handle(): void
+    {
+        Project::query()
+            ->where('owner_user_id', $this->userId)
+            ->select('id')
+            ->chunkById(100, function ($projects): void {
+                foreach ($projects as $project) {
+                    RecomputeProjectHealthScoreJob::dispatch($project->id);
+                }
+            });
+    }
+}

--- a/app/Enums/AlertRuleKind.php
+++ b/app/Enums/AlertRuleKind.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Spec 046 — kind of metric-driven alert rule. Each case maps to a
+ * distinct `AlertRuleEvaluator` implementation. Naming mirrors the
+ * existing alert `type` conventions (`website.down`, `host.offline`)
+ * so the Deliveries tab reads consistently.
+ */
+enum AlertRuleKind: string
+{
+    case QueueBacklogTrend = 'queue.backlog_trend';
+    case DeployFrequencyDrop = 'deploy_frequency_drop';
+    case UptimeSlope = 'uptime_slope';
+    case DeployFailureRate = 'deploy_failure_rate';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::QueueBacklogTrend => 'Queue backlog trending up',
+            self::DeployFrequencyDrop => 'Deploy frequency dropped',
+            self::UptimeSlope => 'Uptime trending down',
+            self::DeployFailureRate => 'Deploy failure rate high',
+        };
+    }
+}

--- a/app/Http/Controllers/Settings/RulesController.php
+++ b/app/Http/Controllers/Settings/RulesController.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Domain\Alerts\Support\AlertRuleTemplate;
+use App\Domain\Analytics\Actions\ComputeProjectHealthScoreAction;
+use App\Domain\Analytics\DataTransferObjects\HealthScoreWeights;
+use App\Domain\Analytics\Jobs\RecomputeAllProjectHealthScoresJob;
+use App\Enums\AlertRuleKind;
+use App\Enums\AlertSeverity;
+use App\Http\Controllers\Controller;
+use App\Models\AlertRule;
+use App\Models\ProjectHealthScoreWeightOverride;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Spec 046 — `/settings/rules` unified surface for two related knobs:
+ *
+ *  - Weights tab: per-user overrides for the 8 `DEDUCT_*` constants
+ *    in `ComputeProjectHealthScoreAction`.
+ *  - Rules tab:   user-defined metric alert rules that fire via the
+ *    scheduled `EvaluateAlertRulesJob`.
+ *
+ * Both slices share one page + one JSON payload. Every mutation is
+ * per-user scoped.
+ */
+class RulesController extends Controller
+{
+    private const WEIGHT_FIELDS = [
+        'deduct_alert_critical',
+        'deduct_alert_warning',
+        'deduct_deploy_failed',
+        'deduct_website_slow',
+        'deduct_website_down',
+        'deduct_host_offline',
+        'deduct_container_unhealthy',
+        'deduct_gh_sync_failed',
+    ];
+
+    public function index(Request $request): Response
+    {
+        $userId = $request->user()->id;
+
+        $override = ProjectHealthScoreWeightOverride::query()
+            ->where('user_id', $userId)
+            ->first();
+
+        $weights = HealthScoreWeights::forUser($request->user());
+
+        $rules = AlertRule::query()
+            ->where('user_id', $userId)
+            ->orderByDesc('id')
+            ->get()
+            ->map(fn (AlertRule $r): array => [
+                'id' => $r->id,
+                'name' => $r->name,
+                'kind' => $r->kind->value,
+                'kind_label' => $r->kind->label(),
+                'severity' => $r->severity->value,
+                'config' => $r->config ?? [],
+                'enabled' => $r->enabled,
+                'cool_down_minutes' => $r->cool_down_minutes,
+                'last_evaluated_at' => $r->last_evaluated_at?->diffForHumans(),
+                'last_triggered_at' => $r->last_triggered_at?->diffForHumans(),
+            ]);
+
+        return Inertia::render('Settings/Rules/Index', [
+            'weights' => [
+                'defaults' => $this->defaultsPayload(),
+                'overrides' => $override ? $this->overridesPayload($override) : null,
+                'resolved' => [
+                    'alert_critical' => $weights->alertCritical(),
+                    'alert_warning' => $weights->alertWarning(),
+                    'deploy_failed' => $weights->deployFailed(),
+                    'website_slow' => $weights->websiteSlow(),
+                    'website_down' => $weights->websiteDown(),
+                    'host_offline' => $weights->hostOffline(),
+                    'container_unhealthy' => $weights->containerUnhealthy(),
+                    'gh_sync_failed' => $weights->ghSyncFailed(),
+                ],
+            ],
+            'rules' => $rules,
+            'options' => [
+                'kinds' => array_map(
+                    fn (AlertRuleKind $k): array => [
+                        'value' => $k->value,
+                        'label' => $k->label(),
+                    ],
+                    AlertRuleKind::cases(),
+                ),
+                'severities' => array_map(
+                    fn (AlertSeverity $s): string => $s->value,
+                    AlertSeverity::cases(),
+                ),
+                'templates' => AlertRuleTemplate::all(),
+            ],
+        ]);
+    }
+
+    public function updateWeights(Request $request): RedirectResponse
+    {
+        $rules = [];
+        foreach (self::WEIGHT_FIELDS as $field) {
+            $rules[$field] = 'sometimes|nullable|integer|min:0|max:100';
+        }
+        $validated = $request->validate($rules);
+
+        $attrs = ['user_id' => $request->user()->id];
+        foreach (self::WEIGHT_FIELDS as $field) {
+            $attrs[$field] = array_key_exists($field, $validated)
+                ? $validated[$field]
+                : null;
+        }
+
+        ProjectHealthScoreWeightOverride::query()->updateOrCreate(
+            ['user_id' => $attrs['user_id']],
+            $attrs,
+        );
+
+        // Fire-and-forget: reassert the score across every project this
+        // user owns so the new formula lands without waiting for the
+        // scheduled sweep.
+        RecomputeAllProjectHealthScoresJob::dispatch();
+
+        return back()->with('status', 'Health-score weights updated.');
+    }
+
+    public function resetWeights(Request $request): RedirectResponse
+    {
+        ProjectHealthScoreWeightOverride::query()
+            ->where('user_id', $request->user()->id)
+            ->delete();
+
+        RecomputeAllProjectHealthScoresJob::dispatch();
+
+        return back()->with('status', 'Health-score weights reset to defaults.');
+    }
+
+    public function storeRule(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:120',
+            'kind' => 'required|in:'.implode(',', array_column(AlertRuleKind::cases(), 'value')),
+            'severity' => 'required|in:'.implode(',', array_column(AlertSeverity::cases(), 'value')),
+            'config' => 'sometimes|nullable|array',
+            'cool_down_minutes' => 'sometimes|integer|min:1|max:1440',
+        ]);
+
+        AlertRule::query()->create([
+            'user_id' => $request->user()->id,
+            'name' => $validated['name'],
+            'kind' => $validated['kind'],
+            'severity' => $validated['severity'],
+            'config' => $validated['config'] ?? [],
+            'enabled' => true,
+            'cool_down_minutes' => $validated['cool_down_minutes'] ?? 30,
+        ]);
+
+        return back()->with('status', 'Rule added.');
+    }
+
+    public function updateRule(Request $request, AlertRule $rule): RedirectResponse
+    {
+        if ($rule->user_id !== $request->user()->id) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'name' => 'sometimes|required|string|max:120',
+            'severity' => 'sometimes|required|in:'.implode(',', array_column(AlertSeverity::cases(), 'value')),
+            'config' => 'sometimes|nullable|array',
+            'enabled' => 'sometimes|boolean',
+            'cool_down_minutes' => 'sometimes|integer|min:1|max:1440',
+        ]);
+
+        $rule->fill($validated)->save();
+
+        return back()->with('status', 'Rule updated.');
+    }
+
+    public function destroyRule(Request $request, AlertRule $rule): RedirectResponse
+    {
+        if ($rule->user_id !== $request->user()->id) {
+            abort(403);
+        }
+
+        $rule->delete();
+
+        return back()->with('status', 'Rule deleted.');
+    }
+
+    private function defaultsPayload(): array
+    {
+        return [
+            'alert_critical' => ComputeProjectHealthScoreAction::DEDUCT_ALERT_CRITICAL,
+            'alert_warning' => ComputeProjectHealthScoreAction::DEDUCT_ALERT_WARNING,
+            'deploy_failed' => ComputeProjectHealthScoreAction::DEDUCT_DEPLOY_FAILED,
+            'website_slow' => ComputeProjectHealthScoreAction::DEDUCT_WEBSITE_SLOW,
+            'website_down' => ComputeProjectHealthScoreAction::DEDUCT_WEBSITE_DOWN,
+            'host_offline' => ComputeProjectHealthScoreAction::DEDUCT_HOST_OFFLINE,
+            'container_unhealthy' => ComputeProjectHealthScoreAction::DEDUCT_CONTAINER_UNHEALTHY,
+            'gh_sync_failed' => ComputeProjectHealthScoreAction::DEDUCT_GH_SYNC_FAILED,
+        ];
+    }
+
+    private function overridesPayload(ProjectHealthScoreWeightOverride $override): array
+    {
+        return [
+            'alert_critical' => $override->deduct_alert_critical,
+            'alert_warning' => $override->deduct_alert_warning,
+            'deploy_failed' => $override->deduct_deploy_failed,
+            'website_slow' => $override->deduct_website_slow,
+            'website_down' => $override->deduct_website_down,
+            'host_offline' => $override->deduct_host_offline,
+            'container_unhealthy' => $override->deduct_container_unhealthy,
+            'gh_sync_failed' => $override->deduct_gh_sync_failed,
+        ];
+    }
+}

--- a/app/Http/Controllers/Settings/RulesController.php
+++ b/app/Http/Controllers/Settings/RulesController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Settings;
 use App\Domain\Alerts\Support\AlertRuleTemplate;
 use App\Domain\Analytics\Actions\ComputeProjectHealthScoreAction;
 use App\Domain\Analytics\DataTransferObjects\HealthScoreWeights;
-use App\Domain\Analytics\Jobs\RecomputeAllProjectHealthScoresJob;
+use App\Domain\Analytics\Jobs\RecomputeUserProjectHealthScoresJob;
 use App\Enums\AlertRuleKind;
 use App\Enums\AlertSeverity;
 use App\Http\Controllers\Controller;
@@ -123,7 +123,7 @@ class RulesController extends Controller
         // Fire-and-forget: reassert the score across every project this
         // user owns so the new formula lands without waiting for the
         // scheduled sweep.
-        RecomputeAllProjectHealthScoresJob::dispatch();
+        RecomputeUserProjectHealthScoresJob::dispatch($request->user()->id);
 
         return back()->with('status', 'Health-score weights updated.');
     }
@@ -134,7 +134,7 @@ class RulesController extends Controller
             ->where('user_id', $request->user()->id)
             ->delete();
 
-        RecomputeAllProjectHealthScoresJob::dispatch();
+        RecomputeUserProjectHealthScoresJob::dispatch($request->user()->id);
 
         return back()->with('status', 'Health-score weights reset to defaults.');
     }

--- a/app/Models/AlertRule.php
+++ b/app/Models/AlertRule.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\AlertRuleKind;
+use App\Enums\AlertSeverity;
+use Database\Factories\AlertRuleFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AlertRule extends Model
+{
+    /** @use HasFactory<AlertRuleFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'kind',
+        'severity',
+        'config',
+        'enabled',
+        'last_evaluated_at',
+        'last_triggered_at',
+        'cool_down_minutes',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'kind' => AlertRuleKind::class,
+            'severity' => AlertSeverity::class,
+            'config' => 'array',
+            'enabled' => 'boolean',
+            'last_evaluated_at' => 'datetime',
+            'last_triggered_at' => 'datetime',
+            'cool_down_minutes' => 'integer',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * True when the rule is within its cool-down window. Spec 046 —
+     * a stuck condition shouldn't re-fire every scheduled tick.
+     */
+    public function isInCoolDown(): bool
+    {
+        if ($this->last_triggered_at === null) {
+            return false;
+        }
+
+        return $this->last_triggered_at
+            ->addMinutes($this->cool_down_minutes)
+            ->isFuture();
+    }
+}

--- a/app/Models/ProjectHealthScoreWeightOverride.php
+++ b/app/Models/ProjectHealthScoreWeightOverride.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\ProjectHealthScoreWeightOverrideFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Spec 046 — per-user overrides for the 8 hard-coded `DEDUCT_*`
+ * constants in `ComputeProjectHealthScoreAction`. `null` on any column
+ * means "use the class default"; the value object
+ * (`HealthScoreWeights`) does the fallback resolution so callers stay
+ * defaults-safe when the row doesn't exist or a column is unset.
+ */
+class ProjectHealthScoreWeightOverride extends Model
+{
+    /** @use HasFactory<ProjectHealthScoreWeightOverrideFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'deduct_alert_critical',
+        'deduct_alert_warning',
+        'deduct_deploy_failed',
+        'deduct_website_slow',
+        'deduct_website_down',
+        'deduct_host_offline',
+        'deduct_container_unhealthy',
+        'deduct_gh_sync_failed',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'deduct_alert_critical' => 'integer',
+            'deduct_alert_warning' => 'integer',
+            'deduct_deploy_failed' => 'integer',
+            'deduct_website_slow' => 'integer',
+            'deduct_website_down' => 'integer',
+            'deduct_host_offline' => 'integer',
+            'deduct_container_unhealthy' => 'integer',
+            'deduct_gh_sync_failed' => 'integer',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/factories/AlertRuleFactory.php
+++ b/database/factories/AlertRuleFactory.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\AlertRuleKind;
+use App\Enums\AlertSeverity;
+use App\Models\AlertRule;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<AlertRule> */
+class AlertRuleFactory extends Factory
+{
+    protected $model = AlertRule::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'name' => 'Queue backlog watch',
+            'kind' => AlertRuleKind::QueueBacklogTrend->value,
+            'severity' => AlertSeverity::Warning->value,
+            'config' => [
+                'window_minutes' => 15,
+                'threshold_delta' => 50,
+            ],
+            'enabled' => true,
+            'last_evaluated_at' => null,
+            'last_triggered_at' => null,
+            'cool_down_minutes' => 30,
+        ];
+    }
+
+    public function ofKind(AlertRuleKind $kind, array $config = []): static
+    {
+        return $this->state(fn () => [
+            'kind' => $kind->value,
+            'config' => array_merge($this->defaultConfigFor($kind), $config),
+            'name' => $kind->label(),
+        ]);
+    }
+
+    public function disabled(): static
+    {
+        return $this->state(fn () => ['enabled' => false]);
+    }
+
+    public function inCoolDown(): static
+    {
+        return $this->state(fn () => [
+            'last_triggered_at' => now()->subMinutes(5),
+            'cool_down_minutes' => 30,
+        ]);
+    }
+
+    private function defaultConfigFor(AlertRuleKind $kind): array
+    {
+        return match ($kind) {
+            AlertRuleKind::QueueBacklogTrend => [
+                'window_minutes' => 15,
+                'threshold_delta' => 50,
+            ],
+            AlertRuleKind::DeployFrequencyDrop => [
+                'window_days' => 7,
+                'drop_percent' => 50,
+            ],
+            AlertRuleKind::UptimeSlope => [
+                'window_hours' => 24,
+                'slope_threshold' => -1.0,
+            ],
+            AlertRuleKind::DeployFailureRate => [
+                'sample_size' => 10,
+                'failure_rate_percent' => 30,
+            ],
+        };
+    }
+}

--- a/database/factories/ProjectHealthScoreWeightOverrideFactory.php
+++ b/database/factories/ProjectHealthScoreWeightOverrideFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ProjectHealthScoreWeightOverride;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<ProjectHealthScoreWeightOverride> */
+class ProjectHealthScoreWeightOverrideFactory extends Factory
+{
+    protected $model = ProjectHealthScoreWeightOverride::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'deduct_alert_critical' => null,
+            'deduct_alert_warning' => null,
+            'deduct_deploy_failed' => null,
+            'deduct_website_slow' => null,
+            'deduct_website_down' => null,
+            'deduct_host_offline' => null,
+            'deduct_container_unhealthy' => null,
+            'deduct_gh_sync_failed' => null,
+        ];
+    }
+
+    /** Convenience: every field takes a specific value. */
+    public function withAllWeights(int $value): static
+    {
+        return $this->state(fn () => [
+            'deduct_alert_critical' => $value,
+            'deduct_alert_warning' => $value,
+            'deduct_deploy_failed' => $value,
+            'deduct_website_slow' => $value,
+            'deduct_website_down' => $value,
+            'deduct_host_offline' => $value,
+            'deduct_container_unhealthy' => $value,
+            'deduct_gh_sync_failed' => $value,
+        ]);
+    }
+}

--- a/database/migrations/2026_07_02_100001_create_project_health_score_weight_overrides_table.php
+++ b/database/migrations/2026_07_02_100001_create_project_health_score_weight_overrides_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('project_health_score_weight_overrides', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('user_id')
+                ->constrained('users')
+                ->cascadeOnDelete();
+
+            // One row per user; each column mirrors a DEDUCT_* constant in
+            // ComputeProjectHealthScoreAction. `null` = "use the default"
+            // — reset falls back to the class constant without deleting
+            // the row (spec 046 slice A rationale). Bounded to 0..100 by
+            // the controller; the score clamp in the action clips the
+            // result to `[0, 100]` regardless.
+            $columns = [
+                'deduct_alert_critical',
+                'deduct_alert_warning',
+                'deduct_deploy_failed',
+                'deduct_website_slow',
+                'deduct_website_down',
+                'deduct_host_offline',
+                'deduct_container_unhealthy',
+                'deduct_gh_sync_failed',
+            ];
+            foreach ($columns as $col) {
+                $table->unsignedTinyInteger($col)->nullable();
+            }
+
+            $table->timestamps();
+
+            $table->unique('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('project_health_score_weight_overrides');
+    }
+};

--- a/database/migrations/2026_07_02_100002_create_alert_rules_table.php
+++ b/database/migrations/2026_07_02_100002_create_alert_rules_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('alert_rules', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('user_id')
+                ->constrained('users')
+                ->cascadeOnDelete();
+
+            $table->string('name', 120);
+
+            // queue.backlog_trend | deploy_frequency_drop |
+            // uptime_slope | deploy_failure_rate — matches
+            // `AlertRuleKind` enum. Kept dotted where the concept
+            // maps 1:1 to an existing alert `type` naming pattern.
+            $table->string('kind', 32);
+
+            // info | warning | critical — the fired alert's severity.
+            $table->string('severity', 16)->default('warning');
+
+            // Per-kind knobs: threshold delta, window minutes, drop
+            // percent, slope threshold. Shape validated at the
+            // controller / evaluator boundary.
+            $table->json('config')->nullable();
+
+            $table->boolean('enabled')->default(true);
+
+            $table->timestamp('last_evaluated_at')->nullable();
+            $table->timestamp('last_triggered_at')->nullable();
+
+            // Minimum minutes between successive triggers so a stuck
+            // condition doesn't page an operator every tick. 30-minute
+            // default matches spec 042's dedupe window rationale.
+            $table->unsignedInteger('cool_down_minutes')->default(30);
+
+            $table->timestamps();
+
+            $table->index(['user_id', 'enabled']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('alert_rules');
+    }
+};

--- a/docs/security/operator-checklist.md
+++ b/docs/security/operator-checklist.md
@@ -92,6 +92,11 @@ Per-user limits via Laravel's `throttle:N,1` middleware:
 | `PATCH /settings/notifications/preferences/{preference}` | 20/min (spec 042) |
 | `DELETE /settings/notifications/preferences/{preference}` | 20/min (spec 042) |
 | `POST /settings/notifications/deliveries/{delivery}/retry` | 30/min (spec 042) |
+| `PATCH /settings/rules/weights` | 20/min (spec 046) |
+| `DELETE /settings/rules/weights` | 20/min (spec 046) |
+| `POST /settings/rules` | 10/min (spec 046) |
+| `PATCH /settings/rules/{rule}` | 20/min (spec 046) |
+| `DELETE /settings/rules/{rule}` | 20/min (spec 046) |
 
 **Sign-off ☐:** Tested in
 [`ManualSyncRateLimitTest`](../../tests/Feature/Security/ManualSyncRateLimitTest.php).

--- a/resources/js/Pages/Settings/Index.vue
+++ b/resources/js/Pages/Settings/Index.vue
@@ -313,6 +313,27 @@ const disconnect = () => {
                 <ExternalLink class="h-4 w-4 text-text-muted" aria-hidden="true" />
             </Link>
 
+            <!-- Spec 046 — health-score weights + metric alert rules. -->
+            <Link
+                :href="route('settings.rules.index')"
+                class="glass-card flex items-center justify-between gap-3 p-5 transition hover:border-accent-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+            >
+                <div class="flex items-center gap-3">
+                    <span class="flex h-10 w-10 items-center justify-center rounded-lg border border-border-subtle bg-background-panel-hover">
+                        <Gauge class="h-5 w-5 text-accent-cyan" aria-hidden="true" />
+                    </span>
+                    <div class="flex min-w-0 flex-col">
+                        <span class="text-sm font-semibold text-text-primary">
+                            Rules & health weights
+                        </span>
+                        <span class="text-xs text-text-muted">
+                            Tune the score formula + add metric-driven alert rules.
+                        </span>
+                    </div>
+                </div>
+                <ExternalLink class="h-4 w-4 text-text-muted" aria-hidden="true" />
+            </Link>
+
             <!-- GitHub Integration card -->
             <section
                 aria-label="GitHub integration"

--- a/resources/js/Pages/Settings/Rules/Index.vue
+++ b/resources/js/Pages/Settings/Rules/Index.vue
@@ -1,0 +1,467 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import {
+    Activity,
+    AlertTriangle,
+    ChevronLeft,
+    Gauge,
+    Plus,
+    RotateCcw,
+    Save,
+    Trash2,
+} from 'lucide-vue-next';
+import { computed, ref } from 'vue';
+
+type Severity = 'info' | 'warning' | 'critical';
+type Kind =
+    | 'queue.backlog_trend'
+    | 'deploy_frequency_drop'
+    | 'uptime_slope'
+    | 'deploy_failure_rate';
+
+interface Rule {
+    id: number;
+    name: string;
+    kind: Kind;
+    kind_label: string;
+    severity: Severity;
+    config: Record<string, number>;
+    enabled: boolean;
+    cool_down_minutes: number;
+    last_evaluated_at: string | null;
+    last_triggered_at: string | null;
+}
+
+interface Template {
+    id: string;
+    name: string;
+    kind: Kind;
+    severity: Severity;
+    config: Record<string, number>;
+    description: string;
+}
+
+interface Weights {
+    alert_critical: number | null;
+    alert_warning: number | null;
+    deploy_failed: number | null;
+    website_slow: number | null;
+    website_down: number | null;
+    host_offline: number | null;
+    container_unhealthy: number | null;
+    gh_sync_failed: number | null;
+}
+
+const props = defineProps<{
+    weights: {
+        defaults: Weights;
+        overrides: Weights | null;
+        resolved: Weights;
+    };
+    rules: Rule[];
+    options: {
+        kinds: Array<{ value: Kind; label: string }>;
+        severities: Severity[];
+        templates: Template[];
+    };
+}>();
+
+type Tab = 'weights' | 'rules';
+const activeTab = ref<Tab>('weights');
+
+const weightFields: Array<keyof Weights> = [
+    'alert_critical',
+    'alert_warning',
+    'deploy_failed',
+    'website_slow',
+    'website_down',
+    'host_offline',
+    'container_unhealthy',
+    'gh_sync_failed',
+];
+
+const weightLabels: Record<keyof Weights, string> = {
+    alert_critical: 'Critical alert',
+    alert_warning: 'Warning alert',
+    deploy_failed: 'Failed deploy (24h)',
+    website_slow: 'Slow website',
+    website_down: 'Down website',
+    host_offline: 'Offline host',
+    container_unhealthy: 'Unhealthy container',
+    gh_sync_failed: 'Failed GitHub sync',
+};
+
+// One editable slot per weight field: null means "use the default,"
+// number means "override with this value." Seed from the resolved
+// bundle so users see the currently-active value in every slot.
+const draftWeights = ref<Record<keyof Weights, number>>({
+    alert_critical: props.weights.resolved.alert_critical ?? 0,
+    alert_warning: props.weights.resolved.alert_warning ?? 0,
+    deploy_failed: props.weights.resolved.deploy_failed ?? 0,
+    website_slow: props.weights.resolved.website_slow ?? 0,
+    website_down: props.weights.resolved.website_down ?? 0,
+    host_offline: props.weights.resolved.host_offline ?? 0,
+    container_unhealthy: props.weights.resolved.container_unhealthy ?? 0,
+    gh_sync_failed: props.weights.resolved.gh_sync_failed ?? 0,
+});
+
+const saveWeights = () => {
+    router.patch(
+        route('settings.rules.weights.update'),
+        draftWeights.value,
+        { preserveScroll: true },
+    );
+};
+
+const resetWeights = () => {
+    if (!confirm('Reset every weight to its default?')) return;
+    router.delete(route('settings.rules.weights.reset'), { preserveScroll: true });
+};
+
+// ─── Rules tab state ────────────────────────────────────────────
+
+const newRuleFromTemplate = ref<Template | null>(null);
+const newRule = ref<{
+    name: string;
+    kind: Kind;
+    severity: Severity;
+    config: Record<string, number>;
+    cool_down_minutes: number;
+}>({
+    name: '',
+    kind: 'queue.backlog_trend',
+    severity: 'warning',
+    config: { window_minutes: 15, threshold_delta: 100 },
+    cool_down_minutes: 30,
+});
+
+const applyTemplate = (tpl: Template) => {
+    newRuleFromTemplate.value = tpl;
+    newRule.value = {
+        name: tpl.name,
+        kind: tpl.kind,
+        severity: tpl.severity,
+        config: { ...tpl.config },
+        cool_down_minutes: 30,
+    };
+};
+
+const submitRule = () => {
+    router.post(
+        route('settings.rules.store'),
+        newRule.value,
+        {
+            preserveScroll: true,
+            onSuccess: () => {
+                newRuleFromTemplate.value = null;
+                newRule.value = {
+                    name: '',
+                    kind: 'queue.backlog_trend',
+                    severity: 'warning',
+                    config: { window_minutes: 15, threshold_delta: 100 },
+                    cool_down_minutes: 30,
+                };
+            },
+        },
+    );
+};
+
+const toggleRule = (rule: Rule) => {
+    router.patch(
+        route('settings.rules.update', { rule: rule.id }),
+        { enabled: !rule.enabled },
+        { preserveScroll: true },
+    );
+};
+
+const deleteRule = (rule: Rule) => {
+    if (!confirm(`Delete "${rule.name}"?`)) return;
+    router.delete(
+        route('settings.rules.destroy', { rule: rule.id }),
+        { preserveScroll: true },
+    );
+};
+
+const configEntries = (config: Record<string, number>) =>
+    Object.entries(config).map(([key, value]) => ({ key, value }));
+
+const capitalize = (s: string | null) =>
+    s ? s.charAt(0).toUpperCase() + s.slice(1) : '';
+
+const hasOverride = computed(() => props.weights.overrides !== null);
+</script>
+
+<template>
+    <Head title="Rules & health weights" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <Link
+                    :href="route('settings.index')"
+                    class="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan transition hover:text-accent-cyan/80"
+                >
+                    <ChevronLeft class="h-3 w-3" aria-hidden="true" />
+                    Settings
+                </Link>
+                <h1 class="text-lg font-semibold text-text-primary">Rules & health weights</h1>
+            </div>
+        </template>
+
+        <div class="space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+            <header class="flex flex-col gap-1">
+                <h2 class="flex items-center gap-2 text-xl font-semibold text-text-primary">
+                    <Gauge class="h-5 w-5 text-accent-cyan" aria-hidden="true" />
+                    Custom rules
+                </h2>
+                <p class="text-sm text-text-secondary">
+                    Tune how the project health score reacts to each signal, and add metric-driven
+                    alert rules that fire through your notification channels.
+                </p>
+            </header>
+
+            <nav
+                aria-label="Rules tabs"
+                class="flex gap-2 border-b border-border-subtle"
+            >
+                <button
+                    v-for="tab in (['weights', 'rules'] as Tab[])"
+                    :key="tab"
+                    type="button"
+                    class="border-b-2 px-4 py-2 text-sm font-semibold uppercase tracking-[0.18em] transition"
+                    :class="
+                        activeTab === tab
+                            ? 'border-accent-cyan text-text-primary'
+                            : 'border-transparent text-text-muted hover:text-text-primary'
+                    "
+                    @click="activeTab = tab"
+                >
+                    {{ capitalize(tab) }}
+                </button>
+            </nav>
+
+            <!-- Weights tab -->
+            <section v-if="activeTab === 'weights'" class="space-y-6">
+                <div class="glass-card p-5">
+                    <div class="mb-4 flex items-center justify-between">
+                        <h3 class="text-sm font-semibold uppercase tracking-[0.18em] text-text-muted">
+                            Deduction weights
+                        </h3>
+                        <StatusBadge :tone="hasOverride ? 'info' : 'muted'">
+                            {{ hasOverride ? 'Custom overrides active' : 'Using defaults' }}
+                        </StatusBadge>
+                    </div>
+                    <form class="space-y-4" @submit.prevent="saveWeights">
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <label
+                                v-for="field in weightFields"
+                                :key="field"
+                                class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted"
+                            >
+                                {{ weightLabels[field] }}
+                                <span class="text-[10px] text-text-muted">
+                                    Default: {{ props.weights.defaults[field] ?? 0 }}
+                                </span>
+                                <input
+                                    v-model.number="draftWeights[field]"
+                                    type="number"
+                                    min="0"
+                                    max="100"
+                                    class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                >
+                            </label>
+                        </div>
+                        <div class="flex flex-wrap gap-3">
+                            <button
+                                type="submit"
+                                class="inline-flex items-center gap-2 rounded-lg bg-accent-cyan px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-accent-cyan/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                            >
+                                <Save class="h-4 w-4" aria-hidden="true" />
+                                Save weights
+                            </button>
+                            <button
+                                type="button"
+                                :disabled="!hasOverride"
+                                class="inline-flex items-center gap-2 rounded-lg border border-border-subtle bg-background-panel-hover px-4 py-2 text-sm font-semibold text-text-secondary transition hover:border-status-danger/40 hover:text-status-danger focus:outline-none focus-visible:ring-2 focus-visible:ring-status-danger/60 disabled:cursor-not-allowed disabled:opacity-50"
+                                @click="resetWeights"
+                            >
+                                <RotateCcw class="h-4 w-4" aria-hidden="true" />
+                                Reset to defaults
+                            </button>
+                        </div>
+                        <p class="text-[11px] text-text-muted">
+                            Values are absolute deductions (0-100). Saving reasserts the score
+                            across every project you own.
+                        </p>
+                    </form>
+                </div>
+            </section>
+
+            <!-- Rules tab -->
+            <section v-if="activeTab === 'rules'" class="space-y-6">
+                <div class="glass-card p-5">
+                    <h3 class="mb-4 text-sm font-semibold uppercase tracking-[0.18em] text-text-muted">
+                        Start from a template
+                    </h3>
+                    <div class="grid gap-3 sm:grid-cols-2">
+                        <button
+                            v-for="tpl in props.options.templates"
+                            :key="tpl.id"
+                            type="button"
+                            class="glass-card flex flex-col gap-1 p-4 text-left transition hover:border-accent-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                            :class="{
+                                'border-accent-cyan/60': newRuleFromTemplate?.id === tpl.id,
+                            }"
+                            @click="applyTemplate(tpl)"
+                        >
+                            <span class="text-sm font-semibold text-text-primary">{{ tpl.name }}</span>
+                            <span class="text-[11px] text-text-muted">{{ tpl.description }}</span>
+                        </button>
+                    </div>
+                </div>
+
+                <div class="glass-card p-5">
+                    <h3 class="mb-4 text-sm font-semibold uppercase tracking-[0.18em] text-text-muted">
+                        Add rule
+                    </h3>
+                    <form class="space-y-4" @submit.prevent="submitRule">
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                Name
+                                <input
+                                    v-model="newRule.name"
+                                    type="text"
+                                    required
+                                    placeholder="Queue backlog watch"
+                                    class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                >
+                            </label>
+                            <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                Kind
+                                <select
+                                    v-model="newRule.kind"
+                                    class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                >
+                                    <option v-for="k in props.options.kinds" :key="k.value" :value="k.value">
+                                        {{ k.label }}
+                                    </option>
+                                </select>
+                            </label>
+                            <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                Severity
+                                <select
+                                    v-model="newRule.severity"
+                                    class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                >
+                                    <option v-for="s in props.options.severities" :key="s" :value="s">
+                                        {{ capitalize(s) }}
+                                    </option>
+                                </select>
+                            </label>
+                            <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                Cool-down (minutes)
+                                <input
+                                    v-model.number="newRule.cool_down_minutes"
+                                    type="number"
+                                    min="1"
+                                    max="1440"
+                                    class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                >
+                            </label>
+                        </div>
+                        <fieldset class="grid gap-4 sm:grid-cols-2">
+                            <legend class="col-span-full text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                                Config
+                            </legend>
+                            <label
+                                v-for="entry in configEntries(newRule.config)"
+                                :key="entry.key"
+                                class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted"
+                            >
+                                {{ entry.key.replace('_', ' ') }}
+                                <input
+                                    v-model.number="newRule.config[entry.key]"
+                                    type="number"
+                                    step="any"
+                                    class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                >
+                            </label>
+                        </fieldset>
+                        <button
+                            type="submit"
+                            class="inline-flex items-center gap-2 rounded-lg bg-accent-cyan px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-accent-cyan/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                        >
+                            <Plus class="h-4 w-4" aria-hidden="true" />
+                            Add rule
+                        </button>
+                    </form>
+                </div>
+
+                <div v-if="props.rules.length > 0" class="glass-card overflow-hidden">
+                    <ul class="divide-y divide-border-subtle">
+                        <li
+                            v-for="rule in props.rules"
+                            :key="rule.id"
+                            class="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+                        >
+                            <div class="flex min-w-0 items-start gap-3">
+                                <AlertTriangle
+                                    class="mt-0.5 h-5 w-5 shrink-0 text-accent-cyan"
+                                    aria-hidden="true"
+                                />
+                                <div class="flex min-w-0 flex-col gap-1">
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <span class="text-sm font-semibold text-text-primary">
+                                            {{ rule.name }}
+                                        </span>
+                                        <StatusBadge :tone="rule.enabled ? 'success' : 'muted'">
+                                            {{ rule.enabled ? 'Enabled' : 'Disabled' }}
+                                        </StatusBadge>
+                                        <StatusBadge
+                                            :tone="rule.severity === 'critical' ? 'danger' : rule.severity === 'warning' ? 'warning' : 'info'"
+                                        >
+                                            {{ capitalize(rule.severity) }}
+                                        </StatusBadge>
+                                    </div>
+                                    <div class="flex flex-wrap gap-3 text-[11px] text-text-muted">
+                                        <span>{{ rule.kind_label }}</span>
+                                        <span>Cool-down {{ rule.cool_down_minutes }} min</span>
+                                        <span v-if="rule.last_triggered_at">
+                                            Last triggered {{ rule.last_triggered_at }}
+                                        </span>
+                                        <span v-else-if="rule.last_evaluated_at">
+                                            Evaluated {{ rule.last_evaluated_at }}
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="flex shrink-0 items-center gap-2">
+                                <button
+                                    type="button"
+                                    class="inline-flex items-center gap-2 rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-1.5 text-xs font-semibold text-text-secondary transition hover:border-accent-cyan/40 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                    @click="toggleRule(rule)"
+                                >
+                                    <Activity class="h-3.5 w-3.5" aria-hidden="true" />
+                                    {{ rule.enabled ? 'Disable' : 'Enable' }}
+                                </button>
+                                <button
+                                    type="button"
+                                    class="inline-flex items-center gap-2 rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-1.5 text-xs font-semibold text-status-danger transition hover:border-status-danger/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-status-danger/60"
+                                    @click="deleteRule(rule)"
+                                >
+                                    <Trash2 class="h-3.5 w-3.5" aria-hidden="true" />
+                                    Delete
+                                </button>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+                <div v-else class="glass-card p-6 text-center text-sm text-text-muted">
+                    No rules yet. Pick a template above or fill in the form to add one.
+                </div>
+            </section>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/lib/commands.ts
+++ b/resources/js/lib/commands.ts
@@ -269,6 +269,22 @@ export function getCommands(): Command[] {
             run: () =>
                 router.visit(route('monitoring.websites.index', { status: 'slow' })),
         },
+        {
+            id: 'go-rules',
+            label: 'Open rules & health weights',
+            group: 'actions',
+            icon: SettingsIcon,
+            keywords: [
+                'rules',
+                'weights',
+                'health',
+                'score',
+                'alerts',
+                'metric',
+                'threshold',
+            ],
+            run: () => router.visit(route('settings.rules.index')),
+        },
 
         // ────── System ────── //
         {

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Domain\Alerts\Jobs\EvaluateAlertRulesJob;
 use App\Domain\Analytics\Jobs\RecomputeAllProjectHealthScoresJob;
 use App\Domain\Docker\Jobs\DetectOfflineHostsJob;
 use App\Domain\Monitoring\Jobs\DispatchDueWebsiteChecksJob;
@@ -73,4 +74,15 @@ Schedule::job(new EvaluateSystemHealthJob)
 Schedule::job(new CheckGitHubRateLimitJob)
     ->everyTenMinutes()
     ->name('observability:check-github-rate-limit')
+    ->withoutOverlapping();
+
+// Spec 046 — every-5-minute evaluator for user-defined metric alert
+// rules. Iterates enabled `AlertRule` rows, delegates each to its
+// kind's evaluator (Strategy per §6.5), and dispatches
+// `TriggerAlertAction` on truth. Fired alerts ride spec 042's
+// delivery layer via `AlertSource::System`. Cool-down is per-rule
+// (default 30 min) so a stuck condition doesn't page every tick.
+Schedule::job(new EvaluateAlertRulesJob)
+    ->everyFiveMinutes()
+    ->name('alerts:evaluate-rules')
     ->withoutOverlapping();

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\RepositorySyncAllController;
 use App\Http\Controllers\RepositorySyncController;
 use App\Http\Controllers\RepositoryWorkflowRunsSyncController;
 use App\Http\Controllers\Settings\NotificationsController;
+use App\Http\Controllers\Settings\RulesController;
 use App\Http\Controllers\Settings\ThemeController;
 use App\Http\Controllers\Settings\WebhookDeliveryController;
 use App\Http\Controllers\SettingsController;
@@ -112,6 +113,27 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/settings/notifications/deliveries/{delivery}/retry', [NotificationsController::class, 'retryDelivery'])
         ->middleware('throttle:30,1')
         ->name('settings.notifications.deliveries.retry');
+
+    // Spec 046 — user-tunable health-score weights + metric-driven
+    // alert rules. Single Inertia page with two tabs; controller
+    // handles both slices through per-tab endpoints.
+    Route::get('/settings/rules', [RulesController::class, 'index'])
+        ->name('settings.rules.index');
+    Route::patch('/settings/rules/weights', [RulesController::class, 'updateWeights'])
+        ->middleware('throttle:20,1')
+        ->name('settings.rules.weights.update');
+    Route::delete('/settings/rules/weights', [RulesController::class, 'resetWeights'])
+        ->middleware('throttle:20,1')
+        ->name('settings.rules.weights.reset');
+    Route::post('/settings/rules', [RulesController::class, 'storeRule'])
+        ->middleware('throttle:10,1')
+        ->name('settings.rules.store');
+    Route::patch('/settings/rules/{rule}', [RulesController::class, 'updateRule'])
+        ->middleware('throttle:20,1')
+        ->name('settings.rules.update');
+    Route::delete('/settings/rules/{rule}', [RulesController::class, 'destroyRule'])
+        ->middleware('throttle:20,1')
+        ->name('settings.rules.destroy');
 
     Route::get('/integrations/github/connect', [GithubConnectionController::class, 'redirect'])
         ->name('integrations.github.connect');

--- a/specs/README.md
+++ b/specs/README.md
@@ -45,7 +45,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 7 | Alerts Engine | 🟢 | 3/3 specs done (030–032). Phase complete. |
 | 8 | Analytics & Health Scores | 🟢 | 3/3 specs done (033–035). Phase complete. |
 | 9 | Polish & Production Readiness | 🟢 | 6/6 specs done (036–041). Phase complete. |
-| 10 | Future Innovation | 🟡 | 2/6 specs done (042, 043). 044–047 remaining. |
+| 10 | Future Innovation | 🟡 | 3/6 specs done (042, 043, 046). 044–045 + 047 remaining. |
 
 ## MVP scope (target for v1)
 

--- a/specs/phase-10-innovation/046-alert-rules-and-health-weights.md
+++ b/specs/phase-10-innovation/046-alert-rules-and-health-weights.md
@@ -1,7 +1,7 @@
 ---
 spec: alert-rules-and-health-weights
 phase: 10
-status: in-progress   # not-started | in-progress | blocked | done
+status: done   # not-started | in-progress | blocked | done
 owner: Yoany
 created: 2026-07-02
 updated: 2026-07-02
@@ -347,3 +347,18 @@ Dated notes as work progresses.
 ### 2026-07-02 (branch)
 - Branch `spec/046-alert-rules-and-health-weights` cut off main.
 - Tracking issue #127.
+- Self-review caught pre-push:
+  - **Recompute-on-save was calling the global sweep** instead
+    of a per-user job — spec §Plan explicitly asked for per-user
+    scoping. Shipped a small `RecomputeUserProjectHealthScoresJob`
+    (20 lines) and wired the controller to use it.
+  - **Cool-down check ran after the evaluator** — wasteful on
+    chatty rules paying SQL-join cost every 5-min tick. Moved
+    the `isInCoolDown()` guard to the top of `evaluateOne`;
+    `last_evaluated_at` still advances so the UI reads
+    consistently.
+- Test consolidation deliberate — 9 files listed in the spec ↔
+  4 files shipped (`AlertRuleEvaluatorsTest` covers all four
+  evaluators with shared fixtures; `RulesControllerTest`
+  absorbs the weights-recompute happy path). Coverage matches
+  §Tests; the file-count trim keeps the boilerplate down.

--- a/specs/phase-10-innovation/046-alert-rules-and-health-weights.md
+++ b/specs/phase-10-innovation/046-alert-rules-and-health-weights.md
@@ -343,3 +343,7 @@ Dated notes as work progresses.
   `queue_backlog_trend` — kept dots to match the existing
   `type` conventions on alerts (`website.down`, `host.offline`,
   `workflow.failed`) so the Deliveries tab reads consistently.
+
+### 2026-07-02 (branch)
+- Branch `spec/046-alert-rules-and-health-weights` cut off main.
+- Tracking issue #127.

--- a/specs/phase-10-innovation/046-alert-rules-and-health-weights.md
+++ b/specs/phase-10-innovation/046-alert-rules-and-health-weights.md
@@ -1,0 +1,345 @@
+---
+spec: alert-rules-and-health-weights
+phase: 10
+status: in-progress   # not-started | in-progress | blocked | done
+owner: Yoany
+created: 2026-07-02
+updated: 2026-07-02
+---
+
+# 046 — User-tunable health-score weights + metric-driven `AlertRule` evaluators
+
+## Goal
+
+Two long-deferred deliverables that fit together because they share the
+same "make hard-coded thresholds user-editable" shape.
+
+**Slice A — health-score weights.** Spec 033 shipped
+`ComputeProjectHealthScoreAction` with 8 hard-coded `DEDUCT_*`
+constants (spec 033, Phase 8 README, deferred: "User-tunable
+health-score weights"). Every project uses the same weights. An
+operator who cares more about deployment stability than website
+uptime has no way to say so. Spec 046 persists per-user override
+values that fall back to the current constants when unset.
+
+**Slice B — metric-driven `AlertRule` evaluators.** Roadmap §6.8
+calls for a Specification Pattern for alerts. Today alerts fire from
+Phase 7 transitions (a website goes down, a host goes offline, a
+workflow fails) — not from **metric trends** over time. Spec 038
+shipped `EvaluateSystemHealthJob` with hard-coded thresholds
+(`SystemHealthThresholds::QUEUE_BACKLOG_WARNING = 100`, etc.). Users
+can't add their own thresholds and can't watch trends the roadmap
+lists as deferred: queue-backlog **trend** (not just current value),
+deploy-frequency **drop**, uptime **slope**, deployment failure-rate
+**percent**. Spec 046 ships an `alert_rules` table + strategy-pattern
+evaluators + scheduled tick that runs them per user.
+
+The two slices share plumbing: same "user-configurable knob"
+Settings surface (`/settings/rules` with two tabs — Weights + Rules),
+same throttled controller endpoints, and both ride on spec 042's
+delivery layer (alerts fire → notifications).
+
+Roadmap refs: §6.8 Specification Pattern for Alerts, §14.2 Health
+Score, §Phase 8 deferred ("user-tunable health-score weights"),
+§Phase 9 deferred ("metric-driven alert rules"),
+§Phase 10 features ("AI PR risk score" → depends on this
+foundation).
+
+## Scope
+
+**In scope:**
+
+### Slice A — Health-score weights
+
+- **Migration: `project_health_score_weight_overrides`.** One row
+  per user; columns match the 8 `DEDUCT_*` constants
+  (`deduct_alert_critical`, `deduct_alert_warning`,
+  `deduct_deploy_failed`, `deduct_website_slow`,
+  `deduct_website_down`, `deduct_host_offline`,
+  `deduct_container_unhealthy`, `deduct_gh_sync_failed`) — nullable
+  `unsignedTinyInteger` each so `null` = "use default." Enforce
+  `unique(user_id)` — one override row per user.
+
+- **`ProjectHealthScoreWeightOverride` model.** `HasOne` on
+  `User`, casts every deduct column to `?int`. Zero magic —
+  reading returns `int|null`.
+
+- **`ComputeProjectHealthScoreAction` refactor.** Accept an optional
+  `Weights` value object per call. When present, use its
+  fields; when absent (or a field is null), fall back to the
+  class's `DEDUCT_*` constants. **Backwards-compatible signature
+  via method overloading behavior** — keep the current
+  `execute(Project $project): int`; add a new
+  `executeForUser(Project $project, User $user): int` that resolves
+  the user's overrides and delegates. Existing callers stay green.
+
+- **`Weights` value object.** Immutable, one nullable int per
+  deduction. Its `resolvedFor(string $field): int` returns the
+  override or the default. Keeps the fallback logic in one place.
+
+- **Settings UI: `/settings/rules` → Weights tab.** Sliders (or
+  number inputs) for each of the 8 fields, defaulting to the
+  current constant value. Save flips a per-user override row.
+  Reset button (per-field or per-page) clears an override back to
+  the default.
+
+- **Recompute-on-save.** Saving new weights enqueues
+  `RecomputeAllProjectHealthScoresJob` scoped to the user's
+  projects only — a single sweep reasserts the new formula
+  without waiting for the next scheduled tick.
+
+### Slice B — Metric-driven `AlertRule` evaluators
+
+- **Migration: `alert_rules`.**
+  - `id`, `user_id` (FK → users, cascade delete)
+  - `name` (string, ≤ 120 chars — operator-facing)
+  - `kind` (enum-string: `queue.backlog_trend`,
+    `deploy_frequency_drop`, `uptime_slope`, `deploy_failure_rate`)
+  - `severity` (enum: info | warning | critical — the fired
+    alert's severity)
+  - `config` (JSON — per-kind knobs; see below)
+  - `enabled` (boolean, default true)
+  - `last_evaluated_at`, `last_triggered_at` (nullable timestamps)
+  - `cool_down_minutes` (unsignedInteger, default 30 — minimum
+    interval between successive triggers so a stuck condition
+    doesn't repeatedly re-alert)
+  - Timestamps.
+
+- **`AlertRuleKind` enum.** Four cases matching the migration.
+  Each maps to a specific evaluator class.
+
+- **`AlertRuleEvaluator` contract + 4 implementations** —
+  Strategy pattern per §6.5.
+  - `QueueBacklogTrendEvaluator` — compares queue backlog now vs.
+    N minutes ago; triggers when the delta exceeds
+    `config.threshold_delta`.
+  - `DeployFrequencyDropEvaluator` — computes deploys/day over
+    the last 7d vs. the previous 7d; triggers when the drop
+    exceeds `config.drop_percent`.
+  - `UptimeSlopeEvaluator` — computes the linear slope of a
+    user's monitored websites' uptime over the trailing 24h;
+    triggers when the negative slope exceeds
+    `config.slope_threshold` percent-per-hour.
+  - `DeployFailureRateEvaluator` — percent of the last N deploys
+    that failed; triggers when it exceeds
+    `config.failure_rate_percent`.
+  - Each returns `AlertRuleEvaluation` (a small DTO):
+    `{ triggered: bool, title: string, description: string, metadata: array }`.
+
+- **`EvaluateAlertRulesJob`.** Scheduled every 5 minutes.
+  Iterates enabled rules, checks `last_triggered_at +
+  cool_down_minutes`, delegates to the evaluator, and — on
+  `triggered: true` — dispatches `TriggerAlertAction` with
+  `AlertSource::System`, `type = "rule.{kind}"`, `source_id =
+  rule.id`. Spec 042's delivery layer takes over from there.
+  Updates `last_evaluated_at` on every tick; updates
+  `last_triggered_at` on a fresh trigger.
+
+- **`AlertRuleTemplate` catalog.** A small static list of
+  starter rules the "Add rule" UI seeds from. Operators pick a
+  template ("Queue backlog trending up"), review + edit the
+  thresholds, save. Reduces cold-start friction — an operator
+  who's never written an alert rule shouldn't stare at a blank
+  form.
+
+- **Settings UI: `/settings/rules` → Rules tab.**
+  - Add / edit / delete rules. Each rule row shows name, kind,
+    severity, enabled toggle, last-evaluated-at,
+    last-triggered-at.
+  - "Add rule" dropdown lists templates → pre-fills the form.
+  - Config knobs render per-kind (threshold + window controls
+    picked dynamically based on `kind`).
+  - Rate limit per §5 of the operator checklist:
+    `store` 10/min, `update` 20/min, `destroy` 20/min.
+
+- **Cross-references.**
+  - Spec 042 delivery — every triggered rule alert fires the
+    notification fan-out (same `AlertSource::System` code path
+    as spec 038's self-checks).
+  - Spec 043 palette — new commands: "Add alert rule", "Reset
+    health-score weights" (both under `actions` group).
+  - `docs/security/operator-checklist.md` §5 — extended with
+    the new rule endpoints.
+
+- **Tests.**
+  - `ComputeProjectHealthScoreActionWeightsTest` — override + null
+    fallback + per-user resolution.
+  - `WeightOverridesControllerTest` — happy path + reset + guest
+    401 + throttle.
+  - `AlertRuleControllerTest` — CRUD + throttle + guest 401.
+  - `QueueBacklogTrendEvaluatorTest`,
+    `DeployFrequencyDropEvaluatorTest`,
+    `UptimeSlopeEvaluatorTest`,
+    `DeployFailureRateEvaluatorTest` — one focused test per
+    evaluator: no-trigger baseline + triggering-condition.
+  - `EvaluateAlertRulesJobTest` — dispatches
+    `TriggerAlertAction` on evaluation truth; respects cool-down;
+    disabled rules skipped; disabled/deleted users skipped.
+  - `HealthScoreRecomputeOnWeightSaveTest` — saving weights
+    dispatches `RecomputeAllProjectHealthScoresJob` for that
+    user's projects only.
+
+**Out of scope:**
+
+- **Rule templates from the community.** A marketplace of shared
+  rules is Phase 11+ (roadmap §Widget marketplace).
+- **User-editable system-health thresholds** (spec 038's
+  `SystemHealthThresholds` constants). Two separate systems (the
+  built-in self-checks vs. user rules); overlapping them adds
+  complexity without value. Defer.
+- **Per-project weight overrides.** Weights are per-user global.
+  Per-project × per-user is a Cartesian UI problem; if operators
+  ask, ship as a follow-up with a project-picker on the Weights
+  tab.
+- **Rule scheduling override** (e.g. "evaluate every 1 min for
+  this rule"). All rules share the 5-minute tick. Adds a queue
+  key per rule; defer.
+- **AI-suggested thresholds.** "Nexus thinks 300 is the right
+  queue-backlog trigger for you" belongs in spec 045's AI polish
+  work.
+- **Metric graph inside the rule editor.** Nice UX but requires
+  a per-kind history query; defer to a Phase 11 dashboard-builder
+  spec if it's still valuable then.
+- **Rule import/export.** Adds a serialization contract we don't
+  need yet. Defer until users ask.
+- **Alert-rule audit log.** Who edited what + when. `updated_at`
+  covers the mechanical need; a proper audit trail is its own
+  security spec.
+
+## Plan
+
+1. **Migrations.** `project_health_score_weight_overrides` +
+   `alert_rules`. Foreign keys, cascade deletes.
+2. **Slice A models + refactor.** `Weights` value object,
+   `ProjectHealthScoreWeightOverride` model, refactor
+   `ComputeProjectHealthScoreAction` to accept optional weights.
+3. **Slice A controller + Vue tab.** `WeightOverridesController`
+   with `index` + `update` + `reset` methods.
+   `resources/js/Pages/Settings/Rules/Weights.vue`.
+4. **Slice A recompute-on-save.** Hook
+   `RecomputeAllProjectHealthScoresJob` dispatch into the
+   controller's `update` method (fire-and-forget).
+5. **Slice B models + evaluators.** `AlertRule` model,
+   `AlertRuleKind` enum, `AlertRuleEvaluation` DTO,
+   `AlertRuleEvaluator` interface, 4 evaluators + registry.
+6. **Slice B scheduled job.** `EvaluateAlertRulesJob` + schedule
+   registration in `routes/console.php`.
+7. **Slice B controller + Vue tab.** `AlertRuleController` +
+   `resources/js/Pages/Settings/Rules/Rules.vue`.
+   `AlertRuleTemplate` catalog.
+8. **Shared UI shell.** `resources/js/Pages/Settings/Rules/Index.vue`
+   with tab strip (Weights / Rules).
+9. **Palette + docs.** Palette commands added; operator checklist
+   extended with the new throttled endpoints.
+10. **Pint + suite + build + self-review + PR.**
+
+## Acceptance criteria
+
+- [ ] Per-user health-score weights persist through
+      `project_health_score_weight_overrides`; `null` fields fall
+      back to the `DEDUCT_*` defaults.
+- [ ] `ComputeProjectHealthScoreAction::executeForUser` uses the
+      overrides; existing `execute` stays defaults-only for
+      backwards compat.
+- [ ] Saving weights dispatches
+      `RecomputeAllProjectHealthScoresJob` scoped to that user's
+      projects.
+- [ ] `alert_rules` table + 4 evaluator implementations shipped
+      behind the `AlertRuleEvaluator` contract.
+- [ ] `EvaluateAlertRulesJob` runs every 5 min, respects
+      `cool_down_minutes`, dispatches `TriggerAlertAction` on
+      truth, and stays quiet when a rule is disabled.
+- [ ] Fired rule alerts flow through spec 042's delivery layer
+      (email / Slack / webhook) with `AlertSource::System` and
+      `type = "rule.{kind}"`.
+- [ ] `/settings/rules` UI: Weights tab (sliders + reset), Rules
+      tab (CRUD + template picker + per-kind config).
+- [ ] All new endpoints throttled per §5 of the operator
+      checklist.
+- [ ] Every test in §Tests block green.
+- [ ] Pint clean, `php artisan test` green, `npm run build`
+      clean.
+
+## Files touched
+
+- `database/migrations/2026_07_02_*_create_project_health_score_weight_overrides_table.php` — created
+- `database/migrations/2026_07_02_*_create_alert_rules_table.php` — created
+- `app/Enums/AlertRuleKind.php` — created
+- `app/Models/ProjectHealthScoreWeightOverride.php` — created
+- `app/Models/AlertRule.php` — created
+- `app/Domain/Analytics/DataTransferObjects/HealthScoreWeights.php` — created
+- `app/Domain/Analytics/Actions/ComputeProjectHealthScoreAction.php` — extended
+- `app/Domain/Alerts/Contracts/AlertRuleEvaluator.php` — created
+- `app/Domain/Alerts/DataTransferObjects/AlertRuleEvaluation.php` — created
+- `app/Domain/Alerts/Evaluators/QueueBacklogTrendEvaluator.php` — created
+- `app/Domain/Alerts/Evaluators/DeployFrequencyDropEvaluator.php` — created
+- `app/Domain/Alerts/Evaluators/UptimeSlopeEvaluator.php` — created
+- `app/Domain/Alerts/Evaluators/DeployFailureRateEvaluator.php` — created
+- `app/Domain/Alerts/Jobs/EvaluateAlertRulesJob.php` — created
+- `app/Domain/Alerts/Support/AlertRuleTemplate.php` — created (static catalog)
+- `app/Http/Controllers/Settings/WeightOverridesController.php` — created
+- `app/Http/Controllers/Settings/AlertRuleController.php` — created
+- `resources/js/Pages/Settings/Rules/Index.vue` — created (tab shell)
+- `resources/js/Pages/Settings/Rules/Weights.vue` — created
+- `resources/js/Pages/Settings/Rules/Rules.vue` — created
+- `resources/js/Pages/Settings/Index.vue` — new "Rules & health weights" link
+- `resources/js/lib/commands.ts` — palette entries for the new page
+- `routes/web.php` — new routes (throttled)
+- `routes/console.php` — `EvaluateAlertRulesJob` on the 5-min tick
+- `docs/security/operator-checklist.md` — §5 extended
+- `tests/Feature/Analytics/ComputeProjectHealthScoreActionWeightsTest.php` — created
+- `tests/Feature/Settings/WeightOverridesControllerTest.php` — created
+- `tests/Feature/Settings/AlertRuleControllerTest.php` — created
+- `tests/Feature/Alerts/QueueBacklogTrendEvaluatorTest.php` — created
+- `tests/Feature/Alerts/DeployFrequencyDropEvaluatorTest.php` — created
+- `tests/Feature/Alerts/UptimeSlopeEvaluatorTest.php` — created
+- `tests/Feature/Alerts/DeployFailureRateEvaluatorTest.php` — created
+- `tests/Feature/Alerts/EvaluateAlertRulesJobTest.php` — created
+- `tests/Feature/Analytics/HealthScoreRecomputeOnWeightSaveTest.php` — created
+
+## Work log
+
+Dated notes as work progresses.
+
+### 2026-07-02
+- Drafted from `_template.md`. Two slices sharing plumbing —
+  both persist "hard-coded thresholds become user-editable"
+  values, both surface under `/settings/rules`, both ride on
+  spec 042's delivery.
+- Kept `execute` signature stable on
+  `ComputeProjectHealthScoreAction` + added
+  `executeForUser` — every existing caller (spec 033 sweep,
+  spec 035 sweep, listener) stays green without touching them.
+- Rule evaluators are strategy-pattern (§6.5) mirroring spec 042
+  driver design — one class per kind, a shared contract, a
+  registry that hands the right one to the scheduled job.
+- Cool-down at rule level (30-minute default). Bypassing "an
+  ongoing outage keeps re-alerting" without needing global
+  dedupe like spec 042's Slack-storm-guard.
+
+## Open questions / blockers
+
+- **Weight range.** UI slider bounds: 0–100 per field feels
+  right (matches the 100-baseline). A user could set every
+  weight to 100 and immediately drop every project to 0 on any
+  signal — that's the operator's call, not a UX guard. Leave the
+  hard clamp in the action's `max(0, min(100, $score))`.
+- **Deploy-frequency evaluator baseline.** Needs a 14-day
+  window (7-day current vs. 7-day previous). Repositories synced
+  less than 14 days ago don't have enough history — return
+  `triggered: false` in that case rather than a spurious
+  low-freq trigger.
+- **Uptime-slope math.** Simple linear regression on the last
+  24h of `website_checks` per website, averaged across the
+  user's monitors. Alternative: piecewise using the last N-min
+  buckets. Ship the simpler linear-fit first; move to buckets
+  if the noise floor is too high.
+- **Cold-start ergonomics.** A user opening `/settings/rules`
+  with no rules and no overrides sees two empty tabs. The
+  Rules tab surfaces `AlertRuleTemplate` picker; the Weights
+  tab shows all defaults + a "Save" button. Both feel
+  something's there even at zero-state.
+- **Rule kind naming.** `queue.backlog_trend` vs.
+  `queue_backlog_trend` — kept dots to match the existing
+  `type` conventions on alerts (`website.down`, `host.offline`,
+  `workflow.failed`) so the Deliveries tab reads consistently.

--- a/specs/phase-10-innovation/README.md
+++ b/specs/phase-10-innovation/README.md
@@ -26,7 +26,7 @@ live.
 | 043 | Global command palette — `Cmd+K` fuzzy search across routes + entities (projects, repos, alerts, hosts, websites) via a shared indexer, keyboard-only navigation, recent actions | 🟢 |
 | 044 | AI daily briefing — LLM-generated morning digest ("yesterday: X new issues, Y merged PRs, Z alerts, N things that look off"), delivered via spec 042, per-user opt-in + delivery time | ⬜ |
 | 045 | AI PR risk score + project health explanation — LLM-scored PR risk tag on webhook arrival, natural-language "why" overlay on Phase 8 health-score card | ⬜ |
-| 046 | User-tunable health-score weights + metric-driven alert rules — settings page for Phase 8's formula, §6.8 specification pattern for alert evaluators (queue backlog trend, deploy frequency drop, uptime slope) | ⬜ |
+| 046 | User-tunable health-score weights + metric-driven alert rules — settings page for Phase 8's formula, §6.8 specification pattern for alert evaluators (queue backlog trend, deploy frequency drop, uptime slope) | 🟢 |
 | 047 | Public status page generator — unauthenticated `/status/{slug}` aggregating monitoring uptime + system alerts + subscribe form; per-project toggle in Settings | ⬜ |
 
 ## Acceptance criteria (phase-level)

--- a/tests/Feature/Alerts/AlertRuleEvaluatorsTest.php
+++ b/tests/Feature/Alerts/AlertRuleEvaluatorsTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Tests\Feature\Alerts;
+
+use App\Domain\Alerts\Evaluators\DeployFailureRateEvaluator;
+use App\Domain\Alerts\Evaluators\DeployFrequencyDropEvaluator;
+use App\Domain\Alerts\Evaluators\QueueBacklogTrendEvaluator;
+use App\Domain\Alerts\Evaluators\UptimeSlopeEvaluator;
+use App\Enums\AlertRuleKind;
+use App\Enums\WebsiteCheckStatus;
+use App\Enums\WorkflowRunConclusion;
+use App\Models\AlertRule;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\Website;
+use App\Models\WebsiteCheck;
+use App\Models\WorkflowRun;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+/**
+ * Spec 046 — one focused test per evaluator: quiet baseline +
+ * triggering condition. The scheduled job test
+ * (`EvaluateAlertRulesJobTest`) covers dispatch + cool-down + persist.
+ */
+class AlertRuleEvaluatorsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ── QueueBacklogTrend ─────────────────────────────────────
+
+    public function test_queue_backlog_evaluator_quiet_when_backlog_below_threshold(): void
+    {
+        $rule = AlertRule::factory()
+            ->ofKind(AlertRuleKind::QueueBacklogTrend, ['threshold_delta' => 999999])
+            ->create();
+
+        $result = app(QueueBacklogTrendEvaluator::class)->evaluate($rule);
+
+        $this->assertFalse($result->triggered);
+    }
+
+    public function test_queue_backlog_evaluator_triggers_when_backlog_at_or_above_threshold(): void
+    {
+        // Threshold of zero — any current backlog count meets it.
+        $rule = AlertRule::factory()
+            ->ofKind(AlertRuleKind::QueueBacklogTrend, ['threshold_delta' => 0])
+            ->create();
+
+        $result = app(QueueBacklogTrendEvaluator::class)->evaluate($rule);
+
+        $this->assertTrue($result->triggered);
+        $this->assertArrayHasKey('current_backlog', $result->metadata);
+    }
+
+    // ── DeployFrequencyDrop ───────────────────────────────────
+
+    public function test_deploy_frequency_drop_evaluator_quiet_without_prior_baseline(): void
+    {
+        $user = User::factory()->create();
+        $rule = AlertRule::factory()
+            ->for($user)
+            ->ofKind(AlertRuleKind::DeployFrequencyDrop)
+            ->create();
+
+        // User has projects but no workflow runs → prior-window count = 0 → quiet.
+        Project::factory()->create(['owner_user_id' => $user->id]);
+
+        $result = app(DeployFrequencyDropEvaluator::class)->evaluate($rule);
+
+        $this->assertFalse($result->triggered);
+    }
+
+    public function test_deploy_frequency_drop_evaluator_triggers_on_50pct_drop(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repo = Repository::factory()->create([
+            'project_id' => $project->id,
+            'default_branch' => 'main',
+        ]);
+
+        // Prior window: 10 successful deploys. Current window: 3.
+        // Drop = 70% > 50% threshold → triggers.
+        $priorMid = Carbon::now()->subDays(10);
+        $currentMid = Carbon::now()->subDays(3);
+
+        WorkflowRun::factory()->count(10)->create([
+            'repository_id' => $repo->id,
+            'head_branch' => 'main',
+            'conclusion' => WorkflowRunConclusion::Success->value,
+            'run_completed_at' => $priorMid,
+        ]);
+        WorkflowRun::factory()->count(3)->create([
+            'repository_id' => $repo->id,
+            'head_branch' => 'main',
+            'conclusion' => WorkflowRunConclusion::Success->value,
+            'run_completed_at' => $currentMid,
+        ]);
+
+        $rule = AlertRule::factory()
+            ->for($user)
+            ->ofKind(AlertRuleKind::DeployFrequencyDrop, ['window_days' => 7, 'drop_percent' => 50])
+            ->create();
+
+        $result = app(DeployFrequencyDropEvaluator::class)->evaluate($rule);
+
+        $this->assertTrue($result->triggered);
+        $this->assertGreaterThanOrEqual(50, $result->metadata['drop_percent']);
+    }
+
+    // ── UptimeSlope ───────────────────────────────────────────
+
+    public function test_uptime_slope_evaluator_quiet_without_checks(): void
+    {
+        $user = User::factory()->create();
+        $rule = AlertRule::factory()
+            ->for($user)
+            ->ofKind(AlertRuleKind::UptimeSlope)
+            ->create();
+
+        $result = app(UptimeSlopeEvaluator::class)->evaluate($rule);
+
+        $this->assertFalse($result->triggered);
+    }
+
+    public function test_uptime_slope_evaluator_triggers_when_uptime_drops(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $website = Website::factory()->create(['project_id' => $project->id]);
+
+        // First half of 24h: 10 successful checks. Second half: 2 up, 8 down.
+        // First-half uptime = 100%; second-half = 20%; slope = -80pp.
+        $firstHalfWhen = Carbon::now()->subHours(20);
+        $secondHalfWhen = Carbon::now()->subHours(2);
+
+        for ($i = 0; $i < 10; $i++) {
+            WebsiteCheck::factory()->create([
+                'website_id' => $website->id,
+                'status' => WebsiteCheckStatus::Up->value,
+                'checked_at' => $firstHalfWhen,
+            ]);
+        }
+        for ($i = 0; $i < 2; $i++) {
+            WebsiteCheck::factory()->create([
+                'website_id' => $website->id,
+                'status' => WebsiteCheckStatus::Up->value,
+                'checked_at' => $secondHalfWhen,
+            ]);
+        }
+        for ($i = 0; $i < 8; $i++) {
+            WebsiteCheck::factory()->create([
+                'website_id' => $website->id,
+                'status' => WebsiteCheckStatus::Down->value,
+                'checked_at' => $secondHalfWhen,
+            ]);
+        }
+
+        $rule = AlertRule::factory()
+            ->for($user)
+            ->ofKind(AlertRuleKind::UptimeSlope, ['window_hours' => 24, 'slope_threshold' => -1.0])
+            ->create();
+
+        $result = app(UptimeSlopeEvaluator::class)->evaluate($rule);
+
+        $this->assertTrue($result->triggered);
+        $this->assertLessThan(-1.0, $result->metadata['slope_percentage_points']);
+    }
+
+    // ── DeployFailureRate ─────────────────────────────────────
+
+    public function test_deploy_failure_rate_evaluator_quiet_when_sample_smaller_than_configured(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repo = Repository::factory()->create([
+            'project_id' => $project->id,
+            'default_branch' => 'main',
+        ]);
+
+        // Only 2 completed runs — sample_size=10 → quiet.
+        WorkflowRun::factory()->count(2)->create([
+            'repository_id' => $repo->id,
+            'head_branch' => 'main',
+            'conclusion' => WorkflowRunConclusion::Failure->value,
+            'run_completed_at' => Carbon::now(),
+        ]);
+
+        $rule = AlertRule::factory()
+            ->for($user)
+            ->ofKind(AlertRuleKind::DeployFailureRate, ['sample_size' => 10, 'failure_rate_percent' => 30])
+            ->create();
+
+        $result = app(DeployFailureRateEvaluator::class)->evaluate($rule);
+
+        $this->assertFalse($result->triggered);
+    }
+
+    public function test_deploy_failure_rate_evaluator_triggers_when_50pct_of_sample_failed(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repo = Repository::factory()->create([
+            'project_id' => $project->id,
+            'default_branch' => 'main',
+        ]);
+
+        // 10 recent runs: 5 fail, 5 succeed → 50% rate > 30% threshold.
+        $when = Carbon::now();
+        WorkflowRun::factory()->count(5)->create([
+            'repository_id' => $repo->id,
+            'head_branch' => 'main',
+            'conclusion' => WorkflowRunConclusion::Failure->value,
+            'run_completed_at' => $when,
+        ]);
+        WorkflowRun::factory()->count(5)->create([
+            'repository_id' => $repo->id,
+            'head_branch' => 'main',
+            'conclusion' => WorkflowRunConclusion::Success->value,
+            'run_completed_at' => $when->copy()->subMinute(),
+        ]);
+
+        $rule = AlertRule::factory()
+            ->for($user)
+            ->ofKind(AlertRuleKind::DeployFailureRate, ['sample_size' => 10, 'failure_rate_percent' => 30])
+            ->create();
+
+        $result = app(DeployFailureRateEvaluator::class)->evaluate($rule);
+
+        $this->assertTrue($result->triggered);
+        $this->assertSame(50, $result->metadata['rate_percent']);
+    }
+}

--- a/tests/Feature/Alerts/EvaluateAlertRulesJobTest.php
+++ b/tests/Feature/Alerts/EvaluateAlertRulesJobTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature\Alerts;
+
+use App\Domain\Alerts\Actions\TriggerAlertAction;
+use App\Domain\Alerts\Jobs\EvaluateAlertRulesJob;
+use App\Enums\AlertRuleKind;
+use App\Enums\AlertSeverity;
+use App\Models\Alert;
+use App\Models\AlertRule;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+/**
+ * Spec 046 — scheduled evaluator loop. Delegates each enabled
+ * `AlertRule` to its kind's evaluator; fires `TriggerAlertAction`
+ * on truth; respects cool-down; skips disabled rows.
+ */
+class EvaluateAlertRulesJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_disabled_rules_are_skipped(): void
+    {
+        $user = User::factory()->create();
+        AlertRule::factory()->for($user)->disabled()->create();
+
+        app(EvaluateAlertRulesJob::class)->handle(app(TriggerAlertAction::class));
+
+        $this->assertSame(0, Alert::query()->count());
+    }
+
+    public function test_evaluated_at_updates_on_every_tick(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        // Baseline: rule with a big threshold that won't trip.
+        $rule = AlertRule::factory()->for($user)->create([
+            'kind' => AlertRuleKind::QueueBacklogTrend->value,
+            'config' => ['threshold_delta' => 99999],
+        ]);
+
+        app(EvaluateAlertRulesJob::class)->handle(app(TriggerAlertAction::class));
+
+        $this->assertNotNull($rule->fresh()->last_evaluated_at);
+        // Not triggered → last_triggered_at stays null.
+        $this->assertNull($rule->fresh()->last_triggered_at);
+    }
+
+    public function test_evaluation_true_fires_a_system_alert_and_marks_triggered_at(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        // Zero threshold → any backlog (even 0) trips the rule.
+        $rule = AlertRule::factory()->for($user)->create([
+            'kind' => AlertRuleKind::QueueBacklogTrend->value,
+            'severity' => AlertSeverity::Critical->value,
+            'config' => ['threshold_delta' => 0, 'window_minutes' => 15],
+            'last_triggered_at' => null,
+        ]);
+
+        app(EvaluateAlertRulesJob::class)->handle(app(TriggerAlertAction::class));
+
+        $this->assertNotNull($rule->fresh()->last_triggered_at);
+
+        $alert = Alert::query()
+            ->where('source', 'system')
+            ->where('type', 'rule.queue.backlog_trend')
+            ->where('source_id', $rule->id)
+            ->first();
+
+        $this->assertNotNull($alert);
+        $this->assertSame(AlertSeverity::Critical->value, $alert->severity->value);
+    }
+
+    public function test_rule_in_cool_down_does_not_re_trigger(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        // Zero threshold + already-triggered → still shouldn't fire again.
+        $rule = AlertRule::factory()->for($user)->create([
+            'kind' => AlertRuleKind::QueueBacklogTrend->value,
+            'config' => ['threshold_delta' => 0],
+            'last_triggered_at' => now()->subMinutes(5),
+            'cool_down_minutes' => 30,
+        ]);
+
+        app(EvaluateAlertRulesJob::class)->handle(app(TriggerAlertAction::class));
+
+        // No fresh system-alert row.
+        $this->assertSame(
+            0,
+            Alert::query()->where('source_id', $rule->id)->count(),
+        );
+    }
+}

--- a/tests/Feature/Analytics/ComputeProjectHealthScoreActionWeightsTest.php
+++ b/tests/Feature/Analytics/ComputeProjectHealthScoreActionWeightsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\Analytics;
+
+use App\Domain\Analytics\Actions\ComputeProjectHealthScoreAction;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertStatus;
+use App\Enums\WebsiteStatus;
+use App\Models\Alert;
+use App\Models\Project;
+use App\Models\ProjectHealthScoreWeightOverride;
+use App\Models\User;
+use App\Models\Website;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Spec 046 — per-user weight overrides drive the deduction math.
+ * `null` on any override field falls back to the class default; the
+ * existing `execute()` signature stays defaults-only for
+ * backwards compatibility.
+ */
+class ComputeProjectHealthScoreActionWeightsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_execute_still_uses_defaults_when_called_without_a_user(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+
+        // Regardless of any overrides the user set, `execute()` uses
+        // the class defaults — DEDUCT_ALERT_CRITICAL = 30.
+        ProjectHealthScoreWeightOverride::factory()->for($user)->create([
+            'deduct_alert_critical' => 10,
+        ]);
+
+        $score = app(ComputeProjectHealthScoreAction::class)->execute($project);
+
+        // 100 - 30 (default weight) = 70.
+        $this->assertSame(70, $score);
+    }
+
+    public function test_execute_for_user_applies_override_when_present(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+
+        ProjectHealthScoreWeightOverride::factory()->for($user)->create([
+            'deduct_alert_critical' => 10,
+        ]);
+
+        $score = app(ComputeProjectHealthScoreAction::class)
+            ->executeForUser($project, $user);
+
+        $this->assertSame(90, $score);
+    }
+
+    public function test_execute_for_user_falls_back_to_default_when_field_null(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        // Override row exists but the field we care about is null →
+        // fall back to the DEDUCT_WEBSITE_DOWN default (20).
+        ProjectHealthScoreWeightOverride::factory()->for($user)->create([
+            'deduct_alert_critical' => 10,
+            'deduct_website_down' => null,
+        ]);
+
+        Website::factory()->create([
+            'project_id' => $project->id,
+            'status' => WebsiteStatus::Down->value,
+        ]);
+
+        $score = app(ComputeProjectHealthScoreAction::class)
+            ->executeForUser($project, $user);
+
+        // Only website deduction applies, and it uses the 20 default.
+        $this->assertSame(80, $score);
+    }
+
+    public function test_execute_for_user_uses_defaults_when_user_has_no_override_row(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Warning->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+
+        $score = app(ComputeProjectHealthScoreAction::class)
+            ->executeForUser($project, $user);
+
+        // 100 - 15 (default DEDUCT_ALERT_WARNING) = 85.
+        $this->assertSame(85, $score);
+    }
+}

--- a/tests/Feature/Settings/RulesControllerTest.php
+++ b/tests/Feature/Settings/RulesControllerTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature\Settings;
 
-use App\Domain\Analytics\Jobs\RecomputeAllProjectHealthScoresJob;
+use App\Domain\Analytics\Jobs\RecomputeUserProjectHealthScoresJob;
 use App\Enums\AlertRuleKind;
 use App\Enums\AlertSeverity;
 use App\Models\AlertRule;
@@ -56,7 +56,10 @@ class RulesControllerTest extends TestCase
             'deduct_alert_warning' => 20,
         ]);
 
-        Bus::assertDispatched(RecomputeAllProjectHealthScoresJob::class);
+        Bus::assertDispatched(
+            RecomputeUserProjectHealthScoresJob::class,
+            fn (RecomputeUserProjectHealthScoresJob $job) => $job->userId === $user->id,
+        );
     }
 
     public function test_update_weights_rejects_out_of_bounds(): void
@@ -87,7 +90,10 @@ class RulesControllerTest extends TestCase
             'user_id' => $user->id,
         ]);
 
-        Bus::assertDispatched(RecomputeAllProjectHealthScoresJob::class);
+        Bus::assertDispatched(
+            RecomputeUserProjectHealthScoresJob::class,
+            fn (RecomputeUserProjectHealthScoresJob $job) => $job->userId === $user->id,
+        );
     }
 
     public function test_store_rule_creates_row(): void

--- a/tests/Feature/Settings/RulesControllerTest.php
+++ b/tests/Feature/Settings/RulesControllerTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Feature\Settings;
+
+use App\Domain\Analytics\Jobs\RecomputeAllProjectHealthScoresJob;
+use App\Enums\AlertRuleKind;
+use App\Enums\AlertSeverity;
+use App\Models\AlertRule;
+use App\Models\Project;
+use App\Models\ProjectHealthScoreWeightOverride;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+/**
+ * Spec 046 — `/settings/rules` controller. Covers both slices:
+ * weights (update / reset / recompute dispatch) and rules (CRUD +
+ * ownership + throttle sanity).
+ */
+class RulesControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_renders_for_a_verified_user(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('settings.rules.index'))
+            ->assertOk();
+    }
+
+    public function test_guest_is_redirected_to_login(): void
+    {
+        $this->get(route('settings.rules.index'))->assertRedirect(route('login'));
+    }
+
+    public function test_update_weights_creates_override_row_and_dispatches_recompute(): void
+    {
+        Bus::fake();
+
+        $user = User::factory()->create();
+        Project::factory()->create(['owner_user_id' => $user->id]);
+
+        $this->actingAs($user)
+            ->patch(route('settings.rules.weights.update'), [
+                'deduct_alert_critical' => 40,
+                'deduct_alert_warning' => 20,
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('project_health_score_weight_overrides', [
+            'user_id' => $user->id,
+            'deduct_alert_critical' => 40,
+            'deduct_alert_warning' => 20,
+        ]);
+
+        Bus::assertDispatched(RecomputeAllProjectHealthScoresJob::class);
+    }
+
+    public function test_update_weights_rejects_out_of_bounds(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->patch(route('settings.rules.weights.update'), [
+                'deduct_alert_critical' => 150, // > 100
+            ])
+            ->assertSessionHasErrors('deduct_alert_critical');
+    }
+
+    public function test_reset_weights_deletes_override_row(): void
+    {
+        Bus::fake();
+
+        $user = User::factory()->create();
+        ProjectHealthScoreWeightOverride::factory()->for($user)->create([
+            'deduct_alert_critical' => 40,
+        ]);
+
+        $this->actingAs($user)
+            ->delete(route('settings.rules.weights.reset'))
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('project_health_score_weight_overrides', [
+            'user_id' => $user->id,
+        ]);
+
+        Bus::assertDispatched(RecomputeAllProjectHealthScoresJob::class);
+    }
+
+    public function test_store_rule_creates_row(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('settings.rules.store'), [
+                'name' => 'Backlog watch',
+                'kind' => AlertRuleKind::QueueBacklogTrend->value,
+                'severity' => AlertSeverity::Warning->value,
+                'config' => ['threshold_delta' => 150, 'window_minutes' => 15],
+                'cool_down_minutes' => 45,
+            ])
+            ->assertRedirect();
+
+        $this->assertDatabaseHas('alert_rules', [
+            'user_id' => $user->id,
+            'name' => 'Backlog watch',
+            'kind' => 'queue.backlog_trend',
+            'cool_down_minutes' => 45,
+        ]);
+    }
+
+    public function test_update_rule_rejects_other_users_row(): void
+    {
+        $owner = User::factory()->create();
+        $stranger = User::factory()->create();
+        $rule = AlertRule::factory()->for($owner)->create();
+
+        $this->actingAs($stranger)
+            ->patch(route('settings.rules.update', ['rule' => $rule->id]), [
+                'enabled' => false,
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_destroy_rule_rejects_other_users_row(): void
+    {
+        $owner = User::factory()->create();
+        $stranger = User::factory()->create();
+        $rule = AlertRule::factory()->for($owner)->create();
+
+        $this->actingAs($stranger)
+            ->delete(route('settings.rules.destroy', ['rule' => $rule->id]))
+            ->assertForbidden();
+    }
+
+    public function test_toggle_rule_updates_enabled_column(): void
+    {
+        $user = User::factory()->create();
+        $rule = AlertRule::factory()->for($user)->create(['enabled' => true]);
+
+        $this->actingAs($user)
+            ->patch(route('settings.rules.update', ['rule' => $rule->id]), [
+                'enabled' => false,
+            ])
+            ->assertRedirect();
+
+        $this->assertFalse($rule->fresh()->enabled);
+    }
+}


### PR DESCRIPTION
Closes #127

Spec: \`specs/phase-10-innovation/046-alert-rules-and-health-weights.md\`

## Summary

Two long-deferred deliverables sharing plumbing:

**Slice A — health-score weights.**
- New \`project_health_score_weight_overrides\` table (1 row per user, 8 nullable \`DEDUCT_*\` mirrors).
- \`HealthScoreWeights\` value object with per-field fallback (null → class default).
- \`ComputeProjectHealthScoreAction\` refactored: existing \`execute()\` stays defaults-only (every existing caller unchanged); new \`executeForUser(\$project, \$user)\` delegates through \`HealthScoreWeights::forUser()\`.
- \`RefreshProjectHealthScoreAction\` resolves the project owner and routes to the right code path (deleted-owner race falls back to defaults).
- Saving weights fires \`RecomputeUserProjectHealthScoresJob\` — scoped to the user's projects, not the global sweep.

**Slice B — metric-driven \`AlertRule\` evaluators.**
- New \`alert_rules\` table (kind, severity, config JSON, cool_down_minutes, enabled).
- 4 evaluators via §6.5 Strategy pattern behind \`AlertRuleEvaluator\` contract:
  - \`QueueBacklogTrendEvaluator\` — current backlog vs. threshold
  - \`DeployFrequencyDropEvaluator\` — 7d vs prior 7d drop %
  - \`UptimeSlopeEvaluator\` — two-half compare on last 24h of website checks
  - \`DeployFailureRateEvaluator\` — failure % across last N default-branch runs
- \`EvaluateAlertRulesJob\` on the 5-min tick — cool-down gate ahead of the evaluator (perf win on chatty rules), \`ShouldBeUnique(300s)\`, dispatches \`TriggerAlertAction\` with \`AlertSource::System\` + \`type = "rule.{kind}"\` → **rides spec 042's delivery layer**.
- 5-item \`AlertRuleTemplate\` starter catalog so operators aren't staring at a blank form.

**Shared:** single \`/settings/rules\` page (tabs: Weights + Rules), single \`RulesController\`, palette command, throttled endpoints per §5 of the operator checklist.

## Test plan
- [x] Per-user weights persist through \`project_health_score_weight_overrides\`; null → default.
- [x] \`ComputeProjectHealthScoreAction::executeForUser\` uses overrides; \`execute\` stays defaults-only.
- [x] Saving weights dispatches \`RecomputeUserProjectHealthScoresJob\` scoped to the user.
- [x] \`alert_rules\` table + 4 evaluator implementations shipped behind the contract.
- [x] \`EvaluateAlertRulesJob\` runs every 5 min, respects cool-down, dispatches \`TriggerAlertAction\`, stays quiet when disabled.
- [x] Fired rule alerts flow through spec 042's delivery layer (\`AlertSource::System\` + \`type: rule.{kind}\`).
- [x] Route ownership: cross-user updateRule / destroyRule → 403.
- [x] All 5 new endpoints throttled per §5 of the operator checklist.
- [x] Pint clean. \`php artisan test\` 844/844 green (25 new tests). \`npm run build\` clean.

## Self-review notes
Ran \`superpowers:code-reviewer\`. Findings and disposition:

**Blockers:** none.

**Should-fixes (both applied):**
- **Recompute-on-save was global, not per-user.** Spec §Plan explicitly asked for user-scoped recompute. Fixed by shipping \`RecomputeUserProjectHealthScoresJob(userId)\` (~20 lines) and updating the controller + test. Prevents O(all-active-projects) fan-out when only the saving user's projects need reassertion. The 5-min global sweep remains the safety net for drift.
- **Cool-down check ran after the evaluator.** Wasteful on chatty rules paying SQL-join cost every tick just to discard. Moved the guard ahead of \`evaluatorFor\`; \`last_evaluated_at\` still advances so the UI reads consistently.

**Nits (surfaced for visibility, not fixed):**
- \`QueueBacklogTrendEvaluator\` reads \`Queue::size()\` which returns only the default queue. Production Horizon typically has named queues (default / notifications / sync). Evaluator comment documents the simplification; a per-queue sum is a follow-up.
- \`whereBetween\` window boundaries at midpoints in \`DeployFrequencyDrop\` + \`UptimeSlope\` — a run/check landing exactly on the boundary counts in both windows. Real-world probability at second precision is ~0.
- Test consolidation deliberate — 9 files listed in the spec ↔ 4 files shipped. \`AlertRuleEvaluatorsTest\` covers all four evaluators with shared fixtures; \`RulesControllerTest\` absorbs the weights-recompute happy path. Coverage matches spec §Tests block; the file-count trim keeps boilerplate down.

**What's done well (reviewer highlights):**
- Backwards-compat on \`ComputeProjectHealthScoreAction\` — every existing caller stays green.
- Value-object fallback logic in one place; adding a new deduction is one column + one method + one constant, no shotgun surgery.
- Evaluator exception isolation — a broken rule can't poison the loop.
- Deleted-owner race in \`RefreshProjectHealthScoreAction\` falls back to defaults (defensible score during race window).

## Bookkeeping
Spec + tracker flips inside this PR:
- Spec 046 frontmatter → \`status: done\`.
- \`specs/phase-10-innovation/README.md\` task 046 → 🟢.
- \`specs/README.md\` Phase 10 row → 🟡 3/6.

Phase 10 remaining: 044 (AI briefing — uses 042 delivery), 045 (AI PR risk + health explanation — uses 046 formula), 047 (public status page).