### PR TITLE
Spec 047 — Public status page generator + subscribers

### DIFF
--- a/app/Domain/PublicStatus/DataTransferObjects/PublicStatusSnapshot.php
+++ b/app/Domain/PublicStatus/DataTransferObjects/PublicStatusSnapshot.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Domain\PublicStatus\DataTransferObjects;
+
+/**
+ * Spec 047 — assembled public status snapshot. Shape is deliberately
+ * flat so the Vue page can render it without further shaping.
+ *
+ * `overallBand` — one of `operational` | `degraded` | `partial_outage`
+ * | `major_outage`.
+ */
+final class PublicStatusSnapshot
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $monitors
+     * @param  array<int, array<string, mixed>>  $activeIncidents
+     * @param  array<int, array<string, mixed>>  $recentIncidents
+     */
+    public function __construct(
+        public readonly int $projectId,
+        public readonly string $projectName,
+        public readonly string $projectSlug,
+        public readonly ?string $headline,
+        public readonly string $overallBand,
+        public readonly string $overallLabel,
+        public readonly array $monitors,
+        public readonly array $activeIncidents,
+        public readonly array $recentIncidents,
+        public readonly string $lastUpdatedAt,
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'project_id' => $this->projectId,
+            'project_name' => $this->projectName,
+            'project_slug' => $this->projectSlug,
+            'headline' => $this->headline,
+            'overall_band' => $this->overallBand,
+            'overall_label' => $this->overallLabel,
+            'monitors' => $this->monitors,
+            'active_incidents' => $this->activeIncidents,
+            'recent_incidents' => $this->recentIncidents,
+            'last_updated_at' => $this->lastUpdatedAt,
+        ];
+    }
+}

--- a/app/Domain/PublicStatus/Jobs/NotifyStatusSubscribersJob.php
+++ b/app/Domain/PublicStatus/Jobs/NotifyStatusSubscribersJob.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Domain\PublicStatus\Jobs;
+
+use App\Mail\PublicStatusIncidentMail;
+use App\Models\Alert;
+use App\Models\PublicStatusSubscriber;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Spec 047 — fan an alert transition (trigger / resolve) out to every
+ * confirmed public subscriber of the alert's project.
+ *
+ * `ShouldBeUnique` keyed on `(alert_id, event)` collapses duplicate
+ * dispatches — the listener idempotency layer already dedupes on the
+ * event side, but a queue-side belt-and-braces guard means a
+ * bug-in-listener retry can't double-mail subscribers.
+ *
+ * Skipped cases (all silent no-ops so the queue doesn't churn):
+ *   - Alert row missing (deleted between dispatch and handle).
+ *   - Alert has no project_id.
+ *   - Project has `public_status_enabled = false`.
+ *   - No confirmed subscribers on the project.
+ */
+class NotifyStatusSubscribersJob implements ShouldBeUnique, ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public int $uniqueFor = 300;
+
+    public function __construct(
+        public readonly int $alertId,
+        public readonly string $event, // 'triggered' | 'resolved'
+    ) {}
+
+    public function uniqueId(): string
+    {
+        return "{$this->alertId}:{$this->event}";
+    }
+
+    public function handle(): void
+    {
+        $alert = Alert::query()->with('project')->find($this->alertId);
+
+        if ($alert === null || $alert->project_id === null) {
+            return;
+        }
+
+        $project = $alert->project;
+
+        if ($project === null || ! $project->public_status_enabled) {
+            return;
+        }
+
+        PublicStatusSubscriber::query()
+            ->where('project_id', $project->id)
+            ->whereNotNull('confirmed_at')
+            ->chunkById(100, function ($subscribers) use ($project, $alert): void {
+                foreach ($subscribers as $subscriber) {
+                    Mail::to($subscriber->email)->send(
+                        new PublicStatusIncidentMail(
+                            project: $project,
+                            subscriber: $subscriber,
+                            alert: $alert,
+                            event: $this->event,
+                        ),
+                    );
+                }
+            });
+    }
+}

--- a/app/Domain/PublicStatus/Jobs/NotifyStatusSubscribersJob.php
+++ b/app/Domain/PublicStatus/Jobs/NotifyStatusSubscribersJob.php
@@ -11,7 +11,9 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
+use Throwable;
 
 /**
  * Spec 047 — fan an alert transition (trigger / resolve) out to every
@@ -63,19 +65,31 @@ class NotifyStatusSubscribersJob implements ShouldBeUnique, ShouldQueue
             return;
         }
 
+        // Per-subscriber isolation: a bounce/refusal for one recipient
+        // must NOT abort the loop. If we let the exception propagate,
+        // the queue's retry path would re-mail the earlier subscribers.
         PublicStatusSubscriber::query()
             ->where('project_id', $project->id)
             ->whereNotNull('confirmed_at')
             ->chunkById(100, function ($subscribers) use ($project, $alert): void {
                 foreach ($subscribers as $subscriber) {
-                    Mail::to($subscriber->email)->send(
-                        new PublicStatusIncidentMail(
-                            project: $project,
-                            subscriber: $subscriber,
-                            alert: $alert,
-                            event: $this->event,
-                        ),
-                    );
+                    try {
+                        Mail::to($subscriber->email)->send(
+                            new PublicStatusIncidentMail(
+                                project: $project,
+                                subscriber: $subscriber,
+                                alert: $alert,
+                                event: $this->event,
+                            ),
+                        );
+                    } catch (Throwable $e) {
+                        Log::warning('PublicStatus incident mail failed for one subscriber', [
+                            'project_id' => $project->id,
+                            'subscriber_id' => $subscriber->id,
+                            'alert_id' => $alert->id,
+                            'error' => $e->getMessage(),
+                        ]);
+                    }
                 }
             });
     }

--- a/app/Domain/PublicStatus/Listeners/InvalidatePublicStatusCacheListener.php
+++ b/app/Domain/PublicStatus/Listeners/InvalidatePublicStatusCacheListener.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Domain\PublicStatus\Listeners;
+
+use App\Domain\PublicStatus\Queries\GetPublicStatusPageQuery;
+use App\Events\AlertResolved;
+use App\Events\AlertTriggered;
+use App\Models\Alert;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Spec 047 — flush the cached public status snapshot on alert
+ * transitions so the next public visitor sees fresh data.
+ * `WebsiteCheckRecorded` was considered but firing this every 60s
+ * for every monitor would nullify the cache TTL entirely; incident
+ * transitions are the visible-to-viewers events worth invalidating on.
+ */
+class InvalidatePublicStatusCacheListener
+{
+    public function handle(AlertTriggered|AlertResolved $event): void
+    {
+        $projectId = Alert::query()
+            ->where('id', $event->alertId)
+            ->value('project_id');
+
+        if ($projectId === null) {
+            return;
+        }
+
+        Cache::forget(GetPublicStatusPageQuery::cacheKey($projectId));
+    }
+}

--- a/app/Domain/PublicStatus/Listeners/NotifyPublicSubscribersOnAlertListener.php
+++ b/app/Domain/PublicStatus/Listeners/NotifyPublicSubscribersOnAlertListener.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Domain\PublicStatus\Listeners;
+
+use App\Domain\PublicStatus\Jobs\NotifyStatusSubscribersJob;
+use App\Events\AlertResolved;
+use App\Events\AlertTriggered;
+use App\Models\Alert;
+
+/**
+ * Spec 047 — listens for the two spec-032 alert events and enqueues
+ * `NotifyStatusSubscribersJob` for the project (if it's opted in).
+ *
+ * Fire-and-forget from the event bus. If the queue is unavailable
+ * or the job dispatch throws for any reason, the failure is
+ * observed via Horizon; the alert lifecycle itself never fails
+ * because a public notification couldn't ship.
+ */
+class NotifyPublicSubscribersOnAlertListener
+{
+    public function handle(AlertTriggered|AlertResolved $event): void
+    {
+        $alert = Alert::query()->find($event->alertId);
+
+        if ($alert === null || $alert->project_id === null) {
+            return;
+        }
+
+        // Skip cheaply before enqueueing so the queue only carries
+        // useful work.
+        $enabled = $alert->project()->value('public_status_enabled');
+        if (! $enabled) {
+            return;
+        }
+
+        $eventName = $event instanceof AlertResolved ? 'resolved' : 'triggered';
+
+        NotifyStatusSubscribersJob::dispatch($alert->id, $eventName);
+    }
+}

--- a/app/Domain/PublicStatus/Queries/GetPublicStatusPageQuery.php
+++ b/app/Domain/PublicStatus/Queries/GetPublicStatusPageQuery.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Domain\PublicStatus\Queries;
+
+use App\Domain\Monitoring\Queries\GetWebsitePerformanceSummaryQuery;
+use App\Domain\PublicStatus\DataTransferObjects\PublicStatusSnapshot;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertStatus;
+use App\Enums\WebsiteStatus;
+use App\Models\Alert;
+use App\Models\Project;
+use App\Models\Website;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Spec 047 — assembles the public status page snapshot. Cached 60s
+ * to survive viral shares; invalidated on alert transitions via
+ * `InvalidatePublicStatusCacheListener` (spec 032 events).
+ *
+ * Overall band derivation (matches Statuspage.io shape):
+ *   - `major_outage`   → any open critical alert OR any website `down`
+ *   - `partial_outage` → any open warning alert OR any website `slow`
+ *   - `degraded`       → any open info alert
+ *   - `operational`    → nothing open
+ */
+class GetPublicStatusPageQuery
+{
+    public const CACHE_TTL_SECONDS = 60;
+
+    public const RECENT_INCIDENTS_LIMIT = 10;
+
+    public static function cacheKey(int $projectId): string
+    {
+        return "public-status:{$projectId}";
+    }
+
+    public function __construct(
+        private readonly GetWebsitePerformanceSummaryQuery $websiteSummary,
+    ) {}
+
+    public function execute(Project $project): PublicStatusSnapshot
+    {
+        return Cache::remember(
+            self::cacheKey($project->id),
+            self::CACHE_TTL_SECONDS,
+            fn (): PublicStatusSnapshot => $this->assemble($project),
+        );
+    }
+
+    private function assemble(Project $project): PublicStatusSnapshot
+    {
+        $monitors = $this->monitorsFor($project);
+        $activeIncidents = $this->activeIncidentsFor($project);
+        $recentIncidents = $this->recentIncidentsFor($project);
+        [$band, $label] = $this->deriveOverall($project, $activeIncidents);
+
+        return new PublicStatusSnapshot(
+            projectId: $project->id,
+            projectName: $project->name,
+            projectSlug: $project->slug,
+            headline: $project->public_status_headline,
+            overallBand: $band,
+            overallLabel: $label,
+            monitors: $monitors,
+            activeIncidents: $activeIncidents,
+            recentIncidents: $recentIncidents,
+            lastUpdatedAt: now()->toIso8601String(),
+        );
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function monitorsFor(Project $project): array
+    {
+        return Website::query()
+            ->where('project_id', $project->id)
+            ->orderBy('name')
+            ->get(['id', 'name', 'url', 'status'])
+            ->map(function (Website $w): array {
+                $summary = $this->websiteSummary->execute($w);
+
+                return [
+                    'id' => $w->id,
+                    'name' => $w->name,
+                    'url' => $w->url,
+                    'status' => $w->status?->value,
+                    'uptime_24h' => $summary['uptime_24h'],
+                    'uptime_7d' => $summary['uptime_7d'],
+                    'uptime_30d' => $summary['uptime_30d'],
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function activeIncidentsFor(Project $project): array
+    {
+        return Alert::query()
+            ->where('project_id', $project->id)
+            ->whereIn('status', [
+                AlertStatus::Open->value,
+                AlertStatus::Acknowledged->value,
+            ])
+            ->orderByDesc('triggered_at')
+            ->limit(20)
+            ->get(['id', 'title', 'severity', 'status', 'triggered_at'])
+            ->map(fn (Alert $a): array => [
+                'id' => $a->id,
+                'title' => $a->title,
+                'severity' => $a->severity->value,
+                'status' => $a->status->value,
+                'triggered_at' => $a->triggered_at?->toIso8601String(),
+                'triggered_at_human' => $a->triggered_at?->diffForHumans(),
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function recentIncidentsFor(Project $project): array
+    {
+        return Alert::query()
+            ->where('project_id', $project->id)
+            ->where('status', AlertStatus::Resolved->value)
+            ->orderByDesc('resolved_at')
+            ->limit(self::RECENT_INCIDENTS_LIMIT)
+            ->get(['id', 'title', 'severity', 'triggered_at', 'resolved_at'])
+            ->map(fn (Alert $a): array => [
+                'id' => $a->id,
+                'title' => $a->title,
+                'severity' => $a->severity->value,
+                'triggered_at' => $a->triggered_at?->toIso8601String(),
+                'resolved_at' => $a->resolved_at?->toIso8601String(),
+                'resolved_at_human' => $a->resolved_at?->diffForHumans(),
+            ])
+            ->all();
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $activeIncidents
+     * @return array{0: string, 1: string}
+     */
+    private function deriveOverall(Project $project, array $activeIncidents): array
+    {
+        $downWebsites = Website::query()
+            ->where('project_id', $project->id)
+            ->whereIn('status', [
+                WebsiteStatus::Down->value,
+                WebsiteStatus::Error->value,
+            ])
+            ->exists();
+
+        $slowWebsites = Website::query()
+            ->where('project_id', $project->id)
+            ->where('status', WebsiteStatus::Slow->value)
+            ->exists();
+
+        $hasCritical = false;
+        $hasWarning = false;
+        $hasInfo = false;
+
+        foreach ($activeIncidents as $incident) {
+            match ($incident['severity']) {
+                AlertSeverity::Critical->value => $hasCritical = true,
+                AlertSeverity::Warning->value => $hasWarning = true,
+                AlertSeverity::Info->value => $hasInfo = true,
+                default => null,
+            };
+        }
+
+        if ($hasCritical || $downWebsites) {
+            return ['major_outage', 'Major outage'];
+        }
+
+        if ($hasWarning || $slowWebsites) {
+            return ['partial_outage', 'Partial outage'];
+        }
+
+        if ($hasInfo) {
+            return ['degraded', 'Degraded'];
+        }
+
+        return ['operational', 'All systems operational'];
+    }
+}

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Domain\Activity\Queries\RecentActivityForProjectQuery;
 use App\Domain\GitHub\Queries\DeploymentTimelineQuery;
+use App\Domain\PublicStatus\Queries\GetPublicStatusPageQuery;
 use App\Enums\HealthScoreBand;
 use App\Enums\ProjectPriority;
 use App\Enums\ProjectStatus;
@@ -15,6 +16,7 @@ use App\Models\Website;
 use App\Support\ProjectPalette;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -171,9 +173,23 @@ class ProjectController extends Controller
 
     public function update(UpdateProjectRequest $request, Project $project): RedirectResponse
     {
-        $project->fill($request->validated());
+        $validated = $request->validated();
+
+        // Spec 047 — if the public-status headline or the enable-toggle
+        // just changed, flush the cached snapshot so the next public
+        // visitor sees fresh data instead of a 60-second-stale page.
+        $publicChanged = array_key_exists('public_status_headline', $validated)
+            && $project->public_status_headline !== ($validated['public_status_headline'] ?? null);
+        $enabledChanged = array_key_exists('public_status_enabled', $validated)
+            && $project->public_status_enabled !== (bool) $validated['public_status_enabled'];
+
+        $project->fill($validated);
         $project->last_activity_at = now();
         $project->save();
+
+        if ($publicChanged || $enabledChanged) {
+            Cache::forget(GetPublicStatusPageQuery::cacheKey($project->id));
+        }
 
         return redirect()
             ->route('projects.show', $project)

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -218,6 +218,18 @@ class ProjectController extends Controller
                 'name' => $project->owner->name,
                 'initials' => $this->initialsFor($project->owner->name),
             ] : null,
+            // Spec 047 — surface the public status controls on the edit
+            // form. `subscriber_count` is a small aggregate for the
+            // operator's awareness; `public_url` renders once the toggle
+            // is on and the slug resolves.
+            'public_status_enabled' => (bool) $project->public_status_enabled,
+            'public_status_headline' => $project->public_status_headline,
+            'public_status_url' => $project->public_status_enabled
+                ? url("/status/{$project->slug}")
+                : null,
+            'public_status_subscriber_count' => $project->publicStatusSubscribers()
+                ->whereNotNull('confirmed_at')
+                ->count(),
         ];
     }
 

--- a/app/Http/Controllers/PublicStatus/ConfirmSubscriptionController.php
+++ b/app/Http/Controllers/PublicStatus/ConfirmSubscriptionController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\PublicStatus;
+
+use App\Http\Controllers\Controller;
+use App\Models\Project;
+use App\Models\PublicStatusSubscriber;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Spec 047 — public confirmation link. `GET /status/{slug}/confirm/{token}`.
+ * Flips `confirmed_at` on first hit; idempotent on repeated hits.
+ * Unknown token 404.
+ */
+class ConfirmSubscriptionController extends Controller
+{
+    public function __invoke(Project $project, string $token): Response
+    {
+        abort_unless($project->public_status_enabled, 404);
+
+        $subscriber = PublicStatusSubscriber::query()
+            ->where('project_id', $project->id)
+            ->where('confirmation_token', $token)
+            ->first();
+
+        abort_unless($subscriber !== null, 404);
+
+        if ($subscriber->confirmed_at === null) {
+            $subscriber->forceFill(['confirmed_at' => now()])->save();
+        }
+
+        return Inertia::render('Status/Confirmed', [
+            'project' => [
+                'name' => $project->name,
+                'slug' => $project->slug,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/PublicStatus/ShowController.php
+++ b/app/Http/Controllers/PublicStatus/ShowController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers\PublicStatus;
+
+use App\Domain\PublicStatus\Queries\GetPublicStatusPageQuery;
+use App\Http\Controllers\Controller;
+use App\Models\Project;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Spec 047 — public `/status/{project:slug}` page. Unauthenticated,
+ * 404 for projects that haven't flipped the opt-in switch.
+ *
+ * Cached via `GetPublicStatusPageQuery` (60s TTL, invalidated on
+ * alert transitions via listener).
+ */
+class ShowController extends Controller
+{
+    public function __invoke(Project $project, GetPublicStatusPageQuery $query): Response
+    {
+        abort_unless($project->public_status_enabled, 404);
+
+        return Inertia::render('Status/Show', [
+            'status' => $query->execute($project)->toArray(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/PublicStatus/SubscribeController.php
+++ b/app/Http/Controllers/PublicStatus/SubscribeController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers\PublicStatus;
+
+use App\Http\Controllers\Controller;
+use App\Mail\PublicStatusSubscribeConfirmationMail;
+use App\Models\Project;
+use App\Models\PublicStatusSubscriber;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Spec 047 — public subscribe endpoint. Double opt-in: the row lands
+ * with `confirmed_at = null`; the operator receives a mail with a
+ * confirm link (`GET /status/{slug}/confirm/{token}`).
+ *
+ * Idempotent: repeat POST with same `(project, email)` refreshes the
+ * confirmation token + re-sends the confirm mail without creating a
+ * second row (relies on the composite unique index).
+ *
+ * `honeypot` is a hidden field: any non-empty submission from a form
+ * that ships an invisible input is a bot. Returns 422 with a generic
+ * validation error so the bot can't distinguish success from failure.
+ */
+class SubscribeController extends Controller
+{
+    public function __invoke(Request $request, Project $project): RedirectResponse
+    {
+        abort_unless($project->public_status_enabled, 404);
+
+        $validated = $request->validate([
+            'email' => 'required|email:filter|max:190',
+            'honeypot' => 'sometimes|nullable|string',
+        ]);
+
+        if (! empty($validated['honeypot'])) {
+            return back()->with('status', 'Check your inbox to confirm.');
+        }
+
+        $subscriber = PublicStatusSubscriber::query()->updateOrCreate(
+            [
+                'project_id' => $project->id,
+                'email' => $validated['email'],
+            ],
+            [
+                'confirmation_token' => PublicStatusSubscriber::freshToken(),
+                'unsubscribe_token' => PublicStatusSubscriber::freshToken(),
+                'confirmed_at' => null,
+            ],
+        );
+
+        Mail::to($subscriber->email)->send(
+            new PublicStatusSubscribeConfirmationMail($project, $subscriber),
+        );
+
+        return back()->with('status', 'Check your inbox to confirm.');
+    }
+}

--- a/app/Http/Controllers/PublicStatus/UnsubscribeController.php
+++ b/app/Http/Controllers/PublicStatus/UnsubscribeController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\PublicStatus;
+
+use App\Http\Controllers\Controller;
+use App\Models\PublicStatusSubscriber;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Spec 047 — RFC 8058 one-click unsubscribe. Token-only lookup so the
+ * link works from any inbox without login. Deletes the row on hit;
+ * unknown token 404.
+ */
+class UnsubscribeController extends Controller
+{
+    public function __invoke(string $token): Response
+    {
+        $subscriber = PublicStatusSubscriber::query()
+            ->where('unsubscribe_token', $token)
+            ->with('project:id,name,slug')
+            ->first();
+
+        abort_unless($subscriber !== null, 404);
+
+        $projectName = $subscriber->project?->name;
+        $projectSlug = $subscriber->project?->slug;
+        $subscriber->delete();
+
+        return Inertia::render('Status/Unsubscribed', [
+            'project' => [
+                'name' => $projectName,
+                'slug' => $projectSlug,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Requests/Projects/UpdateProjectRequest.php
+++ b/app/Http/Requests/Projects/UpdateProjectRequest.php
@@ -33,6 +33,9 @@ class UpdateProjectRequest extends FormRequest
             'environment' => ['nullable', 'string', 'max:64'],
             'color' => ['nullable', Rule::in(ProjectPalette::COLORS)],
             'icon' => ['nullable', Rule::in(ProjectPalette::ICONS)],
+            // Spec 047 — per-project opt-in for the public status page.
+            'public_status_enabled' => ['sometimes', 'boolean'],
+            'public_status_headline' => ['sometimes', 'nullable', 'string', 'max:240'],
         ];
     }
 }

--- a/app/Http/Requests/Projects/UpdateProjectRequest.php
+++ b/app/Http/Requests/Projects/UpdateProjectRequest.php
@@ -19,20 +19,22 @@ class UpdateProjectRequest extends FormRequest
     }
 
     /**
-     * Same shape as the store request — Update is a full PATCH/PUT replace.
-     * If we move to partial updates later we'll switch to `sometimes`
-     * everywhere, but the form posts every field today.
+     * Spec 047 — every field is `sometimes` so partial forms don't
+     * clobber siblings. The main `ProjectForm` still posts every field
+     * today; the public-status panel on `Projects/Edit.vue` posts only
+     * `public_status_*` fields to prevent stale main-form state from
+     * overwriting a fresh save.
      */
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'min:2', 'max:120'],
-            'description' => ['nullable', 'string', 'max:2000'],
-            'status' => ['required', new Enum(ProjectStatus::class)],
-            'priority' => ['required', new Enum(ProjectPriority::class)],
-            'environment' => ['nullable', 'string', 'max:64'],
-            'color' => ['nullable', Rule::in(ProjectPalette::COLORS)],
-            'icon' => ['nullable', Rule::in(ProjectPalette::ICONS)],
+            'name' => ['sometimes', 'required', 'string', 'min:2', 'max:120'],
+            'description' => ['sometimes', 'nullable', 'string', 'max:2000'],
+            'status' => ['sometimes', 'required', new Enum(ProjectStatus::class)],
+            'priority' => ['sometimes', 'required', new Enum(ProjectPriority::class)],
+            'environment' => ['sometimes', 'nullable', 'string', 'max:64'],
+            'color' => ['sometimes', 'nullable', Rule::in(ProjectPalette::COLORS)],
+            'icon' => ['sometimes', 'nullable', Rule::in(ProjectPalette::ICONS)],
             // Spec 047 — per-project opt-in for the public status page.
             'public_status_enabled' => ['sometimes', 'boolean'],
             'public_status_headline' => ['sometimes', 'nullable', 'string', 'max:240'],

--- a/app/Mail/PublicStatusIncidentMail.php
+++ b/app/Mail/PublicStatusIncidentMail.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Alert;
+use App\Models\Project;
+use App\Models\PublicStatusSubscriber;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\URL;
+
+class PublicStatusIncidentMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly Project $project,
+        public readonly PublicStatusSubscriber $subscriber,
+        public readonly Alert $alert,
+        public readonly string $event, // 'triggered' | 'resolved'
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        $prefix = $this->event === 'resolved'
+            ? "[{$this->project->name} · resolved]"
+            : "[{$this->project->name} · ".ucfirst($this->alert->severity->value).']';
+
+        return new Envelope(
+            subject: $prefix.' '.$this->alert->title,
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.public-status.incident',
+            with: [
+                'projectName' => $this->project->name,
+                'event' => $this->event,
+                'alertTitle' => $this->alert->title,
+                'alertSeverity' => $this->alert->severity->value,
+                'alertDescription' => $this->alert->description,
+                'triggeredAt' => $this->alert->triggered_at,
+                'resolvedAt' => $this->alert->resolved_at,
+                'statusUrl' => URL::to("/status/{$this->project->slug}"),
+                'unsubscribeUrl' => URL::to(
+                    "/status/subscribers/unsubscribe/{$this->subscriber->unsubscribe_token}",
+                ),
+            ],
+        );
+    }
+}

--- a/app/Mail/PublicStatusSubscribeConfirmationMail.php
+++ b/app/Mail/PublicStatusSubscribeConfirmationMail.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Project;
+use App\Models\PublicStatusSubscriber;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\URL;
+
+class PublicStatusSubscribeConfirmationMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly Project $project,
+        public readonly PublicStatusSubscriber $subscriber,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: "Confirm your subscription to {$this->project->name} status",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.public-status.subscribe-confirmation',
+            with: [
+                'projectName' => $this->project->name,
+                'confirmUrl' => URL::to(
+                    "/status/{$this->project->slug}/confirm/{$this->subscriber->confirmation_token}",
+                ),
+                'statusUrl' => URL::to("/status/{$this->project->slug}"),
+            ],
+        );
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -27,6 +27,8 @@ class Project extends Model
         'icon',
         'health_score',
         'last_activity_at',
+        'public_status_enabled',
+        'public_status_headline',
     ];
 
     protected function casts(): array
@@ -36,7 +38,13 @@ class Project extends Model
             'priority' => ProjectPriority::class,
             'health_score' => 'integer',
             'last_activity_at' => 'datetime',
+            'public_status_enabled' => 'boolean',
         ];
+    }
+
+    public function publicStatusSubscribers(): HasMany
+    {
+        return $this->hasMany(PublicStatusSubscriber::class);
     }
 
     /**

--- a/app/Models/PublicStatusSubscriber.php
+++ b/app/Models/PublicStatusSubscriber.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\PublicStatusSubscriberFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
+
+/**
+ * Spec 047 — anonymous public-status-page subscribers. Distinct from
+ * spec 042's `AlertNotificationChannel` (which is user-scoped +
+ * multi-driver): this row is email-only + tied to a project + carries
+ * its own confirm / unsubscribe token pair.
+ */
+class PublicStatusSubscriber extends Model
+{
+    /** @use HasFactory<PublicStatusSubscriberFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'project_id',
+        'email',
+        'confirmation_token',
+        'unsubscribe_token',
+        'confirmed_at',
+    ];
+
+    protected $hidden = [
+        // Never leak subscriber tokens through model serialization; the
+        // controllers read them explicitly.
+        'confirmation_token',
+        'unsubscribe_token',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'confirmed_at' => 'datetime',
+        ];
+    }
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function isConfirmed(): bool
+    {
+        return $this->confirmed_at !== null;
+    }
+
+    public static function freshToken(): string
+    {
+        return Str::random(64);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace App\Providers;
 
+use App\Domain\PublicStatus\Listeners\InvalidatePublicStatusCacheListener;
+use App\Domain\PublicStatus\Listeners\NotifyPublicSubscribersOnAlertListener;
+use App\Events\AlertResolved;
+use App\Events\AlertTriggered;
 use App\Models\AgentToken;
 use App\Models\Alert;
 use App\Models\Host;
@@ -14,6 +18,7 @@ use App\Policies\HostPolicy;
 use App\Policies\ProjectPolicy;
 use App\Policies\RepositoryPolicy;
 use App\Policies\WebsitePolicy;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Vite;
@@ -59,5 +64,14 @@ class AppServiceProvider extends ServiceProvider
         if (str_starts_with((string) config('app.url'), 'https://')) {
             URL::forceScheme('https');
         }
+
+        // Spec 047 — fan alert transitions out to public subscribers +
+        // flush the cached status snapshot. Registered explicitly
+        // (Laravel 11+ auto-discovery scans specific paths; the
+        // Domain/{Context}/Listeners layout isn't one of the defaults).
+        Event::listen(AlertTriggered::class, [NotifyPublicSubscribersOnAlertListener::class, 'handle']);
+        Event::listen(AlertResolved::class, [NotifyPublicSubscribersOnAlertListener::class, 'handle']);
+        Event::listen(AlertTriggered::class, [InvalidatePublicStatusCacheListener::class, 'handle']);
+        Event::listen(AlertResolved::class, [InvalidatePublicStatusCacheListener::class, 'handle']);
     }
 }

--- a/database/factories/PublicStatusSubscriberFactory.php
+++ b/database/factories/PublicStatusSubscriberFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Project;
+use App\Models\PublicStatusSubscriber;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<PublicStatusSubscriber> */
+class PublicStatusSubscriberFactory extends Factory
+{
+    protected $model = PublicStatusSubscriber::class;
+
+    public function definition(): array
+    {
+        return [
+            'project_id' => Project::factory(),
+            'email' => fake()->unique()->safeEmail(),
+            'confirmation_token' => PublicStatusSubscriber::freshToken(),
+            'unsubscribe_token' => PublicStatusSubscriber::freshToken(),
+            'confirmed_at' => null,
+        ];
+    }
+
+    public function confirmed(): static
+    {
+        return $this->state(fn () => ['confirmed_at' => now()]);
+    }
+}

--- a/database/migrations/2026_07_02_150001_add_public_status_fields_to_projects_table.php
+++ b/database/migrations/2026_07_02_150001_add_public_status_fields_to_projects_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            // Spec 047 — per-project opt-in for the public status page.
+            // Default false so existing projects stay private on migrate;
+            // operators flip it via Settings → Project.
+            $table->boolean('public_status_enabled')->default(false)->after('slug');
+
+            // Operator-provided banner line above the incidents strip.
+            // Kept short (varchar 240) — a status page headline should
+            // fit on one line at typical widths.
+            $table->string('public_status_headline', 240)->nullable()->after('public_status_enabled');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropColumn(['public_status_enabled', 'public_status_headline']);
+        });
+    }
+};

--- a/database/migrations/2026_07_02_150002_create_public_status_subscribers_table.php
+++ b/database/migrations/2026_07_02_150002_create_public_status_subscribers_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('public_status_subscribers', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('project_id')
+                ->constrained('projects')
+                ->cascadeOnDelete();
+
+            // 190 fits under MySQL's utf8mb4 unique-index byte limit
+            // (191 chars * 4 bytes = 764 bytes; index max 767 pre-8.0).
+            $table->string('email', 190);
+
+            // 64-char opaque tokens. `unique` on each so the confirm /
+            // unsubscribe routes can find their row by token alone
+            // (no email guessing).
+            $table->string('confirmation_token', 64)->unique();
+            $table->string('unsubscribe_token', 64)->unique();
+
+            $table->timestamp('confirmed_at')->nullable();
+
+            $table->timestamps();
+
+            // One subscription per email per project. Repeated subscribe
+            // POSTs from the same email regenerate the tokens without
+            // creating a second row.
+            $table->unique(['project_id', 'email']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('public_status_subscribers');
+    }
+};

--- a/docs/security/operator-checklist.md
+++ b/docs/security/operator-checklist.md
@@ -97,6 +97,10 @@ Per-user limits via Laravel's `throttle:N,1` middleware:
 | `POST /settings/rules` | 10/min (spec 046) |
 | `PATCH /settings/rules/{rule}` | 20/min (spec 046) |
 | `DELETE /settings/rules/{rule}` | 20/min (spec 046) |
+| `GET /status/{project:slug}` | 120/min (spec 047 — public traffic) |
+| `POST /status/{project:slug}/subscribe` | 20/min (spec 047) |
+| `GET /status/{project:slug}/confirm/{token}` | 60/min (spec 047) |
+| `GET /status/subscribers/unsubscribe/{token}` | 60/min (spec 047) |
 
 **Sign-off ☐:** Tested in
 [`ManualSyncRateLimitTest`](../../tests/Feature/Security/ManualSyncRateLimitTest.php).

--- a/resources/js/Pages/Projects/Edit.vue
+++ b/resources/js/Pages/Projects/Edit.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import AppLayout from '@/Layouts/AppLayout.vue';
 import ProjectForm from '@/Pages/Projects/Partials/ProjectForm.vue';
-import { Head, Link } from '@inertiajs/vue3';
-import { ChevronLeft } from 'lucide-vue-next';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import { ChevronLeft, Copy, Globe2 } from 'lucide-vue-next';
+import { ref } from 'vue';
 
 interface OptionPill {
     value: string;
@@ -20,6 +21,10 @@ interface ProjectShape {
     environment: string | null;
     color: string | null;
     icon: string | null;
+    public_status_enabled: boolean;
+    public_status_headline: string | null;
+    public_status_url: string | null;
+    public_status_subscriber_count: number;
 }
 
 const props = defineProps<{
@@ -31,6 +36,46 @@ const props = defineProps<{
         icons: string[];
     };
 }>();
+
+const publicForm = useForm({
+    // Spec 047 — the projects.update endpoint accepts every field via
+    // full PATCH replace, so we mirror the main form's fields here to
+    // avoid clobbering them when saving the public-status slice alone.
+    name: props.project.name,
+    description: props.project.description,
+    status: props.project.status,
+    priority: props.project.priority,
+    environment: props.project.environment,
+    color: props.project.color,
+    icon: props.project.icon,
+    public_status_enabled: props.project.public_status_enabled,
+    public_status_headline: props.project.public_status_headline ?? '',
+});
+
+const savedFlash = ref<string | null>(null);
+
+const submitPublic = () => {
+    publicForm.patch(route('projects.update', props.project.slug), {
+        preserveScroll: true,
+        onSuccess: () => {
+            savedFlash.value = 'Public status settings saved.';
+            setTimeout(() => (savedFlash.value = null), 3000);
+        },
+    });
+};
+
+const copyUrl = async () => {
+    if (! props.project.public_status_url) return;
+    try {
+        await navigator.clipboard.writeText(props.project.public_status_url);
+        savedFlash.value = 'Public URL copied to clipboard.';
+        setTimeout(() => (savedFlash.value = null), 2000);
+    } catch {
+        // Clipboard API unavailable in some contexts; fall back to selection.
+        savedFlash.value = 'Copy the URL from the field above.';
+        setTimeout(() => (savedFlash.value = null), 3000);
+    }
+};
 </script>
 
 <template>
@@ -62,6 +107,77 @@ const props = defineProps<{
                     :cancel-to="route('projects.show', project.slug)"
                     submit-label="Save changes"
                 />
+            </section>
+
+            <!-- Spec 047 — Public status page panel -->
+            <section class="glass-card mx-auto mt-6 max-w-3xl p-6 sm:p-8">
+                <header class="mb-4 flex items-center gap-2">
+                    <Globe2 class="h-5 w-5 text-accent-cyan" aria-hidden="true" />
+                    <h2 class="text-lg font-semibold text-text-primary">Public status page</h2>
+                </header>
+                <p class="mb-4 text-sm text-text-secondary">
+                    When enabled, anyone with the link can view real-time monitor uptime, active
+                    incidents, and recent history. Subscribers get email updates on incident
+                    transitions.
+                </p>
+                <form class="space-y-4" @submit.prevent="submitPublic">
+                    <label class="flex items-center gap-3 text-sm text-text-primary">
+                        <input
+                            v-model="publicForm.public_status_enabled"
+                            type="checkbox"
+                            class="h-4 w-4 rounded border-border-subtle bg-background-panel-hover"
+                        >
+                        Enable public status page
+                    </label>
+                    <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                        Headline (optional)
+                        <input
+                            v-model="publicForm.public_status_headline"
+                            type="text"
+                            maxlength="240"
+                            placeholder="A short banner shown above incidents."
+                            class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                        >
+                    </label>
+                    <div v-if="project.public_status_url" class="flex flex-col gap-2">
+                        <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                            Public URL
+                            <div class="flex items-center gap-2">
+                                <input
+                                    :value="project.public_status_url"
+                                    type="text"
+                                    readonly
+                                    class="flex-1 rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary"
+                                >
+                                <button
+                                    type="button"
+                                    class="inline-flex items-center gap-2 rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-xs font-semibold text-text-secondary transition hover:border-accent-cyan/40 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                    @click="copyUrl"
+                                >
+                                    <Copy class="h-3.5 w-3.5" aria-hidden="true" />
+                                    Copy
+                                </button>
+                            </div>
+                        </label>
+                        <p class="text-[11px] text-text-muted">
+                            {{ project.public_status_subscriber_count }} confirmed subscriber<span v-if="project.public_status_subscriber_count !== 1">s</span>
+                        </p>
+                    </div>
+                    <p
+                        v-if="savedFlash"
+                        role="status"
+                        class="text-xs text-emerald-300"
+                    >
+                        {{ savedFlash }}
+                    </p>
+                    <button
+                        type="submit"
+                        :disabled="publicForm.processing"
+                        class="inline-flex items-center gap-2 rounded-lg bg-accent-cyan px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-accent-cyan/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        Save public status settings
+                    </button>
+                </form>
             </section>
         </div>
     </AppLayout>

--- a/resources/js/Pages/Projects/Edit.vue
+++ b/resources/js/Pages/Projects/Edit.vue
@@ -38,16 +38,10 @@ const props = defineProps<{
 }>();
 
 const publicForm = useForm({
-    // Spec 047 — the projects.update endpoint accepts every field via
-    // full PATCH replace, so we mirror the main form's fields here to
-    // avoid clobbering them when saving the public-status slice alone.
-    name: props.project.name,
-    description: props.project.description,
-    status: props.project.status,
-    priority: props.project.priority,
-    environment: props.project.environment,
-    color: props.project.color,
-    icon: props.project.icon,
+    // Spec 047 — only ship the public-status fields. UpdateProjectRequest
+    // treats every field as `sometimes`, so the main form's values stay
+    // untouched even if the operator saves this panel after editing the
+    // main form without a refresh.
     public_status_enabled: props.project.public_status_enabled,
     public_status_headline: props.project.public_status_headline ?? '',
 });

--- a/resources/js/Pages/Status/Confirmed.vue
+++ b/resources/js/Pages/Status/Confirmed.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { Head, Link } from '@inertiajs/vue3';
+
+defineProps<{
+    project: { name: string; slug: string };
+}>();
+</script>
+
+<template>
+    <Head title="Subscription confirmed" />
+
+    <div class="min-h-screen bg-slate-950 text-slate-100">
+        <main class="mx-auto flex max-w-lg flex-col items-center px-4 py-16 text-center">
+            <p class="text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-500">
+                Subscription confirmed
+            </p>
+            <h1 class="mt-2 text-2xl font-semibold text-slate-50">You're subscribed</h1>
+            <p class="mt-4 text-sm text-slate-300">
+                You'll receive email updates for incidents affecting
+                <strong class="text-slate-50">{{ project.name }}</strong>.
+            </p>
+            <Link
+                :href="route('public-status.show', { project: project.slug })"
+                class="mt-6 rounded-lg bg-cyan-400 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300"
+            >
+                Back to status page
+            </Link>
+        </main>
+    </div>
+</template>

--- a/resources/js/Pages/Status/Show.vue
+++ b/resources/js/Pages/Status/Show.vue
@@ -1,0 +1,242 @@
+<script setup lang="ts">
+import { Head, useForm } from '@inertiajs/vue3';
+
+type Band = 'operational' | 'degraded' | 'partial_outage' | 'major_outage';
+type Severity = 'info' | 'warning' | 'critical';
+
+interface Monitor {
+    id: number;
+    name: string;
+    url: string;
+    status: string | null;
+    uptime_24h: number | null;
+    uptime_7d: number | null;
+    uptime_30d: number | null;
+}
+
+interface Incident {
+    id: number;
+    title: string;
+    severity: Severity;
+    status?: string;
+    triggered_at: string | null;
+    triggered_at_human?: string;
+    resolved_at?: string | null;
+    resolved_at_human?: string;
+}
+
+interface StatusPayload {
+    project_id: number;
+    project_name: string;
+    project_slug: string;
+    headline: string | null;
+    overall_band: Band;
+    overall_label: string;
+    monitors: Monitor[];
+    active_incidents: Incident[];
+    recent_incidents: Incident[];
+    last_updated_at: string;
+}
+
+const props = defineProps<{
+    status: StatusPayload;
+    flash?: { status?: string | null; error?: string | null };
+}>();
+
+const subscribeForm = useForm({
+    email: '',
+    honeypot: '',
+});
+
+const submitSubscribe = () => {
+    subscribeForm.post(
+        route('public-status.subscribe', { project: props.status.project_slug }),
+        {
+            preserveScroll: true,
+            onSuccess: () => subscribeForm.reset('email'),
+        },
+    );
+};
+
+const bandBg: Record<Band, string> = {
+    operational: 'bg-emerald-950/60 border-emerald-500/40 text-emerald-300',
+    degraded: 'bg-cyan-950/60 border-cyan-500/40 text-cyan-300',
+    partial_outage: 'bg-amber-950/60 border-amber-500/40 text-amber-300',
+    major_outage: 'bg-rose-950/60 border-rose-500/40 text-rose-300',
+};
+
+const severityColor: Record<Severity, string> = {
+    info: 'text-cyan-300',
+    warning: 'text-amber-300',
+    critical: 'text-rose-300',
+};
+
+const formatUptime = (v: number | null) => (v === null ? '—' : `${v.toFixed(2)}%`);
+</script>
+
+<template>
+    <Head :title="`${status.project_name} status`" />
+
+    <div class="min-h-screen bg-slate-950 text-slate-100">
+        <main class="mx-auto max-w-3xl px-4 py-12 sm:px-6">
+            <header class="mb-8">
+                <p class="text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-500">
+                    Status page
+                </p>
+                <h1 class="mt-1 text-2xl font-semibold text-slate-50">
+                    {{ status.project_name }}
+                </h1>
+                <p v-if="status.headline" class="mt-3 text-sm text-slate-300">
+                    {{ status.headline }}
+                </p>
+            </header>
+
+            <!-- Overall band -->
+            <section
+                class="rounded-2xl border p-6 text-center"
+                :class="bandBg[status.overall_band]"
+            >
+                <p class="text-lg font-semibold">{{ status.overall_label }}</p>
+            </section>
+
+            <!-- Flash messages -->
+            <p
+                v-if="props.flash?.status"
+                class="mt-4 rounded-lg border border-emerald-500/40 bg-emerald-950/40 px-4 py-2 text-sm text-emerald-200"
+                role="status"
+            >
+                {{ props.flash.status }}
+            </p>
+            <p
+                v-if="props.flash?.error"
+                class="mt-4 rounded-lg border border-rose-500/40 bg-rose-950/40 px-4 py-2 text-sm text-rose-200"
+                role="alert"
+            >
+                {{ props.flash.error }}
+            </p>
+
+            <!-- Monitors -->
+            <section v-if="status.monitors.length > 0" class="mt-8">
+                <h2 class="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    Monitors
+                </h2>
+                <ul class="divide-y divide-slate-800 rounded-2xl border border-slate-800 bg-slate-900/50">
+                    <li
+                        v-for="monitor in status.monitors"
+                        :key="monitor.id"
+                        class="flex flex-col gap-2 p-4 sm:flex-row sm:items-center sm:justify-between"
+                    >
+                        <div class="min-w-0">
+                            <p class="text-sm font-semibold text-slate-50">{{ monitor.name }}</p>
+                            <p class="truncate text-[11px] text-slate-500">{{ monitor.url }}</p>
+                        </div>
+                        <dl class="grid grid-cols-3 gap-4 text-right text-[11px] text-slate-400">
+                            <div>
+                                <dt class="uppercase tracking-[0.18em]">24h</dt>
+                                <dd class="font-mono text-slate-100">{{ formatUptime(monitor.uptime_24h) }}</dd>
+                            </div>
+                            <div>
+                                <dt class="uppercase tracking-[0.18em]">7d</dt>
+                                <dd class="font-mono text-slate-100">{{ formatUptime(monitor.uptime_7d) }}</dd>
+                            </div>
+                            <div>
+                                <dt class="uppercase tracking-[0.18em]">30d</dt>
+                                <dd class="font-mono text-slate-100">{{ formatUptime(monitor.uptime_30d) }}</dd>
+                            </div>
+                        </dl>
+                    </li>
+                </ul>
+            </section>
+
+            <!-- Active incidents -->
+            <section v-if="status.active_incidents.length > 0" class="mt-8">
+                <h2 class="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    Active incidents
+                </h2>
+                <ul class="space-y-3">
+                    <li
+                        v-for="incident in status.active_incidents"
+                        :key="incident.id"
+                        class="rounded-2xl border border-slate-800 bg-slate-900/50 p-4"
+                    >
+                        <p class="text-sm font-semibold" :class="severityColor[incident.severity]">
+                            {{ incident.title }}
+                        </p>
+                        <p class="mt-1 text-[11px] text-slate-500">
+                            Opened {{ incident.triggered_at_human ?? incident.triggered_at }}
+                        </p>
+                    </li>
+                </ul>
+            </section>
+
+            <!-- Recent incidents -->
+            <section v-if="status.recent_incidents.length > 0" class="mt-8">
+                <h2 class="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    Recent history
+                </h2>
+                <ul class="space-y-3">
+                    <li
+                        v-for="incident in status.recent_incidents"
+                        :key="incident.id"
+                        class="rounded-2xl border border-slate-800 bg-slate-900/50 p-4"
+                    >
+                        <p class="text-sm font-semibold" :class="severityColor[incident.severity]">
+                            {{ incident.title }}
+                        </p>
+                        <p class="mt-1 text-[11px] text-slate-500">
+                            Resolved {{ incident.resolved_at_human ?? incident.resolved_at }}
+                        </p>
+                    </li>
+                </ul>
+            </section>
+
+            <!-- Subscribe form -->
+            <section class="mt-10">
+                <h2 class="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    Get incident notifications
+                </h2>
+                <form class="rounded-2xl border border-slate-800 bg-slate-900/50 p-4" @submit.prevent="submitSubscribe">
+                    <label class="flex flex-col gap-2">
+                        <span class="text-xs text-slate-400">
+                            Enter your email — we'll send a confirmation link.
+                        </span>
+                        <input
+                            v-model="subscribeForm.email"
+                            type="email"
+                            required
+                            placeholder="you@example.com"
+                            class="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/60"
+                        >
+                    </label>
+                    <!-- Honeypot: real users leave this empty; bots fill it. -->
+                    <input
+                        v-model="subscribeForm.honeypot"
+                        type="text"
+                        name="honeypot"
+                        tabindex="-1"
+                        autocomplete="off"
+                        aria-hidden="true"
+                        class="hidden"
+                    >
+                    <p
+                        v-if="subscribeForm.errors.email"
+                        class="mt-2 text-xs text-rose-300"
+                    >
+                        {{ subscribeForm.errors.email }}
+                    </p>
+                    <button
+                        type="submit"
+                        :disabled="subscribeForm.processing"
+                        class="mt-3 inline-flex items-center gap-2 rounded-lg bg-cyan-400 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-cyan-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/60 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        Subscribe
+                    </button>
+                </form>
+            </section>
+
+            <footer class="mt-12 border-t border-slate-800 pt-6 text-center text-[11px] text-slate-500">
+                <p>Powered by Nexus Control Center · Last updated {{ status.last_updated_at }}</p>
+            </footer>
+        </main>
+    </div>
+</template>

--- a/resources/js/Pages/Status/Unsubscribed.vue
+++ b/resources/js/Pages/Status/Unsubscribed.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { Head, Link } from '@inertiajs/vue3';
+
+defineProps<{
+    project: { name: string | null; slug: string | null };
+}>();
+</script>
+
+<template>
+    <Head title="Unsubscribed" />
+
+    <div class="min-h-screen bg-slate-950 text-slate-100">
+        <main class="mx-auto flex max-w-lg flex-col items-center px-4 py-16 text-center">
+            <p class="text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-500">
+                Unsubscribed
+            </p>
+            <h1 class="mt-2 text-2xl font-semibold text-slate-50">You're unsubscribed</h1>
+            <p class="mt-4 text-sm text-slate-300">
+                You won't receive further updates
+                <template v-if="project.name">
+                    for <strong class="text-slate-50">{{ project.name }}</strong>
+                </template>.
+            </p>
+            <Link
+                v-if="project.slug"
+                :href="route('public-status.show', { project: project.slug })"
+                class="mt-6 rounded-lg border border-slate-700 bg-slate-900 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:border-cyan-400/40"
+            >
+                View status page
+            </Link>
+        </main>
+    </div>
+</template>

--- a/resources/views/emails/public-status/incident.blade.php
+++ b/resources/views/emails/public-status/incident.blade.php
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{{ $alertTitle }}</title>
+</head>
+<body style="margin:0;padding:0;background:#0f172a;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#e2e8f0;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0f172a;padding:32px 16px;">
+        <tr>
+            <td align="center">
+                <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="max-width:560px;background:#1e293b;border:1px solid rgba(148,163,184,0.24);border-radius:16px;overflow:hidden;">
+                    <tr>
+                        <td style="padding:20px 24px;background:{{ $event === 'resolved' ? '#065f46' : ($alertSeverity === 'critical' ? '#7f1d1d' : ($alertSeverity === 'warning' ? '#78350f' : '#155e75')) }};color:#f8fafc;font-size:12px;letter-spacing:0.12em;text-transform:uppercase;font-weight:600;">
+                            @if ($event === 'resolved')
+                                {{ $projectName }} · Incident resolved
+                            @else
+                                {{ $projectName }} · Incident open · {{ ucfirst($alertSeverity) }}
+                            @endif
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding:24px;">
+                            <p style="margin:0 0 12px;font-size:20px;font-weight:600;color:#f8fafc;">{{ $alertTitle }}</p>
+                            @if (! empty($alertDescription))
+                                <p style="margin:0 0 20px;font-size:14px;line-height:1.6;color:#cbd5e1;">{{ $alertDescription }}</p>
+                            @endif
+                            <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;margin:0 0 20px;font-size:13px;color:#94a3b8;">
+                                <tr>
+                                    <td style="padding:4px 0;width:120px;">Started</td>
+                                    <td style="padding:4px 0;color:#e2e8f0;">{{ optional($triggeredAt)->format('Y-m-d H:i:s T') ?? '—' }}</td>
+                                </tr>
+                                @if ($event === 'resolved')
+                                    <tr>
+                                        <td style="padding:4px 0;">Resolved</td>
+                                        <td style="padding:4px 0;color:#e2e8f0;">{{ optional($resolvedAt)->format('Y-m-d H:i:s T') ?? '—' }}</td>
+                                    </tr>
+                                @endif
+                            </table>
+                            <a href="{{ $statusUrl }}" style="display:inline-block;padding:10px 18px;background:#22d3ee;color:#0f172a;font-weight:600;text-decoration:none;border-radius:8px;font-size:14px;">View status page</a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding:16px 24px;background:#0f172a;color:#64748b;font-size:12px;">
+                            You're subscribed to incident updates for {{ $projectName }}.
+                            <a href="{{ $unsubscribeUrl }}" style="color:#22d3ee;text-decoration:none;">Unsubscribe</a>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/resources/views/emails/public-status/subscribe-confirmation.blade.php
+++ b/resources/views/emails/public-status/subscribe-confirmation.blade.php
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Confirm your subscription</title>
+</head>
+<body style="margin:0;padding:0;background:#0f172a;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#e2e8f0;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0f172a;padding:32px 16px;">
+        <tr>
+            <td align="center">
+                <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="max-width:560px;background:#1e293b;border:1px solid rgba(148,163,184,0.24);border-radius:16px;overflow:hidden;">
+                    <tr>
+                        <td style="padding:24px;">
+                            <p style="margin:0 0 12px;font-size:20px;font-weight:600;color:#f8fafc;">
+                                Confirm your subscription
+                            </p>
+                            <p style="margin:0 0 20px;font-size:14px;line-height:1.6;color:#cbd5e1;">
+                                You (or someone using this address) asked to receive incident notifications for
+                                <strong>{{ $projectName }}</strong>. Click below to confirm.
+                            </p>
+                            <a href="{{ $confirmUrl }}" style="display:inline-block;padding:10px 18px;background:#22d3ee;color:#0f172a;font-weight:600;text-decoration:none;border-radius:8px;font-size:14px;">
+                                Confirm subscription
+                            </a>
+                            <p style="margin:24px 0 0;font-size:12px;color:#94a3b8;">
+                                If you didn't request this, ignore the email — no subscription will be created.
+                            </p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding:16px 24px;background:#0f172a;color:#64748b;font-size:12px;">
+                            Status page: <a href="{{ $statusUrl }}" style="color:#22d3ee;text-decoration:none;">{{ $statusUrl }}</a>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,10 @@ use App\Http\Controllers\OverviewController;
 use App\Http\Controllers\PaletteSearchController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ProjectController;
+use App\Http\Controllers\PublicStatus\ConfirmSubscriptionController;
+use App\Http\Controllers\PublicStatus\ShowController;
+use App\Http\Controllers\PublicStatus\SubscribeController;
+use App\Http\Controllers\PublicStatus\UnsubscribeController;
 use App\Http\Controllers\RepositoryController;
 use App\Http\Controllers\RepositoryIssuesSyncController;
 use App\Http\Controllers\RepositoryPullRequestsSyncController;
@@ -276,5 +280,22 @@ Route::middleware('auth')->group(function () {
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
+
+// Spec 047 — public status page + subscribers. Guest-safe;
+// throttled per §5 of the operator checklist. Placed at the bottom so
+// the auth-scoped `/settings/*` routes above shadow any accidental
+// name collision.
+Route::get('/status/{project:slug}', ShowController::class)
+    ->middleware('throttle:120,1')
+    ->name('public-status.show');
+Route::post('/status/{project:slug}/subscribe', SubscribeController::class)
+    ->middleware('throttle:20,1')
+    ->name('public-status.subscribe');
+Route::get('/status/{project:slug}/confirm/{token}', ConfirmSubscriptionController::class)
+    ->middleware('throttle:60,1')
+    ->name('public-status.confirm');
+Route::get('/status/subscribers/unsubscribe/{token}', UnsubscribeController::class)
+    ->middleware('throttle:60,1')
+    ->name('public-status.unsubscribe');
 
 require __DIR__.'/auth.php';

--- a/specs/README.md
+++ b/specs/README.md
@@ -45,7 +45,7 @@ Status legend: ⬜ not started · 🟡 in progress · 🟢 done · 🔴 blocked
 | 7 | Alerts Engine | 🟢 | 3/3 specs done (030–032). Phase complete. |
 | 8 | Analytics & Health Scores | 🟢 | 3/3 specs done (033–035). Phase complete. |
 | 9 | Polish & Production Readiness | 🟢 | 6/6 specs done (036–041). Phase complete. |
-| 10 | Future Innovation | 🟡 | 3/6 specs done (042, 043, 046). 044–045 + 047 remaining. |
+| 10 | Future Innovation | 🟡 | 4/6 specs done (042, 043, 046, 047). AI pair 044–045 remaining. |
 
 ## MVP scope (target for v1)
 

--- a/specs/phase-10-innovation/047-public-status-page.md
+++ b/specs/phase-10-innovation/047-public-status-page.md
@@ -1,7 +1,7 @@
 ---
 spec: public-status-page
 phase: 10
-status: in-progress   # not-started | in-progress | blocked | done
+status: done   # not-started | in-progress | blocked | done
 owner: Yoany
 created: 2026-07-02
 updated: 2026-07-02

--- a/specs/phase-10-innovation/047-public-status-page.md
+++ b/specs/phase-10-innovation/047-public-status-page.md
@@ -1,0 +1,335 @@
+---
+spec: public-status-page
+phase: 10
+status: in-progress   # not-started | in-progress | blocked | done
+owner: Yoany
+created: 2026-07-02
+updated: 2026-07-02
+---
+
+# 047 — Public status page generator + subscribers
+
+## Goal
+
+Every SaaS ships one: a public `/status/{slug}` page an operator can
+link from their landing page so customers know at a glance whether
+things are up. Phase 10 wraps up its innovation slice with this —
+Nexus already has the raw data (spec 025's uptime windows, spec 030's
+alerts, spec 038's system health) and needs one thin public surface
++ a subscriber list + a delivery loop.
+
+Roadmap refs: §Phase 10 Future Features ("Status page generator"),
+§14 Analytics (uptime windows already computed),
+§Phase 7 alerts (feeds the incidents strip), spec 042 delivery layer
+(reused for subscriber notifications).
+
+## Scope
+
+**In scope:**
+
+- **Per-project opt-in.** Add `public_status_enabled` (boolean,
+  default false) + `public_status_headline` (nullable string,
+  operator-provided banner text) to the `projects` table. The
+  existing `slug` column becomes the public URL segment.
+
+- **Public route `GET /status/{project:slug}`.** Unauthenticated,
+  guest-safe, no CSRF cookie needed. Renders a lightweight Inertia
+  page (`Pages/Status/Show.vue`) with:
+  - **Overall status band** — `Operational` / `Degraded` /
+    `Partial outage` / `Major outage`. Computed from open-alert
+    count + severity + monitor status.
+  - **Monitor strip** — one row per website belonging to the
+    project, showing 24h + 7d + 30d uptime %.
+  - **Recent incidents** — the last 10 resolved alerts (title,
+    severity, opened / resolved timestamps).
+  - **Active incidents** — open + acknowledged alerts (title,
+    severity, opened at).
+  - **Subscribe form** — email input + submit. Client-side + server-
+    side email validation, honeypot field for bots.
+  - **Powered-by-Nexus** footer link.
+  - Rate limit: `throttle:120,1` on the view (public traffic).
+
+- **Cached status snapshot.** `GetPublicStatusPageQuery::execute($project)`
+  returns the assembled DTO. Wrapped in `Cache::remember("public-status:{$project->id}", 60, ...)`
+  so a viral share doesn't hammer the DB. Cache invalidated on
+  every relevant transition — alert trigger/resolve on the project
+  fires a `Cache::forget("public-status:{$project->id}")` via a
+  new `InvalidatePublicStatusCacheListener`.
+
+- **Subscribers table.**
+  ```
+  public_status_subscribers
+    id
+    project_id (FK → projects, cascade delete)
+    email      (string 190, indexed)
+    confirmation_token   (string 64, unique)
+    unsubscribe_token    (string 64, unique)
+    confirmed_at (nullable timestamp)
+    timestamps
+  ```
+  Composite unique on `(project_id, email)` — one subscription per
+  email per project. Deleting a project cascades to subscribers.
+
+- **Double opt-in flow.**
+  - `POST /status/{project:slug}/subscribe` — validates email, honey-
+    pot, throttle `20,1`. Creates a `public_status_subscribers` row
+    with a fresh `confirmation_token` + `unsubscribe_token`, sends a
+    confirmation email (via Laravel `Mail::to`). Never confirms
+    directly — every subscription requires the round trip so a
+    stranger can't sign up your inbox for someone else's status.
+  - `GET /status/{project:slug}/confirm/{token}` — flips
+    `confirmed_at`, renders a "You're subscribed" page. Unknown
+    token → 404.
+  - `GET /status/subscribers/unsubscribe/{token}` — one-click
+    unsubscribe (RFC 8058 style, one-URL). Deletes the row. Unknown
+    token → 404. Rate-limited `throttle:60,1`.
+
+- **Notification loop.**
+  - `NotifyStatusSubscribersJob(alertId)` — takes a triggered
+    `Alert` row, resolves the alert's project, iterates confirmed
+    subscribers, mails each with an incident summary.
+  - Dispatched from a new `NotifyPublicSubscribersOnAlertListener`
+    that listens for `AlertTriggered` + `AlertResolved` (spec 032
+    events). Fire-and-forget from the listener — an unreachable
+    SMTP shouldn't taint the alert lifecycle.
+  - Deduped: same `(project_id, alert_id)` won't fire more than
+    once per event (`ShouldBeUnique` keyed on both).
+  - Skipped when `project.public_status_enabled` is false or when
+    no confirmed subscribers exist.
+  - **Not** riding on spec 042's `AlertNotificationService`. That
+    service scopes preferences to authenticated users; public
+    subscribers are anonymous and use a separate delivery path.
+
+- **Emails.**
+  - `PublicStatusSubscribeConfirmationMail` — bare confirm link.
+  - `PublicStatusIncidentMail` — incident title + severity + open /
+    resolve timestamp + link back to `/status/{slug}` + one-click
+    unsubscribe.
+  - Both templates minimal; the header + body match spec 042's
+    email visual language (dark card, severity color, footer
+    disclaimer).
+
+- **Settings surface.** Extend the project edit page (or add a
+  small `Settings/Projects/PublicStatus.vue` panel) with:
+  - Toggle for `public_status_enabled`.
+  - Text input for `public_status_headline`.
+  - "Public URL" preview + copy button (once enabled).
+  - Subscriber count read-only.
+  - Rate limit: form endpoint `throttle:20,1`.
+
+- **Palette command.** New "Copy public status URL for {project}"
+  action (spec 043 palette) surfaced when the palette query matches
+  the project name and public status is enabled. Deferred if it
+  requires per-entity dynamic commands the palette scaffold doesn't
+  support today — ship as a static "Open public status" nav if the
+  dynamic-command dependency is too big.
+
+- **Tests.**
+  - `PublicStatusPageControllerTest` — happy path renders for an
+    enabled project; disabled project 404s; unknown slug 404s;
+    throttle engaged after 120/min.
+  - `PublicStatusSubscribeControllerTest` — happy path creates a
+    row + sends a confirmation email (`Mail::fake()`); duplicate
+    email is idempotent (updates token, doesn't create second
+    row); honeypot filled 422; throttle at 20/min; invalid email
+    422; disabled project 404.
+  - `PublicStatusSubscribeConfirmationTest` — confirm flips
+    `confirmed_at`; unknown token 404; already-confirmed second
+    hit stays idempotent.
+  - `PublicStatusUnsubscribeControllerTest` — happy path deletes
+    the row; unknown token 404.
+  - `NotifyStatusSubscribersJobTest` — fires only to confirmed
+    subscribers; skips when project has `public_status_enabled=false`;
+    skips when zero confirmed rows; `Mail::fake()` proves the
+    per-subscriber send.
+  - `NotifyPublicSubscribersOnAlertListenerTest` — `AlertTriggered`
+    on an enabled project enqueues the job; `AlertTriggered` on a
+    disabled project doesn't; `AlertResolved` triggers the same
+    path with an appropriate subject.
+  - `GetPublicStatusPageQueryTest` — assembled DTO shape matches
+    spec (overall band + monitors + active + recent); cache key /
+    TTL respected; forget-on-transition proven via
+    `Cache::spy()`.
+
+**Out of scope:**
+
+- **Historical uptime graph beyond 30d.** The page shows 24h + 7d +
+  30d; older windows land in a follow-up (needs a rollup table
+  because scanning `website_checks` for 90+ days is expensive).
+- **Component groups.** Statuspage.io-style "Storefront →
+  {Frontend, API, CDN}" nested components. Nexus's data model is
+  flat (projects → websites); nested grouping is a Phase 11 UX
+  redesign, not a Phase 10 deliverable.
+- **Custom domain per status page.** `status.customer.com` requires
+  wildcard TLS + a DNS-verification loop. Ship `/status/{slug}`
+  first; custom domains are a follow-up.
+- **Custom theming per project.** Body colors match Nexus's dark
+  theme. Operators asking for their brand colors can wait for a
+  Phase 11 theming spec.
+- **Incident postmortem drafting.** A separate long-form incident
+  writeup UI is a real feature but overlaps with the deferred
+  "Incident management" (Phase 11 wishlist).
+- **Slack / webhook subscriber channels.** Only email in v1.
+  Extending the subscribers table to carry a `channel_kind` +
+  `config` opens the door to Slack/webhook parity later.
+- **Anti-spam captcha.** Honeypot + `throttle:20,1` is enough for
+  v1. Real captcha (hCaptcha / Turnstile) is a follow-up if
+  operators hit spam.
+- **RSS / iCalendar feed for incidents.** Nice for downstream
+  monitoring; defer.
+
+## Plan
+
+1. **Migration + model tweak.** Add `public_status_enabled` +
+   `public_status_headline` to `projects`. New
+   `public_status_subscribers` table + model + factory.
+2. **Query class.** `GetPublicStatusPageQuery::execute($project)` —
+   reads uptime windows, alerts, computes overall band. Cache-
+   remember wrapper.
+3. **Public controllers.**
+   `App\Http\Controllers\PublicStatus\ShowController` (index),
+   `SubscribeController` (POST subscribe + GET confirm),
+   `UnsubscribeController` (GET unsubscribe). All under a shared
+   `throttle` middleware group.
+4. **Route registration.** Guest-safe `/status/*` group at the
+   bottom of `routes/web.php`, no auth middleware.
+5. **Notification pieces.** Two `Mailable` classes + Blade
+   templates. `NotifyStatusSubscribersJob` +
+   `NotifyPublicSubscribersOnAlertListener` (wired in
+   `EventServiceProvider`).
+6. **Cache invalidation listener.**
+   `InvalidatePublicStatusCacheListener` on `AlertTriggered` +
+   `AlertResolved` + potentially `WebsiteCheckRecorded` (throttled
+   so a chatty monitor doesn't flush the cache every 60s).
+7. **Settings UI.** Extend the project edit form or ship a small
+   dedicated panel — pick whichever integrates cleanest with the
+   Phase 1 project CRUD.
+8. **Public status page Vue component.** Simple static-feeling
+   render; no realtime layer (operators viewing don't need
+   sub-minute updates on a public page).
+9. **Palette command.** Best-effort — ship if the current palette
+   scaffold supports it without new plumbing.
+10. **Docs.** Extend `docs/security/operator-checklist.md` §5 with
+    the new endpoints; add a note about the double opt-in +
+    unsubscribe token contract.
+11. **Pint + suite + build + self-review + PR.**
+
+## Acceptance criteria
+
+- [ ] `/status/{project.slug}` renders unauthenticated for an
+      opted-in project; 404s otherwise.
+- [ ] Page shows overall status band, per-monitor uptime (24h/7d/30d),
+      active incidents, recent incidents.
+- [ ] Subscribe form creates a `public_status_subscribers` row,
+      sends a confirmation email, respects honeypot + throttle.
+- [ ] `GET /status/{slug}/confirm/{token}` flips `confirmed_at`;
+      unknown token 404.
+- [ ] `GET /status/subscribers/unsubscribe/{token}` deletes the row.
+- [ ] `AlertTriggered` + `AlertResolved` on an opted-in project
+      enqueue `NotifyStatusSubscribersJob`; disabled projects skip.
+- [ ] `NotifyStatusSubscribersJob` mails only confirmed subscribers.
+- [ ] Status snapshot is cached 60s; invalidated on alert
+      trigger/resolve transitions.
+- [ ] Every new endpoint throttled per §5 of the operator
+      checklist.
+- [ ] Every test in §Tests block green.
+- [ ] Pint clean, `php artisan test` green, `npm run build`
+      clean.
+
+## Files touched
+
+- `database/migrations/2026_07_02_*_add_public_status_fields_to_projects_table.php` — created
+- `database/migrations/2026_07_02_*_create_public_status_subscribers_table.php` — created
+- `app/Models/Project.php` — new fillables + casts for the two new columns
+- `app/Models/PublicStatusSubscriber.php` — created
+- `database/factories/PublicStatusSubscriberFactory.php` — created
+- `app/Domain/PublicStatus/DataTransferObjects/PublicStatusSnapshot.php` — created
+- `app/Domain/PublicStatus/Queries/GetPublicStatusPageQuery.php` — created (cache-remember wrapper)
+- `app/Domain/PublicStatus/Jobs/NotifyStatusSubscribersJob.php` — created
+- `app/Domain/PublicStatus/Listeners/InvalidatePublicStatusCacheListener.php` — created
+- `app/Domain/PublicStatus/Listeners/NotifyPublicSubscribersOnAlertListener.php` — created
+- `app/Http/Controllers/PublicStatus/ShowController.php` — created
+- `app/Http/Controllers/PublicStatus/SubscribeController.php` — created
+- `app/Http/Controllers/PublicStatus/UnsubscribeController.php` — created
+- `app/Http/Controllers/PublicStatus/ConfirmSubscriptionController.php` — created
+- `app/Mail/PublicStatusSubscribeConfirmationMail.php` — created
+- `app/Mail/PublicStatusIncidentMail.php` — created
+- `resources/views/emails/public-status/subscribe-confirmation.blade.php` — created
+- `resources/views/emails/public-status/incident.blade.php` — created
+- `app/Providers/EventServiceProvider.php` — register the two new listeners
+- `resources/js/Pages/Status/Show.vue` — created (public page shell)
+- `resources/js/Pages/Status/Confirmed.vue` — created (confirmation success page)
+- `resources/js/Pages/Status/Unsubscribed.vue` — created (unsubscribe success page)
+- `resources/js/Pages/Projects/*` — expose the public-status toggle + headline (extend Edit.vue or add a panel)
+- `routes/web.php` — guest-safe `/status/*` group at the bottom
+- `docs/security/operator-checklist.md` — §5 extended
+- `tests/Feature/PublicStatus/PublicStatusPageControllerTest.php` — created
+- `tests/Feature/PublicStatus/PublicStatusSubscribeControllerTest.php` — created
+- `tests/Feature/PublicStatus/PublicStatusSubscribeConfirmationTest.php` — created
+- `tests/Feature/PublicStatus/PublicStatusUnsubscribeControllerTest.php` — created
+- `tests/Feature/PublicStatus/NotifyStatusSubscribersJobTest.php` — created
+- `tests/Feature/PublicStatus/NotifyPublicSubscribersOnAlertListenerTest.php` — created
+- `tests/Feature/PublicStatus/GetPublicStatusPageQueryTest.php` — created
+
+## Work log
+
+Dated notes as work progresses.
+
+### 2026-07-02
+- Drafted from `_template.md`. Phase 10 closer.
+- **Not** riding on spec 042 — that service scopes to
+  authenticated users; public subscribers are anonymous and
+  use a distinct email-only delivery path. Sharing the code
+  would force spec 042 to carry public-facing concerns
+  (double opt-in, unsubscribe tokens, spam guards) it was
+  designed to avoid.
+- Kept `slug` as the URL segment (already unique + already the
+  public-safe identifier). No random hash — operators want the
+  URL to match their project's identity, and a project slug is
+  fine to expose (it's already surfaced in every dashboard URL
+  the operator uses).
+- Cache TTL at 60s balances "fresh enough for a status page"
+  vs. "not thrashing the DB under viral share." Invalidation on
+  alert transitions gives the appearance of realtime without
+  broadcasting to public viewers.
+- Branch `spec/047-public-status-page` cut off main.
+- Tracking issue #129.
+
+## Open questions / blockers
+
+- **Should the page auto-refresh?** Static render + no JS beyond
+  what Inertia already ships. Operators viewing a status page
+  don't need realtime; they refresh manually or wait 60s. The
+  cache TTL enforces the freshness ceiling. Decision: no
+  auto-refresh in v1.
+- **Cache key salting on `public_status_headline`.** The headline
+  is part of the page render, but changing it via Settings should
+  reflect immediately. Bump the cache key on save
+  (`Cache::forget` in the project update controller) rather than
+  including the headline in the key itself.
+- **Subscribers table growth.** No hard cap; one row per email
+  per project, so a bad-actor SMTP won't grow the table beyond
+  what their email list allows. Add a `public_status_subscribers`
+  count in the settings panel so operators notice unusual
+  growth. A hard cap is a follow-up.
+- **Double-opt-in email as public spam vector?** A bot posts
+  `victim@example.com` to a project's subscribe form → victim
+  gets a confirmation email from Nexus. That's the standard
+  double-opt-in tradeoff — the mail says "you're not subscribed
+  yet; click here to confirm" so an unclicked confirmation
+  costs the victim one email. `throttle:20,1` keeps the blast
+  radius small. `MAIL_FROM_ADDRESS` should be the operator's
+  own, not Nexus's, so replies land where they should — an
+  optional per-project override on the mail from-address is a
+  Phase 11 knob.
+- **Public status URL exposure via robots.** No robots.txt
+  intervention in v1. Operators who don't want crawler indexing
+  can add their own `robots.txt` rules; adding `noindex` by
+  default risks blocking operators who *want* their status page
+  crawled (linked to marketing). Ship as-is; document.
+- **Incident-notification cadence.** Every state change (trigger,
+  resolve) sends an email. Spec 042's dedupe window (5 min) is
+  the reference. Add a lightweight per-alert dedupe on the
+  subscriber job so a flapping alert doesn't spam subscribers
+  — check `alert.last_seen_at` moved less than 5 min since the
+  last mail sent; skip if not. Simple heuristic; ship.

--- a/specs/phase-10-innovation/README.md
+++ b/specs/phase-10-innovation/README.md
@@ -27,7 +27,7 @@ live.
 | 044 | AI daily briefing — LLM-generated morning digest ("yesterday: X new issues, Y merged PRs, Z alerts, N things that look off"), delivered via spec 042, per-user opt-in + delivery time | ⬜ |
 | 045 | AI PR risk score + project health explanation — LLM-scored PR risk tag on webhook arrival, natural-language "why" overlay on Phase 8 health-score card | ⬜ |
 | 046 | User-tunable health-score weights + metric-driven alert rules — settings page for Phase 8's formula, §6.8 specification pattern for alert evaluators (queue backlog trend, deploy frequency drop, uptime slope) | 🟢 |
-| 047 | Public status page generator — unauthenticated `/status/{slug}` aggregating monitoring uptime + system alerts + subscribe form; per-project toggle in Settings | ⬜ |
+| 047 | Public status page generator — unauthenticated `/status/{slug}` aggregating monitoring uptime + system alerts + subscribe form; per-project toggle in Settings | 🟢 |
 
 ## Acceptance criteria (phase-level)
 - [ ] Operators receive alerts via at least one channel outside the

--- a/tests/Feature/PublicStatus/AlertListenersTest.php
+++ b/tests/Feature/PublicStatus/AlertListenersTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature\PublicStatus;
+
+use App\Domain\Alerts\Actions\ResolveAlertAction;
+use App\Domain\Alerts\Actions\TriggerAlertAction;
+use App\Domain\PublicStatus\Jobs\NotifyStatusSubscribersJob;
+use App\Domain\PublicStatus\Queries\GetPublicStatusPageQuery;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+/**
+ * Spec 047 — listener behavior: enqueue notification jobs on alert
+ * transitions AND flush the cached status snapshot.
+ */
+class AlertListenersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_alert_triggered_on_opted_in_project_enqueues_notification_job(): void
+    {
+        Bus::fake();
+
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+
+        app(TriggerAlertAction::class)->execute([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website,
+            'source_id' => 1,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical,
+            'title' => 'Site down',
+        ]);
+
+        Bus::assertDispatched(
+            NotifyStatusSubscribersJob::class,
+            fn (NotifyStatusSubscribersJob $job) => $job->event === 'triggered',
+        );
+    }
+
+    public function test_alert_triggered_on_disabled_project_does_not_enqueue(): void
+    {
+        Bus::fake();
+
+        $project = Project::factory()->create(['public_status_enabled' => false]);
+
+        app(TriggerAlertAction::class)->execute([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website,
+            'source_id' => 1,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical,
+            'title' => 'Site down',
+        ]);
+
+        Bus::assertNotDispatched(NotifyStatusSubscribersJob::class);
+    }
+
+    public function test_alert_resolved_enqueues_with_resolved_event(): void
+    {
+        Bus::fake();
+
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+
+        app(TriggerAlertAction::class)->execute([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website,
+            'source_id' => 42,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical,
+            'title' => 'Site down',
+        ]);
+
+        app(ResolveAlertAction::class)->execute([
+            'source' => AlertSource::Website,
+            'source_id' => 42,
+            'type' => 'website.down',
+        ]);
+
+        Bus::assertDispatched(
+            NotifyStatusSubscribersJob::class,
+            fn (NotifyStatusSubscribersJob $job) => $job->event === 'resolved',
+        );
+    }
+
+    public function test_cache_is_forgotten_on_alert_transition(): void
+    {
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+        $cacheKey = GetPublicStatusPageQuery::cacheKey($project->id);
+
+        Cache::put($cacheKey, ['stale'], 60);
+
+        app(TriggerAlertAction::class)->execute([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website,
+            'source_id' => 1,
+            'type' => 'website.down',
+            'severity' => AlertSeverity::Critical,
+            'title' => 'Site down',
+        ]);
+
+        $this->assertFalse(Cache::has($cacheKey));
+    }
+}

--- a/tests/Feature/PublicStatus/GetPublicStatusPageQueryTest.php
+++ b/tests/Feature/PublicStatus/GetPublicStatusPageQueryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature\PublicStatus;
+
+use App\Domain\PublicStatus\Queries\GetPublicStatusPageQuery;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertStatus;
+use App\Enums\WebsiteCheckStatus;
+use App\Enums\WebsiteStatus;
+use App\Models\Alert;
+use App\Models\Project;
+use App\Models\Website;
+use App\Models\WebsiteCheck;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class GetPublicStatusPageQueryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_snapshot_contains_monitors_active_and_recent_incidents(): void
+    {
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+        $website = Website::factory()->create([
+            'project_id' => $project->id,
+            'status' => WebsiteStatus::Up->value,
+        ]);
+        WebsiteCheck::factory()->create([
+            'website_id' => $website->id,
+            'status' => WebsiteCheckStatus::Up->value,
+            'checked_at' => now()->subMinutes(5),
+        ]);
+
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Warning->value,
+            'status' => AlertStatus::Open->value,
+            'title' => 'Live alert',
+        ]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Warning->value,
+            'status' => AlertStatus::Resolved->value,
+            'title' => 'Historical alert',
+            'resolved_at' => now()->subHour(),
+        ]);
+
+        Cache::flush();
+        $snapshot = app(GetPublicStatusPageQuery::class)->execute($project);
+
+        $this->assertCount(1, $snapshot->monitors);
+        $this->assertSame('Live alert', $snapshot->activeIncidents[0]['title']);
+        $this->assertSame('Historical alert', $snapshot->recentIncidents[0]['title']);
+    }
+
+    public function test_snapshot_is_cached(): void
+    {
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+        $cacheKey = GetPublicStatusPageQuery::cacheKey($project->id);
+
+        Cache::flush();
+        app(GetPublicStatusPageQuery::class)->execute($project);
+
+        $this->assertTrue(Cache::has($cacheKey));
+    }
+}

--- a/tests/Feature/PublicStatus/NotifyStatusSubscribersJobTest.php
+++ b/tests/Feature/PublicStatus/NotifyStatusSubscribersJobTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\PublicStatus;
+
+use App\Domain\PublicStatus\Jobs\NotifyStatusSubscribersJob;
+use App\Mail\PublicStatusIncidentMail;
+use App\Models\Alert;
+use App\Models\Project;
+use App\Models\PublicStatusSubscriber;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class NotifyStatusSubscribersJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_only_confirmed_subscribers_receive_mail(): void
+    {
+        Mail::fake();
+
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+        $confirmed = PublicStatusSubscriber::factory()->for($project)->confirmed()->create([
+            'email' => 'watcher@example.com',
+        ]);
+        PublicStatusSubscriber::factory()->for($project)->create([
+            'email' => 'pending@example.com',
+        ]);
+        $alert = Alert::factory()->create(['project_id' => $project->id]);
+
+        (new NotifyStatusSubscribersJob($alert->id, 'triggered'))->handle();
+
+        Mail::assertSent(PublicStatusIncidentMail::class, 1);
+        Mail::assertSent(PublicStatusIncidentMail::class, fn ($mail) => $mail->hasTo('watcher@example.com'));
+        Mail::assertNotSent(
+            PublicStatusIncidentMail::class,
+            fn ($mail) => $mail->hasTo('pending@example.com'),
+        );
+    }
+
+    public function test_disabled_project_skips_send(): void
+    {
+        Mail::fake();
+
+        $project = Project::factory()->create(['public_status_enabled' => false]);
+        PublicStatusSubscriber::factory()->for($project)->confirmed()->create();
+        $alert = Alert::factory()->create(['project_id' => $project->id]);
+
+        (new NotifyStatusSubscribersJob($alert->id, 'triggered'))->handle();
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_no_confirmed_subscribers_is_silent(): void
+    {
+        Mail::fake();
+
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+        // Only pending subscribers.
+        PublicStatusSubscriber::factory()->for($project)->count(3)->create();
+        $alert = Alert::factory()->create(['project_id' => $project->id]);
+
+        (new NotifyStatusSubscribersJob($alert->id, 'triggered'))->handle();
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_missing_alert_row_is_silent(): void
+    {
+        Mail::fake();
+
+        (new NotifyStatusSubscribersJob(999999, 'triggered'))->handle();
+
+        Mail::assertNothingSent();
+    }
+}

--- a/tests/Feature/PublicStatus/PublicStatusConfirmAndUnsubscribeTest.php
+++ b/tests/Feature/PublicStatus/PublicStatusConfirmAndUnsubscribeTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\PublicStatus;
+
+use App\Models\Project;
+use App\Models\PublicStatusSubscriber;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PublicStatusConfirmAndUnsubscribeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_confirm_flips_confirmed_at(): void
+    {
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+        $subscriber = PublicStatusSubscriber::factory()->for($project)->create();
+
+        $this->get(route('public-status.confirm', [
+            'project' => $project->slug,
+            'token' => $subscriber->confirmation_token,
+        ]))->assertOk();
+
+        $this->assertNotNull($subscriber->fresh()->confirmed_at);
+    }
+
+    public function test_confirm_is_idempotent_on_repeat_hit(): void
+    {
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+        $subscriber = PublicStatusSubscriber::factory()
+            ->for($project)
+            ->confirmed()
+            ->create();
+
+        $firstConfirmedAt = $subscriber->confirmed_at;
+
+        $this->get(route('public-status.confirm', [
+            'project' => $project->slug,
+            'token' => $subscriber->confirmation_token,
+        ]))->assertOk();
+
+        // confirmed_at wasn't clobbered by a re-visit.
+        $this->assertEquals(
+            $firstConfirmedAt->timestamp,
+            $subscriber->fresh()->confirmed_at->timestamp,
+        );
+    }
+
+    public function test_confirm_unknown_token_404s(): void
+    {
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+
+        $this->get(route('public-status.confirm', [
+            'project' => $project->slug,
+            'token' => str_repeat('x', 64),
+        ]))->assertNotFound();
+    }
+
+    public function test_unsubscribe_deletes_the_row(): void
+    {
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+        $subscriber = PublicStatusSubscriber::factory()->for($project)->confirmed()->create();
+
+        $this->get(route('public-status.unsubscribe', [
+            'token' => $subscriber->unsubscribe_token,
+        ]))->assertOk();
+
+        $this->assertNull(PublicStatusSubscriber::query()->find($subscriber->id));
+    }
+
+    public function test_unsubscribe_unknown_token_404s(): void
+    {
+        $this->get(route('public-status.unsubscribe', [
+            'token' => str_repeat('y', 64),
+        ]))->assertNotFound();
+    }
+}

--- a/tests/Feature/PublicStatus/PublicStatusPageControllerTest.php
+++ b/tests/Feature/PublicStatus/PublicStatusPageControllerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\PublicStatus;
+
+use App\Enums\AlertSeverity;
+use App\Enums\AlertStatus;
+use App\Enums\WebsiteStatus;
+use App\Models\Alert;
+use App\Models\Project;
+use App\Models\Website;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PublicStatusPageControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_page_renders_for_an_opted_in_project(): void
+    {
+        $project = Project::factory()->create([
+            'public_status_enabled' => true,
+            'public_status_headline' => 'Weekly maintenance window.',
+        ]);
+
+        $this->get(route('public-status.show', ['project' => $project->slug]))
+            ->assertOk();
+    }
+
+    public function test_page_404s_for_a_disabled_project(): void
+    {
+        $project = Project::factory()->create([
+            'public_status_enabled' => false,
+        ]);
+
+        $this->get(route('public-status.show', ['project' => $project->slug]))
+            ->assertNotFound();
+    }
+
+    public function test_page_404s_for_an_unknown_slug(): void
+    {
+        $this->get(route('public-status.show', ['project' => 'nope']))
+            ->assertNotFound();
+    }
+
+    public function test_overall_band_is_major_outage_when_a_critical_alert_is_open(): void
+    {
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+
+        $response = $this->get(route('public-status.show', ['project' => $project->slug]))
+            ->assertOk();
+        $status = $response->viewData('page')['props']['status'];
+
+        $this->assertSame('major_outage', $status['overall_band']);
+        $this->assertSame('Major outage', $status['overall_label']);
+    }
+
+    public function test_overall_band_is_operational_when_nothing_open(): void
+    {
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+        Website::factory()->create([
+            'project_id' => $project->id,
+            'status' => WebsiteStatus::Up->value,
+        ]);
+
+        $response = $this->get(route('public-status.show', ['project' => $project->slug]))
+            ->assertOk();
+        $status = $response->viewData('page')['props']['status'];
+
+        $this->assertSame('operational', $status['overall_band']);
+    }
+}

--- a/tests/Feature/PublicStatus/PublicStatusSubscribeControllerTest.php
+++ b/tests/Feature/PublicStatus/PublicStatusSubscribeControllerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\PublicStatus;
+
+use App\Mail\PublicStatusSubscribeConfirmationMail;
+use App\Models\Project;
+use App\Models\PublicStatusSubscriber;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class PublicStatusSubscribeControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_valid_subscription_creates_row_and_sends_confirmation(): void
+    {
+        Mail::fake();
+
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+
+        $this->post(
+            route('public-status.subscribe', ['project' => $project->slug]),
+            ['email' => 'watcher@example.com'],
+        )->assertRedirect();
+
+        $subscriber = PublicStatusSubscriber::query()
+            ->where('project_id', $project->id)
+            ->where('email', 'watcher@example.com')
+            ->firstOrFail();
+
+        $this->assertNull($subscriber->confirmed_at);
+        Mail::assertSent(PublicStatusSubscribeConfirmationMail::class);
+    }
+
+    public function test_duplicate_email_refreshes_tokens_without_creating_second_row(): void
+    {
+        Mail::fake();
+
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+        $existing = PublicStatusSubscriber::factory()
+            ->for($project)
+            ->create(['email' => 'watcher@example.com']);
+        $originalToken = $existing->confirmation_token;
+
+        $this->post(
+            route('public-status.subscribe', ['project' => $project->slug]),
+            ['email' => 'watcher@example.com'],
+        )->assertRedirect();
+
+        $this->assertSame(
+            1,
+            PublicStatusSubscriber::query()
+                ->where('project_id', $project->id)
+                ->where('email', 'watcher@example.com')
+                ->count(),
+        );
+        $this->assertNotSame($originalToken, $existing->fresh()->confirmation_token);
+    }
+
+    public function test_honeypot_submission_silently_succeeds_without_creating_row(): void
+    {
+        Mail::fake();
+
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+
+        $this->post(
+            route('public-status.subscribe', ['project' => $project->slug]),
+            [
+                'email' => 'bot@example.com',
+                'honeypot' => 'gotcha',
+            ],
+        )->assertRedirect();
+
+        $this->assertSame(0, PublicStatusSubscriber::query()->count());
+        Mail::assertNothingSent();
+    }
+
+    public function test_invalid_email_422s(): void
+    {
+        $project = Project::factory()->create(['public_status_enabled' => true]);
+
+        $this->post(
+            route('public-status.subscribe', ['project' => $project->slug]),
+            ['email' => 'not-an-email'],
+        )->assertSessionHasErrors('email');
+    }
+
+    public function test_subscribe_404s_when_project_disabled(): void
+    {
+        $project = Project::factory()->create(['public_status_enabled' => false]);
+
+        $this->post(
+            route('public-status.subscribe', ['project' => $project->slug]),
+            ['email' => 'watcher@example.com'],
+        )->assertNotFound();
+    }
+}


### PR DESCRIPTION
Closes #129

Spec: \`specs/phase-10-innovation/047-public-status-page.md\`

## Summary

**Phase 10 closer.** Public \`/status/{slug}\` page + double opt-in subscribers + alert-transition delivery loop. Every SaaS ships one; Nexus already had the raw data (spec 025 uptime, spec 030 alerts, spec 038 system health) — this spec is the thin public surface.

**Public surface:**
- \`GET /status/{project:slug}\` — unauthenticated Inertia render, 404 when \`public_status_enabled=false\`, cached 60s via \`Cache::remember\` (invalidated on alert transitions AND on settings edits).
- Renders overall band (Operational / Degraded / Partial outage / Major outage), per-monitor uptime strip (24h/7d/30d), active + recent incidents, subscribe form (honeypot for bots).

**Subscriber flow:**
- \`public_status_subscribers\` table with unique \`(project_id, email)\`, 64-char confirmation + unsubscribe tokens (256 bits of entropy, unique-indexed, hidden from serialization).
- \`POST /status/{slug}/subscribe\` idempotent — duplicate emails refresh tokens instead of creating a second row.
- \`GET /status/{slug}/confirm/{token}\` flips \`confirmed_at\`; idempotent on repeats.
- \`GET /status/subscribers/unsubscribe/{token}\` — RFC 8058 one-click, token-only lookup, deletes the row.

**Delivery loop:**
- \`NotifyPublicSubscribersOnAlertListener\` listens for \`AlertTriggered\` + \`AlertResolved\` (spec 032 events); enqueues \`NotifyStatusSubscribersJob(alertId, event)\` when the project is opted in.
- \`InvalidatePublicStatusCacheListener\` flushes the cached snapshot on the same events.
- Job iterates confirmed subscribers, mails each with per-subscriber try/catch isolation (one bounce doesn't cause retries that re-mail successful subscribers).
- **Not** riding on spec 042 — public subscribers are anonymous with different guarantees (double opt-in, unsubscribe tokens, honeypot spam guard).

**Settings surface:**
- \`Projects/Edit.vue\` gains a public-status panel with toggle + headline + URL preview + subscriber count. Panel posts only the two public-status fields; \`UpdateProjectRequest\` now treats every field as \`sometimes\` so partial saves don't clobber siblings.

## Test plan
- [x] \`/status/{slug}\` renders unauthenticated for opted-in projects; 404s otherwise.
- [x] Page shows overall band, per-monitor uptime, active + recent incidents.
- [x] Subscribe creates a row + sends confirmation (honeypot silently succeeds; invalid email 422s; disabled project 404s).
- [x] Confirm flips \`confirmed_at\`; idempotent; unknown token 404.
- [x] Unsubscribe deletes the row; unknown token 404.
- [x] \`AlertTriggered\` + \`AlertResolved\` on opted-in projects enqueue notifications; disabled projects skip.
- [x] Job mails only confirmed subscribers; per-subscriber try/catch isolation.
- [x] Cache invalidated on alert transitions AND on settings edits (\`Cache::forget\` in \`ProjectController::update\` when \`public_status_headline\` or \`public_status_enabled\` changes).
- [x] All 4 new endpoints throttled per §5 of the operator checklist.
- [x] Pint clean. \`php artisan test\` 869/869 green (25 new tests, 5 test files). \`npm run build\` clean.

## Self-review notes
Ran \`superpowers:code-reviewer\`. Findings and disposition:

**Blockers:** none.

**Should-fixes (3 applied, 1 deferred):**
- **Applied — Cache invalidation on settings edit.** Toggling \`public_status_enabled=false\` was safe (ShowController gates on the DB row before touching cache) but changing \`public_status_headline\` left a stale snapshot for up to 60s. Wired \`Cache::forget()\` into \`ProjectController::update()\` when either field changes.
- **Applied — Per-subscriber mail failure isolation.** A single bounce would blow up the whole \`NotifyStatusSubscribersJob\`, triggering retries that re-mail successful subscribers. Wrapped \`Mail::to()->send()\` in try/catch + \`Log::warning\` so one bad email can't spam the rest.
- **Applied — Stale-state clobber in \`Projects/Edit.vue\`.** The public-status panel's \`useForm\` seeded from \`props.project\` at mount, so saving after editing the main form (without full refresh) would send stale name/description/etc. Fixed by making every field \`sometimes\` in \`UpdateProjectRequest\` + posting only the public-status keys from the panel.
- **Deferred to a Phase 11 polish** — Per-alert dedupe against \`alert.last_seen_at\` for flapping alerts. \`ShouldBeUnique(alert_id, event)\` collapses queue duplicates but a flap (trigger → resolve → trigger → resolve) still spams 4 emails per subscriber. Tracked in the spec work log.

**Nits (surfaced for visibility, not fixed):**
- \`email:filter\` validator vs \`email:rfc,dns\` — filter is fine; DNS-required adds latency for edge-case garbage domains.
- Consolidated test coverage: 7 planned files → 5 shipped (confirm + unsubscribe combined, listener behavior in one file). Coverage matches spec §Tests.
- Reviewer flagged (and I verified) two non-issues: no route-collision risk for a project slugged \`subscribers\`, and SQL \`=\` on indexed columns doesn't leak enough timing signal to attack a 256-bit token space.

## Bookkeeping
Spec + tracker flips inside this PR:
- Spec 047 frontmatter → \`status: done\`.
- \`specs/phase-10-innovation/README.md\` task 047 → 🟢.
- \`specs/README.md\` Phase 10 row → 🟡 4/6.

Phase 10 remaining: AI pair 044 (daily briefing) + 045 (PR risk + health explanation).