### PR TITLE
Spec 044 — AI daily briefing: scheduled operator digest

### DIFF
--- a/app/Domain/AI/Contracts/LlmClient.php
+++ b/app/Domain/AI/Contracts/LlmClient.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Domain\AI\Contracts;
+
+use App\Domain\AI\DataTransferObjects\LlmPrompt;
+use App\Domain\AI\DataTransferObjects\LlmResponse;
+
+interface LlmClient
+{
+    public function complete(LlmPrompt $prompt): LlmResponse;
+}

--- a/app/Domain/AI/DataTransferObjects/LlmPrompt.php
+++ b/app/Domain/AI/DataTransferObjects/LlmPrompt.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Domain\AI\DataTransferObjects;
+
+class LlmPrompt
+{
+    public function __construct(
+        public readonly string $version,
+        public readonly string $system,
+        public readonly string $user,
+        public readonly int $maxTokens = 1_200,
+    ) {}
+}

--- a/app/Domain/AI/DataTransferObjects/LlmResponse.php
+++ b/app/Domain/AI/DataTransferObjects/LlmResponse.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Domain\AI\DataTransferObjects;
+
+class LlmResponse
+{
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    public function __construct(
+        public readonly string $text,
+        public readonly ?string $model = null,
+        public readonly array $metadata = [],
+    ) {}
+}

--- a/app/Domain/AI/Services/AnthropicLlmClient.php
+++ b/app/Domain/AI/Services/AnthropicLlmClient.php
@@ -28,7 +28,7 @@ class AnthropicLlmClient implements LlmClient
             'x-api-key' => $apiKey,
         ])
             ->timeout($timeout)
-            ->retry(1, 250, function ($exception, $request): bool {
+            ->retry(2, 250, function ($exception, $request): bool {
                 if ($exception instanceof ConnectionException) {
                     return true;
                 }

--- a/app/Domain/AI/Services/AnthropicLlmClient.php
+++ b/app/Domain/AI/Services/AnthropicLlmClient.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Domain\AI\Services;
+
+use App\Domain\AI\Contracts\LlmClient;
+use App\Domain\AI\DataTransferObjects\LlmPrompt;
+use App\Domain\AI\DataTransferObjects\LlmResponse;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+class AnthropicLlmClient implements LlmClient
+{
+    public function complete(LlmPrompt $prompt): LlmResponse
+    {
+        $apiKey = (string) config('services.llm.api_key', '');
+        $model = (string) config('services.llm.model', 'claude-3-5-haiku-latest');
+        $timeout = (int) config('services.llm.timeout', 20);
+
+        if ($apiKey === '') {
+            throw new RuntimeException('LLM API key is not configured.');
+        }
+
+        $response = Http::withHeaders([
+            'anthropic-version' => '2023-06-01',
+            'content-type' => 'application/json',
+            'x-api-key' => $apiKey,
+        ])
+            ->timeout($timeout)
+            ->retry(1, 250, function ($exception, $request): bool {
+                if ($exception instanceof ConnectionException) {
+                    return true;
+                }
+
+                if (! $exception instanceof RequestException) {
+                    return false;
+                }
+
+                return in_array($exception->response->status(), [429, 500, 502, 503, 504], true);
+            }, throw: true)
+            ->post('https://api.anthropic.com/v1/messages', [
+                'model' => $model,
+                'max_tokens' => $prompt->maxTokens,
+                'system' => $prompt->system,
+                'messages' => [
+                    ['role' => 'user', 'content' => $prompt->user],
+                ],
+            ])
+            ->throw()
+            ->json();
+
+        $text = collect($response['content'] ?? [])
+            ->where('type', 'text')
+            ->pluck('text')
+            ->implode("\n");
+
+        if ($text === '') {
+            throw new RuntimeException('LLM response did not include text content.');
+        }
+
+        return new LlmResponse(
+            text: $text,
+            model: $response['model'] ?? $model,
+            metadata: ['usage' => $response['usage'] ?? []],
+        );
+    }
+}

--- a/app/Domain/DailyBriefings/Actions/GenerateDailyBriefingAction.php
+++ b/app/Domain/DailyBriefings/Actions/GenerateDailyBriefingAction.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace App\Domain\DailyBriefings\Actions;
+
+use App\Domain\AI\Contracts\LlmClient;
+use App\Domain\AI\DataTransferObjects\LlmPrompt;
+use App\Enums\DailyBriefingStatus;
+use App\Models\DailyBriefing;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Str;
+use Throwable;
+
+class GenerateDailyBriefingAction
+{
+    public const PROMPT_VERSION = 'daily-briefing-v1';
+
+    public function __construct(private readonly LlmClient $llm) {}
+
+    /**
+     * @param  array<string, mixed>  $inputSnapshot
+     */
+    public function execute(User $user, array $inputSnapshot): DailyBriefing
+    {
+        $briefingDate = $this->briefingDate($inputSnapshot);
+
+        if (! config('services.llm.enabled', false)) {
+            return $this->markFailed($user, $briefingDate, $inputSnapshot, 'AI features are disabled.');
+        }
+
+        try {
+            $response = $this->llm->complete($this->prompt($inputSnapshot));
+            $output = $this->validatedOutput($response->text);
+
+            return $this->writeBriefing($user, $briefingDate, [
+                'status' => DailyBriefingStatus::Generated,
+                'input_snapshot' => $inputSnapshot,
+                'summary' => $output['summary'],
+                'highlights' => $output['highlights'],
+                'risks' => $output['risks'],
+                'prompt_version' => self::PROMPT_VERSION,
+                'generated_at' => now(),
+                'delivered_at' => null,
+                'error_message' => null,
+            ]);
+        } catch (Throwable $exception) {
+            return $this->markFailed($user, $briefingDate, $inputSnapshot, $exception->getMessage());
+        }
+    }
+
+    /** @param array<string, mixed> $inputSnapshot */
+    private function prompt(array $inputSnapshot): LlmPrompt
+    {
+        return new LlmPrompt(
+            version: self::PROMPT_VERSION,
+            system: 'You write concise operator briefings from structured Nexus monitoring data. Return only valid JSON matching the requested schema. Do not invent facts. Do not include secrets, raw logs, tokens, webhook URLs, or unsupported claims.',
+            user: json_encode([
+                'prompt_version' => self::PROMPT_VERSION,
+                'task' => 'Create a daily operator briefing from this bounded input snapshot.',
+                'schema' => [
+                    'summary' => 'string, 2-4 concise paragraphs',
+                    'highlights' => 'array of 3-6 short strings',
+                    'risks' => 'array of 0-5 short strings tied to concrete source entities',
+                    'next_steps' => 'optional array of short strings when supported by data',
+                ],
+                'input_snapshot' => $inputSnapshot,
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+        );
+    }
+
+    /**
+     * @return array{summary: string, highlights: array<int, string>, risks: array<int, string>}
+     */
+    private function validatedOutput(string $text): array
+    {
+        $payload = json_decode($this->stripCodeFence($text), true);
+
+        if (! is_array($payload)) {
+            throw new \UnexpectedValueException('LLM response was not valid JSON.');
+        }
+
+        $summary = $this->sanitizeString($payload['summary'] ?? null, 4_000);
+        $highlights = $this->sanitizeList($payload['highlights'] ?? null, 6);
+        $risks = $this->sanitizeList($payload['risks'] ?? [], 5);
+
+        if ($summary === '') {
+            throw new \UnexpectedValueException('LLM response summary is required.');
+        }
+
+        if (count($highlights) < 3 || count($highlights) > 6) {
+            throw new \UnexpectedValueException('LLM response must include 3 to 6 highlights.');
+        }
+
+        if (count($risks) > 5) {
+            throw new \UnexpectedValueException('LLM response must include at most 5 risks.');
+        }
+
+        return [
+            'summary' => $summary,
+            'highlights' => $highlights,
+            'risks' => $risks,
+        ];
+    }
+
+    /** @param mixed $value */
+    private function sanitizeString($value, int $limit): string
+    {
+        if (! is_string($value)) {
+            return '';
+        }
+
+        $value = trim(strip_tags(preg_replace('/[[:cntrl:]]+/', ' ', $value) ?? ''));
+
+        return Str::limit($value, $limit, '');
+    }
+
+    /**
+     * @param  mixed  $value
+     * @return array<int, string>
+     */
+    private function sanitizeList($value, int $limit): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return collect($value)
+            ->map(fn ($item): string => $this->sanitizeString($item, 500))
+            ->filter(fn (string $item): bool => $item !== '')
+            ->take($limit)
+            ->values()
+            ->all();
+    }
+
+    private function stripCodeFence(string $text): string
+    {
+        $text = trim($text);
+
+        if (str_starts_with($text, '```')) {
+            $text = preg_replace('/^```(?:json)?\s*/', '', $text) ?? $text;
+            $text = preg_replace('/\s*```$/', '', $text) ?? $text;
+        }
+
+        return trim($text);
+    }
+
+    /** @param array<string, mixed> $inputSnapshot */
+    private function briefingDate(array $inputSnapshot): CarbonImmutable
+    {
+        $date = $inputSnapshot['window']['briefing_date'] ?? null;
+
+        if (! is_string($date) || $date === '') {
+            throw new \InvalidArgumentException('Input snapshot is missing window.briefing_date.');
+        }
+
+        return CarbonImmutable::parse($date)->startOfDay();
+    }
+
+    /** @param array<string, mixed> $inputSnapshot */
+    private function markFailed(User $user, CarbonImmutable $briefingDate, array $inputSnapshot, string $error): DailyBriefing
+    {
+        return $this->writeBriefing($user, $briefingDate, [
+            'status' => DailyBriefingStatus::Failed,
+            'input_snapshot' => $inputSnapshot,
+            'summary' => null,
+            'highlights' => null,
+            'risks' => null,
+            'prompt_version' => self::PROMPT_VERSION,
+            'generated_at' => null,
+            'delivered_at' => null,
+            'error_message' => Str::limit($error, 2_000, ''),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function writeBriefing(User $user, CarbonImmutable $briefingDate, array $attributes): DailyBriefing
+    {
+        $briefing = DailyBriefing::query()
+            ->where('user_id', $user->id)
+            ->whereDate('briefing_date', $briefingDate->toDateString())
+            ->first() ?? new DailyBriefing([
+                'user_id' => $user->id,
+                'briefing_date' => $briefingDate->toDateString(),
+            ]);
+
+        $briefing->fill($attributes);
+        $briefing->save();
+
+        return $briefing;
+    }
+}

--- a/app/Domain/DailyBriefings/Actions/GenerateDailyBriefingAction.php
+++ b/app/Domain/DailyBriefings/Actions/GenerateDailyBriefingAction.php
@@ -20,19 +20,19 @@ class GenerateDailyBriefingAction
     /**
      * @param  array<string, mixed>  $inputSnapshot
      */
-    public function execute(User $user, array $inputSnapshot): DailyBriefing
+    public function execute(User $user, array $inputSnapshot, bool $isTest = false): DailyBriefing
     {
         $briefingDate = $this->briefingDate($inputSnapshot);
 
         if (! config('services.llm.enabled', false)) {
-            return $this->markFailed($user, $briefingDate, $inputSnapshot, 'AI features are disabled.');
+            return $this->markFailed($user, $briefingDate, $inputSnapshot, 'AI features are disabled.', $isTest);
         }
 
         try {
             $response = $this->llm->complete($this->prompt($inputSnapshot));
             $output = $this->validatedOutput($response->text);
 
-            return $this->writeBriefing($user, $briefingDate, [
+            return $this->writeBriefing($user, $briefingDate, $isTest, [
                 'status' => DailyBriefingStatus::Generated,
                 'input_snapshot' => $inputSnapshot,
                 'summary' => $output['summary'],
@@ -44,7 +44,7 @@ class GenerateDailyBriefingAction
                 'error_message' => null,
             ]);
         } catch (Throwable $exception) {
-            return $this->markFailed($user, $briefingDate, $inputSnapshot, $exception->getMessage());
+            return $this->markFailed($user, $briefingDate, $inputSnapshot, $exception->getMessage(), $isTest);
         }
     }
 
@@ -157,9 +157,9 @@ class GenerateDailyBriefingAction
     }
 
     /** @param array<string, mixed> $inputSnapshot */
-    private function markFailed(User $user, CarbonImmutable $briefingDate, array $inputSnapshot, string $error): DailyBriefing
+    private function markFailed(User $user, CarbonImmutable $briefingDate, array $inputSnapshot, string $error, bool $isTest): DailyBriefing
     {
-        return $this->writeBriefing($user, $briefingDate, [
+        return $this->writeBriefing($user, $briefingDate, $isTest, [
             'status' => DailyBriefingStatus::Failed,
             'input_snapshot' => $inputSnapshot,
             'summary' => null,
@@ -175,14 +175,16 @@ class GenerateDailyBriefingAction
     /**
      * @param  array<string, mixed>  $attributes
      */
-    private function writeBriefing(User $user, CarbonImmutable $briefingDate, array $attributes): DailyBriefing
+    private function writeBriefing(User $user, CarbonImmutable $briefingDate, bool $isTest, array $attributes): DailyBriefing
     {
         $briefing = DailyBriefing::query()
             ->where('user_id', $user->id)
             ->whereDate('briefing_date', $briefingDate->toDateString())
+            ->where('is_test', $isTest)
             ->first() ?? new DailyBriefing([
                 'user_id' => $user->id,
                 'briefing_date' => $briefingDate->toDateString(),
+                'is_test' => $isTest,
             ]);
 
         $briefing->fill($attributes);

--- a/app/Domain/DailyBriefings/DataTransferObjects/DailyBriefingPayload.php
+++ b/app/Domain/DailyBriefings/DataTransferObjects/DailyBriefingPayload.php
@@ -31,7 +31,7 @@ final class DailyBriefingPayload implements NotificationPayload
             summary: $briefing->summary ?? '',
             highlights: $briefing->highlights ?? [],
             risks: $briefing->risks ?? [],
-            link: URL::to('/daily-briefings/'.$briefing->id),
+            link: URL::route('daily-briefings.index'),
         );
     }
 

--- a/app/Domain/DailyBriefings/DataTransferObjects/DailyBriefingPayload.php
+++ b/app/Domain/DailyBriefings/DataTransferObjects/DailyBriefingPayload.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Domain\DailyBriefings\DataTransferObjects;
+
+use App\Domain\Notifications\Contracts\NotificationPayload;
+use App\Mail\DailyBriefingMail;
+use App\Models\DailyBriefing;
+use Illuminate\Mail\Mailable;
+use Illuminate\Support\Facades\URL;
+
+final class DailyBriefingPayload implements NotificationPayload
+{
+    /**
+     * @param  array<int, string>  $highlights
+     * @param  array<int, string>  $risks
+     */
+    public function __construct(
+        public readonly int $briefingId,
+        public readonly string $briefingDate,
+        public readonly string $summary,
+        public readonly array $highlights,
+        public readonly array $risks,
+        public readonly string $link,
+    ) {}
+
+    public static function fromBriefing(DailyBriefing $briefing): self
+    {
+        return new self(
+            briefingId: $briefing->id,
+            briefingDate: $briefing->briefing_date->toDateString(),
+            summary: $briefing->summary ?? '',
+            highlights: $briefing->highlights ?? [],
+            risks: $briefing->risks ?? [],
+            link: URL::to('/daily-briefings/'.$briefing->id),
+        );
+    }
+
+    public function title(): string
+    {
+        return 'Daily briefing for '.$this->briefingDate;
+    }
+
+    public function message(): ?string
+    {
+        return $this->summary;
+    }
+
+    public function link(): string
+    {
+        return $this->link;
+    }
+
+    public function event(): string
+    {
+        return 'daily_briefing.generated';
+    }
+
+    public function toMail(): Mailable
+    {
+        return new DailyBriefingMail($this);
+    }
+
+    /** @return array<string, mixed> */
+    public function toSlackPayload(): array
+    {
+        return [
+            'text' => $this->title(),
+            'blocks' => array_values(array_filter([
+                [
+                    'type' => 'header',
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => $this->title(),
+                        'emoji' => true,
+                    ],
+                ],
+                [
+                    'type' => 'section',
+                    'text' => [
+                        'type' => 'mrkdwn',
+                        'text' => $this->summary,
+                    ],
+                ],
+                $this->highlights === [] ? null : [
+                    'type' => 'section',
+                    'text' => [
+                        'type' => 'mrkdwn',
+                        'text' => "*Highlights*\n".$this->bullets($this->highlights),
+                    ],
+                ],
+                $this->risks === [] ? null : [
+                    'type' => 'section',
+                    'text' => [
+                        'type' => 'mrkdwn',
+                        'text' => "*Risks*\n".$this->bullets($this->risks),
+                    ],
+                ],
+                [
+                    'type' => 'actions',
+                    'elements' => [[
+                        'type' => 'button',
+                        'text' => [
+                            'type' => 'plain_text',
+                            'text' => 'View in Nexus',
+                            'emoji' => true,
+                        ],
+                        'url' => $this->link,
+                    ]],
+                ],
+            ])),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return [
+            'event' => $this->event(),
+            'briefing_id' => $this->briefingId,
+            'briefing_date' => $this->briefingDate,
+            'title' => $this->title(),
+            'summary' => $this->summary,
+            'highlights' => $this->highlights,
+            'risks' => $this->risks,
+            'link' => $this->link,
+        ];
+    }
+
+    /** @param array<int, string> $items */
+    private function bullets(array $items): string
+    {
+        return collect($items)
+            ->map(fn (string $item): string => '- '.$item)
+            ->implode("\n");
+    }
+}

--- a/app/Domain/DailyBriefings/Jobs/DispatchDueDailyBriefingsJob.php
+++ b/app/Domain/DailyBriefings/Jobs/DispatchDueDailyBriefingsJob.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Domain\DailyBriefings\Jobs;
+
+use App\Enums\DailyBriefingStatus;
+use App\Models\DailyBriefing;
+use App\Models\DailyBriefingPreference;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class DispatchDueDailyBriefingsJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    public function handle(): void
+    {
+        if (! config('services.llm.enabled', false)) {
+            return;
+        }
+
+        DailyBriefingPreference::query()
+            ->where('enabled', true)
+            ->with('user:id')
+            ->chunkById(100, function ($preferences): void {
+                foreach ($preferences as $preference) {
+                    $this->dispatchIfDue($preference);
+                }
+            });
+    }
+
+    private function dispatchIfDue(DailyBriefingPreference $preference): void
+    {
+        $timezone = $preference->timezone ?: config('app.timezone', 'UTC');
+        $now = now($timezone)->toImmutable();
+        $deliveryAt = $now->setTimeFromTimeString((string) $preference->delivery_time);
+
+        if ($now->lessThan($deliveryAt)) {
+            return;
+        }
+
+        $briefingDate = $now->subDay()->toDateString();
+
+        if ($preference->last_sent_for_date?->toDateString() === $briefingDate) {
+            return;
+        }
+
+        if ($this->briefingAlreadyQueuedOrGenerated((int) $preference->user_id, $briefingDate)) {
+            return;
+        }
+
+        GenerateDailyBriefingJob::dispatch((int) $preference->user_id, $briefingDate);
+    }
+
+    private function briefingAlreadyQueuedOrGenerated(int $userId, string $briefingDate): bool
+    {
+        return DailyBriefing::query()
+            ->where('user_id', $userId)
+            ->whereDate('briefing_date', $briefingDate)
+            ->whereIn('status', [
+                DailyBriefingStatus::Pending->value,
+                DailyBriefingStatus::Generated->value,
+                DailyBriefingStatus::Delivered->value,
+            ])
+            ->exists();
+    }
+}

--- a/app/Domain/DailyBriefings/Jobs/DispatchDueDailyBriefingsJob.php
+++ b/app/Domain/DailyBriefings/Jobs/DispatchDueDailyBriefingsJob.php
@@ -52,23 +52,20 @@ class DispatchDueDailyBriefingsJob implements ShouldQueue
             return;
         }
 
-        if ($this->briefingAlreadyQueuedOrGenerated((int) $preference->user_id, $briefingDate)) {
+        if ($this->briefingAlreadyDelivered((int) $preference->user_id, $briefingDate)) {
             return;
         }
 
         GenerateDailyBriefingJob::dispatch((int) $preference->user_id, $briefingDate);
     }
 
-    private function briefingAlreadyQueuedOrGenerated(int $userId, string $briefingDate): bool
+    private function briefingAlreadyDelivered(int $userId, string $briefingDate): bool
     {
         return DailyBriefing::query()
             ->where('user_id', $userId)
             ->whereDate('briefing_date', $briefingDate)
-            ->whereIn('status', [
-                DailyBriefingStatus::Pending->value,
-                DailyBriefingStatus::Generated->value,
-                DailyBriefingStatus::Delivered->value,
-            ])
+            ->where('is_test', false)
+            ->where('status', DailyBriefingStatus::Delivered->value)
             ->exists();
     }
 }

--- a/app/Domain/DailyBriefings/Jobs/GenerateDailyBriefingJob.php
+++ b/app/Domain/DailyBriefings/Jobs/GenerateDailyBriefingJob.php
@@ -8,13 +8,14 @@ use App\Enums\DailyBriefingStatus;
 use App\Models\DailyBriefing;
 use App\Models\DailyBriefingPreference;
 use App\Models\User;
-use Carbon\CarbonImmutable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Str;
+use Throwable;
 
 class GenerateDailyBriefingJob implements ShouldBeUnique, ShouldQueue
 {
@@ -23,7 +24,7 @@ class GenerateDailyBriefingJob implements ShouldBeUnique, ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public int $tries = 1;
+    public int $tries = 2;
 
     public int $uniqueFor = 900;
 
@@ -62,14 +63,17 @@ class GenerateDailyBriefingJob implements ShouldBeUnique, ShouldQueue
             return;
         }
 
-        if ($this->alreadyGeneratedOrQueued($user->id)) {
+        $existing = $this->existingBriefing($user->id);
+
+        if ($existing?->status === DailyBriefingStatus::Delivered) {
             return;
         }
 
-        DailyBriefing::query()->firstOrCreate(
-            ['user_id' => $user->id, 'briefing_date' => CarbonImmutable::parse($this->briefingDate)->toDateString()],
-            ['status' => DailyBriefingStatus::Pending->value],
-        );
+        if ($existing?->status === DailyBriefingStatus::Generated || ($existing?->status === DailyBriefingStatus::Failed && $existing->summary !== null)) {
+            SendDailyBriefingJob::dispatch($existing->id);
+
+            return;
+        }
 
         $snapshot = $inputQuery->execute(
             $user,
@@ -85,16 +89,26 @@ class GenerateDailyBriefingJob implements ShouldBeUnique, ShouldQueue
         }
     }
 
-    private function alreadyGeneratedOrQueued(int $userId): bool
+    public function failed(Throwable $exception): void
+    {
+        $briefing = $this->existingBriefing($this->userId);
+
+        if ($briefing === null || $briefing->status !== DailyBriefingStatus::Pending) {
+            return;
+        }
+
+        $briefing->forceFill([
+            'status' => DailyBriefingStatus::Failed,
+            'error_message' => Str::limit($exception->getMessage(), 2_000, ''),
+        ])->save();
+    }
+
+    private function existingBriefing(int $userId): ?DailyBriefing
     {
         return DailyBriefing::query()
             ->where('user_id', $userId)
             ->whereDate('briefing_date', $this->briefingDate)
-            ->whereIn('status', [
-                DailyBriefingStatus::Pending->value,
-                DailyBriefingStatus::Generated->value,
-                DailyBriefingStatus::Delivered->value,
-            ])
-            ->exists();
+            ->where('is_test', false)
+            ->first();
     }
 }

--- a/app/Domain/DailyBriefings/Jobs/GenerateDailyBriefingJob.php
+++ b/app/Domain/DailyBriefings/Jobs/GenerateDailyBriefingJob.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Domain\DailyBriefings\Jobs;
+
+use App\Domain\DailyBriefings\Actions\GenerateDailyBriefingAction;
+use App\Domain\DailyBriefings\Queries\GetDailyBriefingInputQuery;
+use App\Enums\DailyBriefingStatus;
+use App\Models\DailyBriefing;
+use App\Models\DailyBriefingPreference;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class GenerateDailyBriefingJob implements ShouldBeUnique, ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    public int $uniqueFor = 900;
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly string $briefingDate,
+    ) {}
+
+    public function uniqueId(): string
+    {
+        return "{$this->userId}:{$this->briefingDate}";
+    }
+
+    public function handle(GetDailyBriefingInputQuery $inputQuery, GenerateDailyBriefingAction $generate): void
+    {
+        if (! config('services.llm.enabled', false)) {
+            return;
+        }
+
+        $user = User::query()->find($this->userId);
+
+        if ($user === null) {
+            return;
+        }
+
+        $preference = DailyBriefingPreference::query()
+            ->where('user_id', $user->id)
+            ->where('enabled', true)
+            ->first();
+
+        if ($preference === null) {
+            return;
+        }
+
+        if ($preference->last_sent_for_date?->toDateString() === $this->briefingDate) {
+            return;
+        }
+
+        if ($this->alreadyGeneratedOrQueued($user->id)) {
+            return;
+        }
+
+        DailyBriefing::query()->firstOrCreate(
+            ['user_id' => $user->id, 'briefing_date' => CarbonImmutable::parse($this->briefingDate)->toDateString()],
+            ['status' => DailyBriefingStatus::Pending->value],
+        );
+
+        $snapshot = $inputQuery->execute(
+            $user,
+            $this->briefingDate,
+            $preference->timezone,
+            $preference->include_projects,
+        );
+
+        $generate->execute($user, $snapshot);
+    }
+
+    private function alreadyGeneratedOrQueued(int $userId): bool
+    {
+        return DailyBriefing::query()
+            ->where('user_id', $userId)
+            ->whereDate('briefing_date', $this->briefingDate)
+            ->whereIn('status', [
+                DailyBriefingStatus::Pending->value,
+                DailyBriefingStatus::Generated->value,
+                DailyBriefingStatus::Delivered->value,
+            ])
+            ->exists();
+    }
+}

--- a/app/Domain/DailyBriefings/Jobs/GenerateDailyBriefingJob.php
+++ b/app/Domain/DailyBriefings/Jobs/GenerateDailyBriefingJob.php
@@ -78,7 +78,11 @@ class GenerateDailyBriefingJob implements ShouldBeUnique, ShouldQueue
             $preference->include_projects,
         );
 
-        $generate->execute($user, $snapshot);
+        $briefing = $generate->execute($user, $snapshot);
+
+        if ($briefing->status === DailyBriefingStatus::Generated) {
+            SendDailyBriefingJob::dispatch($briefing->id);
+        }
     }
 
     private function alreadyGeneratedOrQueued(int $userId): bool

--- a/app/Domain/DailyBriefings/Jobs/SendDailyBriefingJob.php
+++ b/app/Domain/DailyBriefings/Jobs/SendDailyBriefingJob.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Domain\DailyBriefings\Jobs;
+
+use App\Domain\DailyBriefings\DataTransferObjects\DailyBriefingPayload;
+use App\Domain\Notifications\Services\AlertNotificationService;
+use App\Enums\DailyBriefingStatus;
+use App\Enums\NotificationChannelKind;
+use App\Models\AlertNotificationChannel;
+use App\Models\DailyBriefing;
+use App\Models\DailyBriefingPreference;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Throwable;
+
+class SendDailyBriefingJob implements ShouldBeUnique, ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public int $uniqueFor = 900;
+
+    public function __construct(public readonly int $briefingId) {}
+
+    public function uniqueId(): string
+    {
+        return (string) $this->briefingId;
+    }
+
+    /** @return array<int, int> */
+    public function backoff(): array
+    {
+        return [5, 30, 120];
+    }
+
+    public function handle(): void
+    {
+        $briefing = DailyBriefing::query()->find($this->briefingId);
+
+        if ($briefing === null || $briefing->status === DailyBriefingStatus::Delivered) {
+            return;
+        }
+
+        if ($briefing->summary === null || ! in_array($briefing->status, [
+            DailyBriefingStatus::Generated,
+            DailyBriefingStatus::Failed,
+        ], true)) {
+            return;
+        }
+
+        $preference = DailyBriefingPreference::query()
+            ->where('user_id', $briefing->user_id)
+            ->where('enabled', true)
+            ->first();
+
+        if ($preference === null) {
+            $this->markFailed($briefing, 'Daily briefing preference is disabled or missing.');
+
+            return;
+        }
+
+        $channel = $this->channelFor($preference);
+
+        if ($channel === null) {
+            $this->markFailed($briefing, 'No verified daily briefing delivery channel is available.');
+
+            return;
+        }
+
+        try {
+            AlertNotificationService::driverFor($channel->kind)->send(
+                $channel,
+                DailyBriefingPayload::fromBriefing($briefing),
+            );
+
+            DB::transaction(function () use ($briefing, $preference): void {
+                $briefing->forceFill([
+                    'status' => DailyBriefingStatus::Delivered,
+                    'delivered_at' => now(),
+                    'error_message' => null,
+                ])->save();
+
+                $preference->forceFill([
+                    'last_sent_for_date' => $briefing->briefing_date->toDateString(),
+                ])->save();
+            });
+        } catch (Throwable $exception) {
+            $this->markFailed($briefing, $exception->getMessage());
+
+            throw $exception;
+        }
+    }
+
+    private function channelFor(DailyBriefingPreference $preference): ?AlertNotificationChannel
+    {
+        if ($preference->channel_id !== null) {
+            return AlertNotificationChannel::query()
+                ->whereKey($preference->channel_id)
+                ->where('user_id', $preference->user_id)
+                ->where('enabled', true)
+                ->whereNotNull('verified_at')
+                ->first();
+        }
+
+        return AlertNotificationChannel::query()
+            ->where('user_id', $preference->user_id)
+            ->where('kind', NotificationChannelKind::Email->value)
+            ->where('enabled', true)
+            ->whereNotNull('verified_at')
+            ->orderBy('id')
+            ->first();
+    }
+
+    private function markFailed(DailyBriefing $briefing, string $message): void
+    {
+        $briefing->forceFill([
+            'status' => DailyBriefingStatus::Failed,
+            'error_message' => Str::limit($message, 2_000, ''),
+        ])->save();
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        $briefing = DailyBriefing::query()->find($this->briefingId);
+
+        if ($briefing === null) {
+            return;
+        }
+
+        $this->markFailed($briefing, $exception->getMessage());
+    }
+}

--- a/app/Domain/DailyBriefings/Jobs/SendDailyBriefingJob.php
+++ b/app/Domain/DailyBriefings/Jobs/SendDailyBriefingJob.php
@@ -30,7 +30,10 @@ class SendDailyBriefingJob implements ShouldBeUnique, ShouldQueue
 
     public int $uniqueFor = 900;
 
-    public function __construct(public readonly int $briefingId) {}
+    public function __construct(
+        public readonly int $briefingId,
+        public readonly bool $updateLastSentForDate = true,
+    ) {}
 
     public function uniqueId(): string
     {
@@ -90,9 +93,11 @@ class SendDailyBriefingJob implements ShouldBeUnique, ShouldQueue
                     'error_message' => null,
                 ])->save();
 
-                $preference->forceFill([
-                    'last_sent_for_date' => $briefing->briefing_date->toDateString(),
-                ])->save();
+                if ($this->updateLastSentForDate && ! $briefing->is_test) {
+                    $preference->forceFill([
+                        'last_sent_for_date' => $briefing->briefing_date->toDateString(),
+                    ])->save();
+                }
             });
         } catch (Throwable $exception) {
             $this->markFailed($briefing, $exception->getMessage());

--- a/app/Domain/DailyBriefings/Queries/GetDailyBriefingInputQuery.php
+++ b/app/Domain/DailyBriefings/Queries/GetDailyBriefingInputQuery.php
@@ -1,0 +1,611 @@
+<?php
+
+namespace App\Domain\DailyBriefings\Queries;
+
+use App\Enums\AlertStatus;
+use App\Enums\GithubIssueState;
+use App\Enums\GithubPullRequestState;
+use App\Enums\WebsiteCheckStatus;
+use App\Enums\WorkflowRunConclusion;
+use App\Enums\WorkflowRunStatus;
+use App\Models\ActivityEvent;
+use App\Models\Alert;
+use App\Models\Container;
+use App\Models\GithubIssue;
+use App\Models\GithubPullRequest;
+use App\Models\Host;
+use App\Models\Project;
+use App\Models\User;
+use App\Models\Website;
+use App\Models\WebsiteCheck;
+use App\Models\WorkflowRun;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Collection;
+
+class GetDailyBriefingInputQuery
+{
+    public const TOP_PROJECTS_LIMIT = 5;
+
+    public const WORK_ITEMS_LIMIT = 10;
+
+    public const ALERTS_LIMIT = 10;
+
+    public const ACTIVITY_EVENTS_LIMIT = 10;
+
+    /**
+     * @param  array<int, int>|null  $includeProjectIds
+     * @return array<string, mixed>
+     */
+    public function execute(
+        User $user,
+        CarbonInterface|string $briefingDate,
+        ?string $timezone = null,
+        ?array $includeProjectIds = null,
+    ): array {
+        $timezone = $timezone ?: config('app.timezone', 'UTC');
+        $localStart = CarbonImmutable::parse($briefingDate, $timezone)->startOfDay();
+        $localEnd = $localStart->addDay();
+        $utcStart = $localStart->setTimezone('UTC');
+        $utcEnd = $localEnd->setTimezone('UTC');
+        $projectIds = $this->projectIdsFor($user, $includeProjectIds);
+
+        return [
+            'window' => [
+                'briefing_date' => $localStart->toDateString(),
+                'timezone' => $timezone,
+                'starts_at_utc' => $utcStart->toIso8601String(),
+                'ends_at_utc' => $utcEnd->toIso8601String(),
+            ],
+            'projects' => $this->projects($projectIds),
+            'github' => $this->github($projectIds, $utcStart, $utcEnd),
+            'deployments' => $this->deployments($projectIds, $utcStart, $utcEnd),
+            'alerts' => $this->alerts($projectIds, $utcStart, $utcEnd),
+            'monitoring' => $this->monitoring($projectIds, $utcStart, $utcEnd),
+            'health' => $this->health($projectIds),
+            'activity' => $this->activity($projectIds, $utcStart, $utcEnd),
+        ];
+    }
+
+    /**
+     * @param  array<int, int>|null  $includeProjectIds
+     * @return array<int, int>
+     */
+    private function projectIdsFor(User $user, ?array $includeProjectIds): array
+    {
+        $query = Project::query()->where('owner_user_id', $user->id);
+
+        if ($includeProjectIds !== null && $includeProjectIds !== []) {
+            $query->whereIn('id', $includeProjectIds);
+        }
+
+        return $query->pluck('id')->map(fn ($id): int => (int) $id)->all();
+    }
+
+    /**
+     * @param  array<int, int>  $projectIds
+     * @return array<string, mixed>
+     */
+    private function projects(array $projectIds): array
+    {
+        $sample = Project::query()
+            ->whereIn('id', $projectIds)
+            ->orderByRaw('health_score IS NULL')
+            ->orderBy('health_score')
+            ->orderByDesc('last_activity_at')
+            ->orderBy('id')
+            ->limit(self::TOP_PROJECTS_LIMIT)
+            ->get(['id', 'name', 'slug', 'health_score', 'last_activity_at'])
+            ->map(fn (Project $project): array => $this->projectPayload($project))
+            ->all();
+
+        return [
+            'total' => count($projectIds),
+            'sample' => $sample,
+        ];
+    }
+
+    /**
+     * @param  array<int, int>  $projectIds
+     * @return array<string, mixed>
+     */
+    private function github(array $projectIds, CarbonInterface $utcStart, CarbonInterface $utcEnd): array
+    {
+        $issueBase = GithubIssue::query()
+            ->join('repositories', 'github_issues.repository_id', '=', 'repositories.id')
+            ->whereIn('repositories.project_id', $projectIds);
+
+        $prBase = GithubPullRequest::query()
+            ->join('repositories', 'github_pull_requests.repository_id', '=', 'repositories.id')
+            ->whereIn('repositories.project_id', $projectIds);
+
+        $items = collect()
+            ->merge($this->issueSamples($projectIds, 'opened', 'created_at_github', $utcStart, $utcEnd))
+            ->merge($this->issueSamples($projectIds, 'closed', 'closed_at_github', $utcStart, $utcEnd))
+            ->merge($this->pullRequestSamples($projectIds, 'opened', 'created_at_github', $utcStart, $utcEnd))
+            ->merge($this->pullRequestSamples($projectIds, 'merged', 'merged_at', $utcStart, $utcEnd))
+            ->merge($this->pullRequestSamples($projectIds, 'closed', 'closed_at_github', $utcStart, $utcEnd, false))
+            ->sortByDesc('occurred_at')
+            ->take(self::WORK_ITEMS_LIMIT)
+            ->values()
+            ->all();
+
+        return [
+            'issues' => [
+                'opened' => (clone $issueBase)->where('github_issues.created_at_github', '>=', $utcStart)->where('github_issues.created_at_github', '<', $utcEnd)->count('github_issues.id'),
+                'closed' => (clone $issueBase)->where('github_issues.state', GithubIssueState::Closed->value)->where('github_issues.closed_at_github', '>=', $utcStart)->where('github_issues.closed_at_github', '<', $utcEnd)->count('github_issues.id'),
+            ],
+            'pull_requests' => [
+                'opened' => (clone $prBase)->where('github_pull_requests.created_at_github', '>=', $utcStart)->where('github_pull_requests.created_at_github', '<', $utcEnd)->count('github_pull_requests.id'),
+                'merged' => (clone $prBase)->where('github_pull_requests.merged', true)->where('github_pull_requests.merged_at', '>=', $utcStart)->where('github_pull_requests.merged_at', '<', $utcEnd)->count('github_pull_requests.id'),
+                'closed' => (clone $prBase)->where('github_pull_requests.state', GithubPullRequestState::Closed->value)->where('github_pull_requests.closed_at_github', '>=', $utcStart)->where('github_pull_requests.closed_at_github', '<', $utcEnd)->count('github_pull_requests.id'),
+            ],
+            'work_items' => $items,
+        ];
+    }
+
+    /**
+     * @param  array<int, int>  $projectIds
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function issueSamples(array $projectIds, string $event, string $timestampColumn, CarbonInterface $utcStart, CarbonInterface $utcEnd): Collection
+    {
+        return GithubIssue::query()
+            ->join('repositories', 'github_issues.repository_id', '=', 'repositories.id')
+            ->join('projects', 'repositories.project_id', '=', 'projects.id')
+            ->whereIn('repositories.project_id', $projectIds)
+            ->whereNotNull("github_issues.{$timestampColumn}")
+            ->where("github_issues.{$timestampColumn}", '>=', $utcStart)
+            ->where("github_issues.{$timestampColumn}", '<', $utcEnd)
+            ->orderByDesc("github_issues.{$timestampColumn}")
+            ->limit(self::WORK_ITEMS_LIMIT)
+            ->get([
+                'github_issues.id',
+                'github_issues.number',
+                'github_issues.title',
+                'github_issues.state',
+                "github_issues.{$timestampColumn} as occurred_at",
+                'projects.id as project_id',
+                'projects.name as project_name',
+            ])
+            ->map(fn ($row): array => [
+                'kind' => 'issue',
+                'event' => $event,
+                'id' => (int) $row->id,
+                'number' => (int) $row->number,
+                'title' => $row->title,
+                'state' => $row->state instanceof GithubIssueState ? $row->state->value : $row->state,
+                'occurred_at' => CarbonImmutable::parse($row->occurred_at, 'UTC')->toIso8601String(),
+                'project_id' => (int) $row->project_id,
+                'project_name' => $row->project_name,
+            ]);
+    }
+
+    /**
+     * @param  array<int, int>  $projectIds
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function pullRequestSamples(array $projectIds, string $event, string $timestampColumn, CarbonInterface $utcStart, CarbonInterface $utcEnd, ?bool $merged = null): Collection
+    {
+        $query = GithubPullRequest::query()
+            ->join('repositories', 'github_pull_requests.repository_id', '=', 'repositories.id')
+            ->join('projects', 'repositories.project_id', '=', 'projects.id')
+            ->whereIn('repositories.project_id', $projectIds)
+            ->whereNotNull("github_pull_requests.{$timestampColumn}")
+            ->where("github_pull_requests.{$timestampColumn}", '>=', $utcStart)
+            ->where("github_pull_requests.{$timestampColumn}", '<', $utcEnd);
+
+        if ($merged !== null) {
+            $query->where('github_pull_requests.merged', $merged);
+        }
+
+        return $query
+            ->orderByDesc("github_pull_requests.{$timestampColumn}")
+            ->limit(self::WORK_ITEMS_LIMIT)
+            ->get([
+                'github_pull_requests.id',
+                'github_pull_requests.number',
+                'github_pull_requests.title',
+                'github_pull_requests.state',
+                "github_pull_requests.{$timestampColumn} as occurred_at",
+                'projects.id as project_id',
+                'projects.name as project_name',
+            ])
+            ->map(fn ($row): array => [
+                'kind' => 'pull_request',
+                'event' => $event,
+                'id' => (int) $row->id,
+                'number' => (int) $row->number,
+                'title' => $row->title,
+                'state' => $row->state instanceof GithubPullRequestState ? $row->state->value : $row->state,
+                'occurred_at' => CarbonImmutable::parse($row->occurred_at, 'UTC')->toIso8601String(),
+                'project_id' => (int) $row->project_id,
+                'project_name' => $row->project_name,
+            ]);
+    }
+
+    /**
+     * @param  array<int, int>  $projectIds
+     * @return array<string, mixed>
+     */
+    private function deployments(array $projectIds, CarbonInterface $utcStart, CarbonInterface $utcEnd): array
+    {
+        $base = WorkflowRun::query()
+            ->join('repositories', 'workflow_runs.repository_id', '=', 'repositories.id')
+            ->join('projects', 'repositories.project_id', '=', 'projects.id')
+            ->whereIn('repositories.project_id', $projectIds)
+            ->where('workflow_runs.status', WorkflowRunStatus::Completed->value)
+            ->where('workflow_runs.run_completed_at', '>=', $utcStart)
+            ->where('workflow_runs.run_completed_at', '<', $utcEnd);
+
+        $failedConclusions = [
+            WorkflowRunConclusion::Failure->value,
+            WorkflowRunConclusion::TimedOut->value,
+            WorkflowRunConclusion::ActionRequired->value,
+        ];
+
+        return [
+            'successful' => (clone $base)->where('workflow_runs.conclusion', WorkflowRunConclusion::Success->value)->count('workflow_runs.id'),
+            'failed' => (clone $base)->whereIn('workflow_runs.conclusion', $failedConclusions)->count('workflow_runs.id'),
+            'failed_workflows' => (clone $base)
+                ->whereIn('workflow_runs.conclusion', $failedConclusions)
+                ->orderByDesc('workflow_runs.run_completed_at')
+                ->limit(self::WORK_ITEMS_LIMIT)
+                ->get([
+                    'workflow_runs.id',
+                    'workflow_runs.name',
+                    'workflow_runs.conclusion',
+                    'workflow_runs.run_completed_at',
+                    'projects.id as project_id',
+                    'projects.name as project_name',
+                ])
+                ->map(fn (WorkflowRun $run): array => [
+                    'id' => $run->id,
+                    'name' => $run->name,
+                    'conclusion' => $run->conclusion instanceof WorkflowRunConclusion ? $run->conclusion->value : $run->conclusion,
+                    'completed_at' => $run->run_completed_at?->toIso8601String(),
+                    'project_id' => (int) $run->project_id,
+                    'project_name' => $run->project_name,
+                ])
+                ->all(),
+        ];
+    }
+
+    /**
+     * @param  array<int, int>  $projectIds
+     * @return array<string, mixed>
+     */
+    private function alerts(array $projectIds, CarbonInterface $utcStart, CarbonInterface $utcEnd): array
+    {
+        $triggeredBase = Alert::query()
+            ->join('projects', 'alerts.project_id', '=', 'projects.id')
+            ->whereIn('alerts.project_id', $projectIds)
+            ->where('alerts.triggered_at', '>=', $utcStart)
+            ->where('alerts.triggered_at', '<', $utcEnd);
+
+        $resolvedBase = Alert::query()
+            ->whereIn('alerts.project_id', $projectIds)
+            ->where('alerts.status', AlertStatus::Resolved->value)
+            ->where('alerts.resolved_at', '>=', $utcStart)
+            ->where('alerts.resolved_at', '<', $utcEnd);
+
+        return [
+            'triggered' => (clone $triggeredBase)->count('alerts.id'),
+            'resolved' => (clone $resolvedBase)->count('alerts.id'),
+            'groups' => (clone $triggeredBase)
+                ->selectRaw('alerts.severity, alerts.source, alerts.project_id, projects.name as project_name, COUNT(alerts.id) as total')
+                ->groupBy('alerts.severity', 'alerts.source', 'alerts.project_id', 'projects.name')
+                ->orderByDesc('total')
+                ->orderBy('alerts.project_id')
+                ->get()
+                ->map(fn ($row): array => [
+                    'severity' => $row->severity,
+                    'source' => $row->source,
+                    'project_id' => (int) $row->project_id,
+                    'project_name' => $row->project_name,
+                    'total' => (int) $row->total,
+                ])
+                ->all(),
+            'sample' => (clone $triggeredBase)
+                ->orderByDesc('alerts.triggered_at')
+                ->limit(self::ALERTS_LIMIT)
+                ->get([
+                    'alerts.id',
+                    'alerts.title',
+                    'alerts.severity',
+                    'alerts.source',
+                    'alerts.status',
+                    'alerts.triggered_at',
+                    'projects.id as project_id',
+                    'projects.name as project_name',
+                ])
+                ->map(fn (Alert $alert): array => [
+                    'id' => $alert->id,
+                    'title' => $alert->title,
+                    'severity' => $alert->severity->value,
+                    'source' => $alert->source->value,
+                    'status' => $alert->status->value,
+                    'triggered_at' => $alert->triggered_at?->toIso8601String(),
+                    'project_id' => (int) $alert->project_id,
+                    'project_name' => $alert->project_name,
+                ])
+                ->all(),
+        ];
+    }
+
+    /**
+     * @param  array<int, int>  $projectIds
+     * @return array<string, mixed>
+     */
+    private function monitoring(array $projectIds, CarbonInterface $utcStart, CarbonInterface $utcEnd): array
+    {
+        $websiteChecks = WebsiteCheck::query()
+            ->join('websites', 'website_checks.website_id', '=', 'websites.id')
+            ->join('projects', 'websites.project_id', '=', 'projects.id')
+            ->whereIn('websites.project_id', $projectIds)
+            ->where('website_checks.checked_at', '>=', $utcStart)
+            ->where('website_checks.checked_at', '<', $utcEnd);
+
+        return [
+            'website_checks' => [
+                'total' => (clone $websiteChecks)->count('website_checks.id'),
+                'by_status' => (clone $websiteChecks)
+                    ->selectRaw('website_checks.status, COUNT(website_checks.id) as total')
+                    ->groupBy('website_checks.status')
+                    ->pluck('total', 'status')
+                    ->map(fn ($total): int => (int) $total)
+                    ->all(),
+                'problem_sample' => (clone $websiteChecks)
+                    ->whereIn('website_checks.status', [
+                        WebsiteCheckStatus::Down->value,
+                        WebsiteCheckStatus::Slow->value,
+                        WebsiteCheckStatus::Error->value,
+                    ])
+                    ->orderByDesc('website_checks.checked_at')
+                    ->limit(self::WORK_ITEMS_LIMIT)
+                    ->get([
+                        'website_checks.id',
+                        'website_checks.status',
+                        'website_checks.response_time_ms',
+                        'website_checks.checked_at',
+                        'websites.name as website_name',
+                        'projects.id as project_id',
+                        'projects.name as project_name',
+                    ])
+                    ->map(fn (WebsiteCheck $check): array => [
+                        'id' => $check->id,
+                        'website_name' => $check->website_name,
+                        'status' => $check->status->value,
+                        'response_time_ms' => $check->response_time_ms,
+                        'checked_at' => $check->checked_at?->toIso8601String(),
+                        'project_id' => (int) $check->project_id,
+                        'project_name' => $check->project_name,
+                    ])
+                    ->all(),
+            ],
+            'hosts' => $this->hostHealth($projectIds),
+            'containers' => $this->containerHealth($projectIds),
+        ];
+    }
+
+    /**
+     * @param  array<int, int>  $projectIds
+     * @return array<string, mixed>
+     */
+    private function hostHealth(array $projectIds): array
+    {
+        return [
+            'by_status' => Host::query()
+                ->whereIn('project_id', $projectIds)
+                ->selectRaw('status, COUNT(id) as total')
+                ->groupBy('status')
+                ->pluck('total', 'status')
+                ->map(fn ($total): int => (int) $total)
+                ->all(),
+            'problem_sample' => Host::query()
+                ->join('projects', 'hosts.project_id', '=', 'projects.id')
+                ->whereIn('hosts.project_id', $projectIds)
+                ->whereIn('hosts.status', ['offline', 'degraded'])
+                ->orderByDesc('hosts.last_seen_at')
+                ->limit(self::TOP_PROJECTS_LIMIT)
+                ->get([
+                    'hosts.id',
+                    'hosts.name',
+                    'hosts.status',
+                    'hosts.last_seen_at',
+                    'projects.id as project_id',
+                    'projects.name as project_name',
+                ])
+                ->map(fn (Host $host): array => [
+                    'id' => $host->id,
+                    'name' => $host->name,
+                    'status' => $host->status->value,
+                    'last_seen_at' => $host->last_seen_at?->toIso8601String(),
+                    'project_id' => (int) $host->project_id,
+                    'project_name' => $host->project_name,
+                ])
+                ->all(),
+        ];
+    }
+
+    /**
+     * @param  array<int, int>  $projectIds
+     * @return array<string, mixed>
+     */
+    private function containerHealth(array $projectIds): array
+    {
+        return [
+            'by_health_status' => Container::query()
+                ->whereIn('project_id', $projectIds)
+                ->selectRaw('COALESCE(health_status, status) as health_key, COUNT(id) as total')
+                ->groupBy('health_key')
+                ->pluck('total', 'health_key')
+                ->map(fn ($total): int => (int) $total)
+                ->all(),
+            'problem_sample' => Container::query()
+                ->join('projects', 'containers.project_id', '=', 'projects.id')
+                ->whereIn('containers.project_id', $projectIds)
+                ->where(function ($query): void {
+                    $query->whereNotNull('containers.health_status')
+                        ->where('containers.health_status', '!=', 'healthy')
+                        ->orWhereIn('containers.status', ['exited', 'dead', 'restarting']);
+                })
+                ->orderByDesc('containers.last_seen_at')
+                ->limit(self::TOP_PROJECTS_LIMIT)
+                ->get([
+                    'containers.id',
+                    'containers.name',
+                    'containers.status',
+                    'containers.health_status',
+                    'containers.last_seen_at',
+                    'projects.id as project_id',
+                    'projects.name as project_name',
+                ])
+                ->map(fn (Container $container): array => [
+                    'id' => $container->id,
+                    'name' => $container->name,
+                    'status' => $container->status,
+                    'health_status' => $container->health_status,
+                    'last_seen_at' => $container->last_seen_at?->toIso8601String(),
+                    'project_id' => (int) $container->project_id,
+                    'project_name' => $container->project_name,
+                ])
+                ->all(),
+        ];
+    }
+
+    /**
+     * @param  array<int, int>  $projectIds
+     * @return array<string, mixed>
+     */
+    private function health(array $projectIds): array
+    {
+        return [
+            'deltas' => [],
+            'worst_projects' => Project::query()
+                ->whereIn('id', $projectIds)
+                ->orderByRaw('health_score IS NULL')
+                ->orderBy('health_score')
+                ->orderBy('id')
+                ->limit(self::TOP_PROJECTS_LIMIT)
+                ->get(['id', 'name', 'slug', 'health_score', 'last_activity_at'])
+                ->map(fn (Project $project): array => $this->projectPayload($project))
+                ->all(),
+        ];
+    }
+
+    /**
+     * @param  array<int, int>  $projectIds
+     * @return array<string, mixed>
+     */
+    private function activity(array $projectIds, CarbonInterface $utcStart, CarbonInterface $utcEnd): array
+    {
+        $websiteIds = Website::query()->whereIn('project_id', $projectIds)->pluck('id')->all();
+        $hostIds = Host::query()->whereIn('project_id', $projectIds)->pluck('id')->all();
+        $alertIds = Alert::query()->whereIn('project_id', $projectIds)->pluck('id')->all();
+
+        $base = ActivityEvent::query()
+            ->leftJoin('repositories', 'activity_events.repository_id', '=', 'repositories.id')
+            ->leftJoin('projects as repo_projects', 'repositories.project_id', '=', 'repo_projects.id')
+            ->where('activity_events.occurred_at', '>=', $utcStart)
+            ->where('activity_events.occurred_at', '<', $utcEnd)
+            ->where(function ($query) use ($projectIds, $websiteIds, $hostIds, $alertIds): void {
+                $query->whereIn('repositories.project_id', $projectIds)
+                    ->orWhere(function ($inner) use ($projectIds): void {
+                        $inner->where('activity_events.source', 'monitoring')
+                            ->whereIn('activity_events.metadata->project_id', $projectIds);
+                    })
+                    ->orWhere(function ($inner) use ($websiteIds): void {
+                        $inner->where('activity_events.source', 'monitoring')
+                            ->whereIn('activity_events.metadata->website_id', $websiteIds);
+                    })
+                    ->orWhere(function ($inner) use ($projectIds): void {
+                        $inner->where('activity_events.source', 'hosts')
+                            ->whereIn('activity_events.metadata->project_id', $projectIds);
+                    })
+                    ->orWhere(function ($inner) use ($hostIds): void {
+                        $inner->where('activity_events.source', 'hosts')
+                            ->whereIn('activity_events.metadata->host_id', $hostIds);
+                    })
+                    ->orWhere(function ($inner) use ($projectIds): void {
+                        $inner->where('activity_events.source', 'alerts')
+                            ->whereIn('activity_events.metadata->project_id', $projectIds);
+                    })
+                    ->orWhere(function ($inner) use ($alertIds): void {
+                        $inner->where('activity_events.source', 'alerts')
+                            ->whereIn('activity_events.metadata->alert_id', $alertIds);
+                    });
+            });
+
+        return [
+            'total' => (clone $base)->count('activity_events.id'),
+            'by_project' => $this->activityByProject($projectIds, $utcStart, $utcEnd),
+            'top_events' => (clone $base)
+                ->with('repository:id,full_name,project_id')
+                ->orderByDesc('activity_events.occurred_at')
+                ->orderByDesc('activity_events.id')
+                ->limit(self::ACTIVITY_EVENTS_LIMIT)
+                ->get(['activity_events.*'])
+                ->map(fn (ActivityEvent $event): array => [
+                    'id' => $event->id,
+                    'source' => $event->source,
+                    'event_type' => $event->event_type,
+                    'severity' => $event->severity->value,
+                    'title' => $event->title,
+                    'occurred_at' => $event->occurred_at?->toIso8601String(),
+                    'project_id' => $event->repository?->project_id ?? $event->metadata['project_id'] ?? null,
+                ])
+                ->all(),
+        ];
+    }
+
+    /**
+     * @param  array<int, int>  $projectIds
+     * @return array<int, array{project_id: int, project_name: string, total: int}>
+     */
+    private function activityByProject(array $projectIds, CarbonInterface $utcStart, CarbonInterface $utcEnd): array
+    {
+        return Project::query()
+            ->whereIn('projects.id', $projectIds)
+            ->get(['id', 'name'])
+            ->map(function (Project $project) use ($utcStart, $utcEnd): array {
+                $total = ActivityEvent::query()
+                    ->where('occurred_at', '>=', $utcStart)
+                    ->where('occurred_at', '<', $utcEnd)
+                    ->where(function ($query) use ($project): void {
+                        $websiteIds = Website::query()->where('project_id', $project->id)->pluck('id')->all();
+                        $hostIds = Host::query()->where('project_id', $project->id)->pluck('id')->all();
+                        $alertIds = Alert::query()->where('project_id', $project->id)->pluck('id')->all();
+
+                        $query->whereHas('repository', fn ($inner) => $inner->where('project_id', $project->id))
+                            ->orWhere('metadata->project_id', $project->id)
+                            ->orWhereIn('metadata->website_id', $websiteIds)
+                            ->orWhereIn('metadata->host_id', $hostIds)
+                            ->orWhereIn('metadata->alert_id', $alertIds);
+                    })
+                    ->count();
+
+                return [
+                    'project_id' => $project->id,
+                    'project_name' => $project->name,
+                    'total' => $total,
+                ];
+            })
+            ->filter(fn (array $row): bool => $row['total'] > 0)
+            ->sortByDesc('total')
+            ->values()
+            ->all();
+    }
+
+    /** @return array<string, mixed> */
+    private function projectPayload(Project $project): array
+    {
+        return [
+            'id' => $project->id,
+            'name' => $project->name,
+            'slug' => $project->slug,
+            'health_score' => $project->health_score,
+            'last_activity_at' => $project->last_activity_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Domain/Notifications/Contracts/NotificationChannelDriver.php
+++ b/app/Domain/Notifications/Contracts/NotificationChannelDriver.php
@@ -2,7 +2,6 @@
 
 namespace App\Domain\Notifications\Contracts;
 
-use App\Domain\Notifications\DataTransferObjects\AlertNotificationPayload;
 use App\Models\AlertNotificationChannel;
 
 /**
@@ -18,5 +17,5 @@ interface NotificationChannelDriver
     /**
      * @throws \Throwable when the channel refuses / errors out.
      */
-    public function send(AlertNotificationChannel $channel, AlertNotificationPayload $payload): void;
+    public function send(AlertNotificationChannel $channel, NotificationPayload $payload): void;
 }

--- a/app/Domain/Notifications/Contracts/NotificationPayload.php
+++ b/app/Domain/Notifications/Contracts/NotificationPayload.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Domain\Notifications\Contracts;
+
+use Illuminate\Mail\Mailable;
+
+interface NotificationPayload
+{
+    public function title(): string;
+
+    public function message(): ?string;
+
+    public function link(): string;
+
+    public function event(): string;
+
+    public function toMail(): Mailable;
+
+    /** @return array<string, mixed> */
+    public function toSlackPayload(): array;
+
+    /** @return array<string, mixed> */
+    public function toArray(): array;
+}

--- a/app/Domain/Notifications/DataTransferObjects/AlertNotificationPayload.php
+++ b/app/Domain/Notifications/DataTransferObjects/AlertNotificationPayload.php
@@ -2,7 +2,10 @@
 
 namespace App\Domain\Notifications\DataTransferObjects;
 
+use App\Domain\Notifications\Contracts\NotificationPayload;
+use App\Mail\AlertNotificationMail;
 use App\Models\Alert;
+use Illuminate\Mail\Mailable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\URL;
 
@@ -18,7 +21,7 @@ use Illuminate\Support\Facades\URL;
  * scalar values only, size bounded ≤ 2 KB before the payload as a
  * whole is bounded ≤ 4 KB at the delivery-log persist step.
  */
-final class AlertNotificationPayload
+final class AlertNotificationPayload implements NotificationPayload
 {
     /**
      * @param  array<string, scalar|null>  $metadata
@@ -87,6 +90,91 @@ final class AlertNotificationPayload
             'link' => $this->link,
             'triggered_at' => $this->triggeredAt->toIso8601String(),
             'metadata' => $this->metadata,
+        ];
+    }
+
+    public function title(): string
+    {
+        return $this->title;
+    }
+
+    public function message(): ?string
+    {
+        return $this->message;
+    }
+
+    public function link(): string
+    {
+        return $this->link;
+    }
+
+    public function event(): string
+    {
+        return $this->event;
+    }
+
+    public function toMail(): Mailable
+    {
+        return new AlertNotificationMail($this);
+    }
+
+    /** @return array<string, mixed> */
+    public function toSlackPayload(): array
+    {
+        $emoji = match ($this->severity) {
+            'critical' => ':rotating_light:',
+            'warning' => ':warning:',
+            default => ':information_source:',
+        };
+
+        $header = $this->event === 'alert.resolved'
+            ? ":white_check_mark: {$this->title} resolved"
+            : "{$emoji} {$this->title}";
+
+        return [
+            'text' => $header,
+            'blocks' => [
+                [
+                    'type' => 'header',
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => $header,
+                        'emoji' => true,
+                    ],
+                ],
+                [
+                    'type' => 'section',
+                    'fields' => array_filter([
+                        [
+                            'type' => 'mrkdwn',
+                            'text' => "*Severity*\n".ucfirst($this->severity),
+                        ],
+                        [
+                            'type' => 'mrkdwn',
+                            'text' => "*Source*\n".ucfirst($this->source),
+                        ],
+                    ]),
+                ],
+                ...($this->message !== null && $this->message !== '' ? [[
+                    'type' => 'section',
+                    'text' => [
+                        'type' => 'mrkdwn',
+                        'text' => $this->message,
+                    ],
+                ]] : []),
+                [
+                    'type' => 'actions',
+                    'elements' => [[
+                        'type' => 'button',
+                        'text' => [
+                            'type' => 'plain_text',
+                            'text' => 'View in Nexus',
+                            'emoji' => true,
+                        ],
+                        'url' => $this->link,
+                    ]],
+                ],
+            ],
         ];
     }
 

--- a/app/Domain/Notifications/Drivers/EmailChannelDriver.php
+++ b/app/Domain/Notifications/Drivers/EmailChannelDriver.php
@@ -3,15 +3,14 @@
 namespace App\Domain\Notifications\Drivers;
 
 use App\Domain\Notifications\Contracts\NotificationChannelDriver;
-use App\Domain\Notifications\DataTransferObjects\AlertNotificationPayload;
-use App\Mail\AlertNotificationMail;
+use App\Domain\Notifications\Contracts\NotificationPayload;
 use App\Models\AlertNotificationChannel;
 use Illuminate\Support\Facades\Mail;
 use InvalidArgumentException;
 
 class EmailChannelDriver implements NotificationChannelDriver
 {
-    public function send(AlertNotificationChannel $channel, AlertNotificationPayload $payload): void
+    public function send(AlertNotificationChannel $channel, NotificationPayload $payload): void
     {
         $to = $channel->config['to'] ?? null;
 
@@ -21,6 +20,6 @@ class EmailChannelDriver implements NotificationChannelDriver
             );
         }
 
-        Mail::to($to)->send(new AlertNotificationMail($payload));
+        Mail::to($to)->send($payload->toMail());
     }
 }

--- a/app/Domain/Notifications/Drivers/GenericWebhookChannelDriver.php
+++ b/app/Domain/Notifications/Drivers/GenericWebhookChannelDriver.php
@@ -3,7 +3,7 @@
 namespace App\Domain\Notifications\Drivers;
 
 use App\Domain\Notifications\Contracts\NotificationChannelDriver;
-use App\Domain\Notifications\DataTransferObjects\AlertNotificationPayload;
+use App\Domain\Notifications\Contracts\NotificationPayload;
 use App\Models\AlertNotificationChannel;
 use Illuminate\Support\Facades\Http;
 use InvalidArgumentException;
@@ -11,7 +11,7 @@ use RuntimeException;
 
 class GenericWebhookChannelDriver implements NotificationChannelDriver
 {
-    public function send(AlertNotificationChannel $channel, AlertNotificationPayload $payload): void
+    public function send(AlertNotificationChannel $channel, NotificationPayload $payload): void
     {
         $url = $channel->config['url'] ?? null;
         $signingSecret = $channel->config['signing_secret'] ?? null;

--- a/app/Domain/Notifications/Drivers/SlackChannelDriver.php
+++ b/app/Domain/Notifications/Drivers/SlackChannelDriver.php
@@ -3,7 +3,7 @@
 namespace App\Domain\Notifications\Drivers;
 
 use App\Domain\Notifications\Contracts\NotificationChannelDriver;
-use App\Domain\Notifications\DataTransferObjects\AlertNotificationPayload;
+use App\Domain\Notifications\Contracts\NotificationPayload;
 use App\Models\AlertNotificationChannel;
 use Illuminate\Support\Facades\Http;
 use InvalidArgumentException;
@@ -11,7 +11,7 @@ use RuntimeException;
 
 class SlackChannelDriver implements NotificationChannelDriver
 {
-    public function send(AlertNotificationChannel $channel, AlertNotificationPayload $payload): void
+    public function send(AlertNotificationChannel $channel, NotificationPayload $payload): void
     {
         $webhookUrl = $channel->config['webhook_url'] ?? null;
 
@@ -24,77 +24,12 @@ class SlackChannelDriver implements NotificationChannelDriver
         $response = Http::timeout(5)
             ->acceptJson()
             ->asJson()
-            ->post($webhookUrl, $this->buildBlockKitPayload($payload));
+            ->post($webhookUrl, $payload->toSlackPayload());
 
         if (! $response->successful()) {
             throw new RuntimeException(
                 "Slack webhook responded {$response->status()}: ".$response->body(),
             );
         }
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function buildBlockKitPayload(AlertNotificationPayload $payload): array
-    {
-        $emoji = match ($payload->severity) {
-            'critical' => ':rotating_light:',
-            'warning' => ':warning:',
-            default => ':information_source:',
-        };
-
-        $header = $payload->event === 'alert.resolved'
-            ? ":white_check_mark: {$payload->title} resolved"
-            : "{$emoji} {$payload->title}";
-
-        return [
-            // Slack shows this in notifications / previews when Block Kit isn't renderable.
-            'text' => $header,
-            'blocks' => [
-                [
-                    'type' => 'header',
-                    'text' => [
-                        'type' => 'plain_text',
-                        'text' => $header,
-                        'emoji' => true,
-                    ],
-                ],
-                [
-                    'type' => 'section',
-                    'fields' => array_filter([
-                        [
-                            'type' => 'mrkdwn',
-                            'text' => "*Severity*\n".ucfirst($payload->severity),
-                        ],
-                        [
-                            'type' => 'mrkdwn',
-                            'text' => "*Source*\n".ucfirst($payload->source),
-                        ],
-                    ]),
-                ],
-                ...($payload->message !== null && $payload->message !== '' ? [[
-                    'type' => 'section',
-                    'text' => [
-                        'type' => 'mrkdwn',
-                        'text' => $payload->message,
-                    ],
-                ]] : []),
-                [
-                    'type' => 'actions',
-                    'elements' => [
-                        [
-                            'type' => 'button',
-                            'text' => [
-                                'type' => 'plain_text',
-                                'text' => 'View in Nexus',
-                                'emoji' => true,
-                            ],
-                            'url' => $payload->link,
-                        ],
-                    ],
-                ],
-            ],
-        ];
     }
 }

--- a/app/Enums/DailyBriefingStatus.php
+++ b/app/Enums/DailyBriefingStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum DailyBriefingStatus: string
+{
+    case Pending = 'pending';
+    case Generated = 'generated';
+    case Delivered = 'delivered';
+    case Failed = 'failed';
+    case Skipped = 'skipped';
+}

--- a/app/Http/Controllers/DailyBriefingController.php
+++ b/app/Http/Controllers/DailyBriefingController.php
@@ -20,6 +20,7 @@ class DailyBriefingController extends Controller
 
         $briefings = DailyBriefing::query()
             ->where('user_id', $user->id)
+            ->where('is_test', false)
             ->whereNotNull('summary')
             ->latest('briefing_date')
             ->latest('id')

--- a/app/Http/Controllers/DailyBriefingController.php
+++ b/app/Http/Controllers/DailyBriefingController.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\DailyBriefingStatus;
+use App\Enums\NotificationChannelKind;
+use App\Models\AlertNotificationChannel;
+use App\Models\DailyBriefing;
+use App\Models\DailyBriefingPreference;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class DailyBriefingController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $user = $request->user();
+        $channel = $this->configuredChannel($user->id);
+
+        $briefings = DailyBriefing::query()
+            ->where('user_id', $user->id)
+            ->whereNotNull('summary')
+            ->latest('briefing_date')
+            ->latest('id')
+            ->get()
+            ->map(fn (DailyBriefing $briefing): array => $this->rowPayload($briefing, $channel))
+            ->all();
+
+        return Inertia::render('DailyBriefings/Index', [
+            'briefings' => $briefings,
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    private function rowPayload(DailyBriefing $briefing, ?AlertNotificationChannel $channel): array
+    {
+        return [
+            'id' => $briefing->id,
+            'briefing_date' => $briefing->briefing_date->toDateString(),
+            'status' => $briefing->status->value,
+            'status_tone' => $this->statusTone($briefing->status),
+            'channel' => $this->channelPayload($channel),
+            'summary_preview' => str($briefing->summary)->squish()->limit(180)->toString(),
+            'summary' => $briefing->summary,
+            'highlights' => $briefing->highlights ?? [],
+            'risks' => $briefing->risks ?? [],
+            'generated_at' => $briefing->generated_at?->diffForHumans(),
+            'delivered_at' => $briefing->delivered_at?->diffForHumans(),
+            'prompt_version' => $briefing->prompt_version,
+            'error_message' => $briefing->error_message,
+        ];
+    }
+
+    private function configuredChannel(int $userId): ?AlertNotificationChannel
+    {
+        $preference = DailyBriefingPreference::query()
+            ->where('user_id', $userId)
+            ->first();
+
+        if ($preference?->channel_id !== null) {
+            return AlertNotificationChannel::query()
+                ->whereKey($preference->channel_id)
+                ->where('user_id', $userId)
+                ->where('enabled', true)
+                ->whereNotNull('verified_at')
+                ->first();
+        }
+
+        return AlertNotificationChannel::query()
+            ->where('user_id', $userId)
+            ->where('kind', NotificationChannelKind::Email->value)
+            ->where('enabled', true)
+            ->whereNotNull('verified_at')
+            ->orderBy('id')
+            ->first();
+    }
+
+    /** @return array<string, string>|null */
+    private function channelPayload(?AlertNotificationChannel $channel): ?array
+    {
+        if ($channel === null) {
+            return null;
+        }
+
+        return [
+            'kind' => $channel->kind->value,
+            'kind_label' => $channel->kind->label(),
+            'name' => $channel->name,
+        ];
+    }
+
+    private function statusTone(DailyBriefingStatus $status): string
+    {
+        return match ($status) {
+            DailyBriefingStatus::Delivered => 'success',
+            DailyBriefingStatus::Failed => 'danger',
+            DailyBriefingStatus::Skipped => 'muted',
+            default => 'info',
+        };
+    }
+}

--- a/app/Http/Controllers/Settings/DailyBriefingPreferenceController.php
+++ b/app/Http/Controllers/Settings/DailyBriefingPreferenceController.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Domain\DailyBriefings\Actions\GenerateDailyBriefingAction;
+use App\Domain\DailyBriefings\Jobs\SendDailyBriefingJob;
+use App\Domain\DailyBriefings\Queries\GetDailyBriefingInputQuery;
+use App\Enums\DailyBriefingStatus;
+use App\Http\Controllers\Controller;
+use App\Models\AlertNotificationChannel;
+use App\Models\DailyBriefing;
+use App\Models\DailyBriefingPreference;
+use App\Models\Project;
+use Carbon\CarbonImmutable;
+use DateTimeZone;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+use Inertia\Response;
+use Throwable;
+
+class DailyBriefingPreferenceController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $user = $request->user();
+        $preference = DailyBriefingPreference::query()->firstOrCreate(
+            ['user_id' => $user->id],
+            [
+                'enabled' => false,
+                'delivery_time' => '08:00:00',
+                'timezone' => config('app.timezone', 'UTC'),
+                'channel_id' => null,
+                'include_projects' => null,
+            ],
+        );
+
+        return Inertia::render('Settings/DailyBriefing', [
+            'preference' => $this->preferencePayload($preference),
+            'channels' => $this->verifiedChannels($user->id),
+            'projects' => $this->projects($user->id),
+            'status' => $this->statusPayload($user->id),
+            'timezones' => DateTimeZone::listIdentifiers(),
+        ]);
+    }
+
+    public function update(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+        $validated = $this->validatePreference($request);
+
+        $preference = DailyBriefingPreference::query()->firstOrNew(['user_id' => $user->id]);
+        $preference->fill([
+            'enabled' => $validated['enabled'],
+            'delivery_time' => $this->normalizeTime($validated['delivery_time']),
+            'timezone' => $validated['timezone'],
+            'channel_id' => $validated['channel_id'] ?? null,
+            'include_projects' => $validated['include_projects'] ?? null,
+        ]);
+        $preference->save();
+
+        return back()->with('status', 'Daily briefing preferences saved.');
+    }
+
+    public function sendTest(
+        Request $request,
+        GetDailyBriefingInputQuery $inputQuery,
+        GenerateDailyBriefingAction $generate,
+    ): RedirectResponse {
+        $user = $request->user();
+        $preference = DailyBriefingPreference::query()
+            ->where('user_id', $user->id)
+            ->first();
+
+        if ($preference === null || ! $preference->enabled) {
+            return back()->with('error', 'Enable daily briefings before sending a test.');
+        }
+
+        if ($preference->channel_id !== null && $this->ownedVerifiedChannel($user->id, $preference->channel_id) === null) {
+            return back()->with('error', 'Selected channel must be enabled, verified, and owned by you.');
+        }
+
+        $briefingDate = CarbonImmutable::now($preference->timezone)->subDay()->toDateString();
+        $snapshot = $inputQuery->execute($user, $briefingDate, $preference->timezone, $preference->include_projects);
+        $briefing = $generate->execute($user, $snapshot);
+
+        if ($briefing->status !== DailyBriefingStatus::Generated) {
+            return back()->with('error', 'Test briefing generation failed: '.$briefing->error_message);
+        }
+
+        try {
+            (new SendDailyBriefingJob($briefing->id))->handle();
+        } catch (Throwable $exception) {
+            return back()->with('error', 'Test briefing delivery failed: '.$exception->getMessage());
+        }
+
+        $briefing->refresh();
+
+        if ($briefing->status !== DailyBriefingStatus::Delivered) {
+            return back()->with('error', 'Test briefing delivery failed: '.$briefing->error_message);
+        }
+
+        return back()->with('status', 'Test daily briefing sent.');
+    }
+
+    /** @return array<string, mixed> */
+    private function validatePreference(Request $request): array
+    {
+        $userId = $request->user()->id;
+
+        $validator = Validator::make($request->all(), [
+            'enabled' => ['required', 'boolean'],
+            'delivery_time' => ['required', 'date_format:H:i'],
+            'timezone' => ['required', 'string', Rule::in(DateTimeZone::listIdentifiers())],
+            'channel_id' => ['nullable', 'integer'],
+            'include_projects' => ['nullable', 'array'],
+            'include_projects.*' => ['integer'],
+        ]);
+
+        $validator->after(function ($validator) use ($request, $userId): void {
+            $channelId = $request->integer('channel_id') ?: null;
+            if ($channelId !== null && $this->ownedVerifiedChannel($userId, $channelId) === null) {
+                $validator->errors()->add('channel_id', 'Select an enabled, verified channel you own.');
+            }
+
+            $projectIds = collect($request->input('include_projects', []))
+                ->filter(fn ($id): bool => $id !== null && $id !== '')
+                ->map(fn ($id): int => (int) $id)
+                ->unique()
+                ->values();
+
+            if ($projectIds->isEmpty()) {
+                return;
+            }
+
+            $ownedCount = Project::query()
+                ->where('owner_user_id', $userId)
+                ->whereIn('id', $projectIds)
+                ->count();
+
+            if ($ownedCount !== $projectIds->count()) {
+                $validator->errors()->add('include_projects', 'Project filter can only include your projects.');
+            }
+        });
+
+        $validated = $validator->validate();
+        $validated['include_projects'] = collect($validated['include_projects'] ?? [])
+            ->filter(fn ($id): bool => $id !== null && $id !== '')
+            ->map(fn ($id): int => (int) $id)
+            ->unique()
+            ->values()
+            ->all();
+
+        if ($validated['include_projects'] === []) {
+            $validated['include_projects'] = null;
+        }
+
+        return $validated;
+    }
+
+    private function ownedVerifiedChannel(int $userId, int $channelId): ?AlertNotificationChannel
+    {
+        return AlertNotificationChannel::query()
+            ->whereKey($channelId)
+            ->where('user_id', $userId)
+            ->where('enabled', true)
+            ->whereNotNull('verified_at')
+            ->first();
+    }
+
+    private function normalizeTime(string $time): string
+    {
+        return strlen($time) === 5 ? "{$time}:00" : $time;
+    }
+
+    /** @return array<string, mixed> */
+    private function preferencePayload(DailyBriefingPreference $preference): array
+    {
+        return [
+            'enabled' => $preference->enabled,
+            'delivery_time' => substr((string) $preference->delivery_time, 0, 5),
+            'timezone' => $preference->timezone,
+            'channel_id' => $preference->channel_id,
+            'include_projects' => $preference->include_projects ?? [],
+            'last_sent_for_date' => $preference->last_sent_for_date?->toDateString(),
+        ];
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function verifiedChannels(int $userId): array
+    {
+        return AlertNotificationChannel::query()
+            ->where('user_id', $userId)
+            ->where('enabled', true)
+            ->whereNotNull('verified_at')
+            ->orderBy('name')
+            ->get(['id', 'kind', 'name'])
+            ->map(fn (AlertNotificationChannel $channel): array => [
+                'id' => $channel->id,
+                'kind' => $channel->kind->value,
+                'kind_label' => $channel->kind->label(),
+                'name' => $channel->name,
+            ])
+            ->all();
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function projects(int $userId): array
+    {
+        return Project::query()
+            ->where('owner_user_id', $userId)
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->map(fn (Project $project): array => [
+                'id' => $project->id,
+                'name' => $project->name,
+            ])
+            ->all();
+    }
+
+    /** @return array<string, mixed>|null */
+    private function statusPayload(int $userId): ?array
+    {
+        $briefing = DailyBriefing::query()
+            ->where('user_id', $userId)
+            ->latest('briefing_date')
+            ->latest('id')
+            ->first();
+
+        if ($briefing === null) {
+            return null;
+        }
+
+        return [
+            'briefing_date' => $briefing->briefing_date->toDateString(),
+            'status' => $briefing->status->value,
+            'generated_at' => $briefing->generated_at?->diffForHumans(),
+            'delivered_at' => $briefing->delivered_at?->diffForHumans(),
+            'error_message' => $briefing->error_message,
+        ];
+    }
+}

--- a/app/Http/Controllers/Settings/DailyBriefingPreferenceController.php
+++ b/app/Http/Controllers/Settings/DailyBriefingPreferenceController.php
@@ -84,14 +84,14 @@ class DailyBriefingPreferenceController extends Controller
 
         $briefingDate = CarbonImmutable::now($preference->timezone)->subDay()->toDateString();
         $snapshot = $inputQuery->execute($user, $briefingDate, $preference->timezone, $preference->include_projects);
-        $briefing = $generate->execute($user, $snapshot);
+        $briefing = $generate->execute($user, $snapshot, isTest: true);
 
         if ($briefing->status !== DailyBriefingStatus::Generated) {
             return back()->with('error', 'Test briefing generation failed: '.$briefing->error_message);
         }
 
         try {
-            (new SendDailyBriefingJob($briefing->id))->handle();
+            (new SendDailyBriefingJob($briefing->id, updateLastSentForDate: false))->handle();
         } catch (Throwable $exception) {
             return back()->with('error', 'Test briefing delivery failed: '.$exception->getMessage());
         }

--- a/app/Mail/DailyBriefingMail.php
+++ b/app/Mail/DailyBriefingMail.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Mail;
+
+use App\Domain\DailyBriefings\DataTransferObjects\DailyBriefingPayload;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class DailyBriefingMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(public readonly DailyBriefingPayload $payload) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: '[Nexus briefing] '.$this->payload->briefingDate,
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.daily-briefing',
+            with: ['payload' => $this->payload],
+        );
+    }
+}

--- a/app/Models/AlertNotificationChannel.php
+++ b/app/Models/AlertNotificationChannel.php
@@ -50,6 +50,11 @@ class AlertNotificationChannel extends Model
         return $this->hasMany(AlertNotificationPreference::class, 'channel_id');
     }
 
+    public function dailyBriefingPreferences(): HasMany
+    {
+        return $this->hasMany(DailyBriefingPreference::class, 'channel_id');
+    }
+
     public function deliveries(): HasMany
     {
         return $this->hasMany(AlertDelivery::class, 'channel_id');

--- a/app/Models/DailyBriefing.php
+++ b/app/Models/DailyBriefing.php
@@ -16,6 +16,7 @@ class DailyBriefing extends Model
     protected $fillable = [
         'user_id',
         'briefing_date',
+        'is_test',
         'status',
         'input_snapshot',
         'summary',
@@ -31,6 +32,7 @@ class DailyBriefing extends Model
     {
         return [
             'briefing_date' => 'immutable_date',
+            'is_test' => 'boolean',
             'status' => DailyBriefingStatus::class,
             'input_snapshot' => 'array',
             'highlights' => 'array',

--- a/app/Models/DailyBriefing.php
+++ b/app/Models/DailyBriefing.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\DailyBriefingStatus;
+use Database\Factories\DailyBriefingFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DailyBriefing extends Model
+{
+    /** @use HasFactory<DailyBriefingFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'briefing_date',
+        'status',
+        'input_snapshot',
+        'summary',
+        'highlights',
+        'risks',
+        'prompt_version',
+        'generated_at',
+        'delivered_at',
+        'error_message',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'briefing_date' => 'immutable_date',
+            'status' => DailyBriefingStatus::class,
+            'input_snapshot' => 'array',
+            'highlights' => 'array',
+            'risks' => 'array',
+            'generated_at' => 'immutable_datetime',
+            'delivered_at' => 'immutable_datetime',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/DailyBriefingPreference.php
+++ b/app/Models/DailyBriefingPreference.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\DailyBriefingPreferenceFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DailyBriefingPreference extends Model
+{
+    /** @use HasFactory<DailyBriefingPreferenceFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'enabled',
+        'delivery_time',
+        'timezone',
+        'channel_id',
+        'include_projects',
+        'last_sent_for_date',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+            'include_projects' => 'array',
+            'last_sent_for_date' => 'immutable_date',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function channel(): BelongsTo
+    {
+        return $this->belongsTo(AlertNotificationChannel::class, 'channel_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -35,5 +36,15 @@ class User extends Authenticatable implements MustVerifyEmail
     public function githubConnection(): HasOne
     {
         return $this->hasOne(GithubConnection::class);
+    }
+
+    public function dailyBriefingPreference(): HasOne
+    {
+        return $this->hasOne(DailyBriefingPreference::class);
+    }
+
+    public function dailyBriefings(): HasMany
+    {
+        return $this->hasMany(DailyBriefing::class);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Domain\AI\Contracts\LlmClient;
+use App\Domain\AI\Services\AnthropicLlmClient;
 use App\Domain\PublicStatus\Listeners\InvalidatePublicStatusCacheListener;
 use App\Domain\PublicStatus\Listeners\NotifyPublicSubscribersOnAlertListener;
 use App\Events\AlertResolved;
@@ -31,7 +33,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->bind(LlmClient::class, function () {
+            return match (config('services.llm.provider', 'anthropic')) {
+                'anthropic' => new AnthropicLlmClient,
+                default => throw new \RuntimeException('Unsupported LLM provider.'),
+            };
+        });
     }
 
     /**

--- a/config/services.php
+++ b/config/services.php
@@ -53,4 +53,12 @@ return [
         'webhook_secret' => env('GITHUB_WEBHOOK_SECRET', ''),
     ],
 
+    'llm' => [
+        'enabled' => env('AI_FEATURES_ENABLED', false),
+        'provider' => env('LLM_PROVIDER', 'anthropic'),
+        'api_key' => env('LLM_API_KEY'),
+        'model' => env('LLM_MODEL', 'claude-3-5-haiku-latest'),
+        'timeout' => (int) env('LLM_TIMEOUT', 20),
+    ],
+
 ];

--- a/database/factories/DailyBriefingFactory.php
+++ b/database/factories/DailyBriefingFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\DailyBriefingStatus;
+use App\Models\DailyBriefing;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<DailyBriefing> */
+class DailyBriefingFactory extends Factory
+{
+    protected $model = DailyBriefing::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'briefing_date' => today()->subDay()->toDateString(),
+            'status' => DailyBriefingStatus::Pending->value,
+            'input_snapshot' => null,
+            'summary' => null,
+            'highlights' => null,
+            'risks' => null,
+            'prompt_version' => 'daily-briefing-v1',
+            'generated_at' => null,
+            'delivered_at' => null,
+            'error_message' => null,
+        ];
+    }
+
+    public function generated(): static
+    {
+        return $this->state(fn () => [
+            'status' => DailyBriefingStatus::Generated->value,
+            'input_snapshot' => ['counts' => ['alerts' => 2]],
+            'summary' => 'Yesterday was mostly quiet with two alerts to review.',
+            'highlights' => ['Two alerts triggered', 'One deployment succeeded'],
+            'risks' => ['Billing API health score dropped'],
+            'generated_at' => now(),
+        ]);
+    }
+}

--- a/database/factories/DailyBriefingFactory.php
+++ b/database/factories/DailyBriefingFactory.php
@@ -17,6 +17,7 @@ class DailyBriefingFactory extends Factory
         return [
             'user_id' => User::factory(),
             'briefing_date' => today()->subDay()->toDateString(),
+            'is_test' => false,
             'status' => DailyBriefingStatus::Pending->value,
             'input_snapshot' => null,
             'summary' => null,

--- a/database/factories/DailyBriefingPreferenceFactory.php
+++ b/database/factories/DailyBriefingPreferenceFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DailyBriefingPreference;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<DailyBriefingPreference> */
+class DailyBriefingPreferenceFactory extends Factory
+{
+    protected $model = DailyBriefingPreference::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'enabled' => false,
+            'delivery_time' => '08:00:00',
+            'timezone' => config('app.timezone', 'UTC'),
+            'channel_id' => null,
+            'include_projects' => null,
+            'last_sent_for_date' => null,
+        ];
+    }
+
+    public function enabled(): static
+    {
+        return $this->state(fn () => [
+            'enabled' => true,
+        ]);
+    }
+}

--- a/database/migrations/2026_07_21_140000_create_daily_briefing_preferences_table.php
+++ b/database/migrations/2026_07_21_140000_create_daily_briefing_preferences_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('daily_briefing_preferences', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('user_id')
+                ->constrained('users')
+                ->cascadeOnDelete();
+
+            $table->boolean('enabled')->default(false);
+            $table->time('delivery_time')->default('08:00:00');
+            $table->string('timezone')->default(config('app.timezone', 'UTC'));
+
+            $table->foreignId('channel_id')
+                ->nullable()
+                ->constrained('alert_notification_channels')
+                ->nullOnDelete();
+
+            $table->json('include_projects')->nullable();
+            $table->date('last_sent_for_date')->nullable();
+
+            $table->timestamps();
+
+            $table->unique('user_id');
+            $table->index(['enabled', 'delivery_time']);
+            $table->index('channel_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('daily_briefing_preferences');
+    }
+};

--- a/database/migrations/2026_07_21_140001_create_daily_briefings_table.php
+++ b/database/migrations/2026_07_21_140001_create_daily_briefings_table.php
@@ -16,6 +16,7 @@ return new class extends Migration
                 ->cascadeOnDelete();
 
             $table->date('briefing_date');
+            $table->boolean('is_test')->default(false);
             $table->string('status', 16)->default('pending');
             $table->json('input_snapshot')->nullable();
             $table->text('summary')->nullable();
@@ -28,7 +29,7 @@ return new class extends Migration
 
             $table->timestamps();
 
-            $table->unique(['user_id', 'briefing_date']);
+            $table->unique(['user_id', 'briefing_date', 'is_test']);
             $table->index(['user_id', 'status']);
         });
     }

--- a/database/migrations/2026_07_21_140001_create_daily_briefings_table.php
+++ b/database/migrations/2026_07_21_140001_create_daily_briefings_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('daily_briefings', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('user_id')
+                ->constrained('users')
+                ->cascadeOnDelete();
+
+            $table->date('briefing_date');
+            $table->string('status', 16)->default('pending');
+            $table->json('input_snapshot')->nullable();
+            $table->text('summary')->nullable();
+            $table->json('highlights')->nullable();
+            $table->json('risks')->nullable();
+            $table->string('prompt_version')->default('daily-briefing-v1');
+            $table->timestamp('generated_at')->nullable();
+            $table->timestamp('delivered_at')->nullable();
+            $table->text('error_message')->nullable();
+
+            $table->timestamps();
+
+            $table->unique(['user_id', 'briefing_date']);
+            $table->index(['user_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('daily_briefings');
+    }
+};

--- a/docs/env.production.example
+++ b/docs/env.production.example
@@ -111,6 +111,15 @@ TELESCOPE_ENABLED=false
 # ALERT_NOTIFICATION_DEDUPE_WINDOW_MINUTES=5
 # ALERT_NOTIFICATION_RATE_LIMIT_PER_HOUR=30
 
+# ---- AI daily briefing / LLM provider (spec 044) -----------------------------
+# Disabled by default. Enable only after an operator has chosen the provider,
+# model, and budget posture for scheduled daily briefings.
+AI_FEATURES_ENABLED=false
+LLM_PROVIDER=anthropic
+LLM_API_KEY=CHANGEME
+LLM_MODEL=claude-3-5-haiku-latest
+LLM_TIMEOUT=20
+
 # ---- Vite dev server --------------------------------------------------------
 # Dev-only. Left blank / unset in production (npm run build handles assets).
 # VITE_DEV_SERVER_URL=

--- a/docs/security/operator-checklist.md
+++ b/docs/security/operator-checklist.md
@@ -92,6 +92,8 @@ Per-user limits via Laravel's `throttle:N,1` middleware:
 | `PATCH /settings/notifications/preferences/{preference}` | 20/min (spec 042) |
 | `DELETE /settings/notifications/preferences/{preference}` | 20/min (spec 042) |
 | `POST /settings/notifications/deliveries/{delivery}/retry` | 30/min (spec 042) |
+| `PATCH /settings/daily-briefing` | 20/min (spec 044) |
+| `POST /settings/daily-briefing/test` | 5/min (spec 044) |
 | `PATCH /settings/rules/weights` | 20/min (spec 046) |
 | `DELETE /settings/rules/weights` | 20/min (spec 046) |
 | `POST /settings/rules` | 10/min (spec 046) |
@@ -138,6 +140,24 @@ configured under `/settings/notifications`. Two extra postures:
   the receiving side can `hash_equals`-verify them (mirrors the
   inbound GitHub-webhook shape).
 
+### AI daily briefings (spec 044)
+
+Daily briefings are opt-in and stay inert unless `AI_FEATURES_ENABLED=true`,
+LLM config is present, and the user has enabled `/settings/daily-briefing`.
+Operators should verify:
+
+- **Settings mutations are throttled.** `PATCH /settings/daily-briefing`
+  is limited to 20/min, and immediate test sends are limited to 5/min.
+- **Scheduler behavior is bounded.** `daily-briefings:dispatch-due` runs
+  every 15 minutes, respects each user's timezone and delivery time, and
+  skips users already sent for the local briefing date.
+- **Delivery uses verified channels only.** Selected channels must be owned,
+  enabled, and verified; otherwise the send job can fall back to the user's
+  first verified email channel when no channel is selected.
+- **LLM input remains sanitized.** Input snapshots carry scoped counts,
+  entity metadata, timestamps, labels, and short snippets, not secrets,
+  tokens, webhook URLs, raw logs, or full issue/PR bodies.
+
 ## 7. Deferred to follow-ups
 
 Documented for visibility; not blockers for spec 039 sign-off:
@@ -165,4 +185,6 @@ Documented for visibility; not blockers for spec 039 sign-off:
 - [ ] §5: Manual sync / probe / retry endpoints all throttled.
 - [ ] §5 (spec 042): Notification channel `config` encrypted at
       rest; outbound webhook HMAC available on demand.
+- [ ] §6 (spec 044): AI daily briefing gate, throttles, scheduler, and
+      sanitized LLM input reviewed before enabling `AI_FEATURES_ENABLED`.
 - [ ] Run the suite: `php artisan test --filter=Security` passes.

--- a/resources/js/Pages/DailyBriefings/Index.vue
+++ b/resources/js/Pages/DailyBriefings/Index.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link } from '@inertiajs/vue3';
+import { CalendarDays, Inbox, Sparkles } from 'lucide-vue-next';
+import { ref } from 'vue';
+
+interface ChannelRef {
+    kind: string;
+    kind_label: string;
+    name: string;
+}
+
+interface BriefingRow {
+    id: number;
+    briefing_date: string;
+    status: 'pending' | 'generated' | 'delivered' | 'failed' | 'skipped';
+    status_tone: 'success' | 'warning' | 'danger' | 'info' | 'muted';
+    channel: ChannelRef | null;
+    summary_preview: string;
+    summary: string;
+    highlights: string[];
+    risks: string[];
+    generated_at: string | null;
+    delivered_at: string | null;
+    prompt_version: string;
+    error_message: string | null;
+}
+
+defineProps<{
+    briefings: BriefingRow[];
+}>();
+
+const selectedBriefingId = ref<number | null>(null);
+
+const toggleBriefing = (briefing: BriefingRow) => {
+    selectedBriefingId.value = selectedBriefingId.value === briefing.id ? null : briefing.id;
+};
+</script>
+
+<template>
+    <Head title="Daily briefings" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <span class="text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan">
+                    Phase 10
+                </span>
+                <h1 class="text-lg font-semibold text-text-primary">Daily briefings</h1>
+            </div>
+        </template>
+
+        <div class="mx-auto max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
+            <header class="mb-6 flex flex-wrap items-end justify-between gap-4">
+                <div class="flex flex-col gap-2">
+                    <h2 class="flex items-center gap-2 text-xl font-semibold text-text-primary">
+                        <Sparkles class="h-5 w-5 text-accent-cyan" aria-hidden="true" />
+                        Briefing history
+                    </h2>
+                    <p class="text-sm text-text-secondary">
+                        Review generated morning digests and delivery status from inside Nexus.
+                    </p>
+                </div>
+                <Link
+                    :href="route('settings.daily-briefing.index')"
+                    class="inline-flex items-center gap-2 rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm font-semibold text-text-secondary transition hover:border-accent-cyan/50 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                >
+                    Settings
+                </Link>
+            </header>
+
+            <section v-if="briefings.length === 0" class="glass-card flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
+                <span class="flex h-12 w-12 items-center justify-center rounded-full border border-border-subtle bg-slate-950/60">
+                    <Inbox class="h-5 w-5 text-text-muted" aria-hidden="true" />
+                </span>
+                <p class="text-sm font-medium text-text-secondary">No generated briefings yet</p>
+                <p class="max-w-sm text-xs text-text-muted">
+                    Once a daily briefing is generated, it will appear here even if delivery later fails.
+                </p>
+            </section>
+
+            <ul v-else class="flex flex-col gap-3">
+                <li
+                    v-for="briefing in briefings"
+                    :key="briefing.id"
+                    class="glass-card p-4 transition hover:border-accent-cyan/40"
+                >
+                    <button
+                        type="button"
+                        class="flex w-full flex-col gap-3 text-left sm:flex-row sm:items-start sm:justify-between"
+                        @click="toggleBriefing(briefing)"
+                    >
+                        <div class="flex min-w-0 flex-1 flex-col gap-2">
+                            <div class="flex flex-wrap items-center gap-2">
+                                <span class="inline-flex items-center gap-1 font-mono text-sm text-text-primary">
+                                    <CalendarDays class="h-4 w-4 text-accent-cyan" aria-hidden="true" />
+                                    {{ briefing.briefing_date }}
+                                </span>
+                                <StatusBadge :tone="briefing.status_tone">
+                                    {{ briefing.status }}
+                                </StatusBadge>
+                            </div>
+                            <p class="line-clamp-2 text-sm text-text-secondary">
+                                {{ briefing.summary_preview }}
+                            </p>
+                            <p class="text-[11px] text-text-muted">
+                                Channel:
+                                <span v-if="briefing.channel" class="text-text-secondary">
+                                    {{ briefing.channel.name }} ({{ briefing.channel.kind_label }})
+                                </span>
+                                <span v-else>No verified channel configured</span>
+                            </p>
+                        </div>
+                        <dl class="grid shrink-0 grid-cols-2 gap-3 text-right text-[11px] sm:min-w-48">
+                            <div>
+                                <dt class="font-semibold uppercase tracking-[0.18em] text-text-muted">Generated</dt>
+                                <dd class="text-text-secondary">{{ briefing.generated_at ?? '—' }}</dd>
+                            </div>
+                            <div>
+                                <dt class="font-semibold uppercase tracking-[0.18em] text-text-muted">Delivered</dt>
+                                <dd class="text-text-secondary">{{ briefing.delivered_at ?? '—' }}</dd>
+                            </div>
+                        </dl>
+                    </button>
+
+                    <section
+                        v-if="selectedBriefingId === briefing.id"
+                        class="mt-4 space-y-4 border-t border-border-subtle pt-4"
+                    >
+                        <p v-if="briefing.error_message" class="rounded-lg border border-status-danger/30 bg-status-danger/10 p-3 text-xs text-status-danger">
+                            {{ briefing.error_message }}
+                        </p>
+                        <div>
+                            <h3 class="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">Summary</h3>
+                            <p class="whitespace-pre-line text-sm leading-6 text-text-secondary">
+                                {{ briefing.summary }}
+                            </p>
+                        </div>
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <div>
+                                <h3 class="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">Highlights</h3>
+                                <ul v-if="briefing.highlights.length > 0" class="list-disc space-y-1 pl-4 text-sm text-text-secondary">
+                                    <li v-for="highlight in briefing.highlights" :key="highlight">
+                                        {{ highlight }}
+                                    </li>
+                                </ul>
+                                <p v-else class="text-sm text-text-muted">No highlights recorded.</p>
+                            </div>
+                            <div>
+                                <h3 class="mb-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">Risks</h3>
+                                <ul v-if="briefing.risks.length > 0" class="list-disc space-y-1 pl-4 text-sm text-text-secondary">
+                                    <li v-for="risk in briefing.risks" :key="risk">
+                                        {{ risk }}
+                                    </li>
+                                </ul>
+                                <p v-else class="text-sm text-text-muted">No risks recorded.</p>
+                            </div>
+                        </div>
+                        <p class="text-[11px] text-text-muted">Prompt version: {{ briefing.prompt_version }}</p>
+                    </section>
+                </li>
+            </ul>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Settings/DailyBriefing.vue
+++ b/resources/js/Pages/Settings/DailyBriefing.vue
@@ -1,0 +1,235 @@
+<script setup lang="ts">
+import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import AppLayout from '@/Layouts/AppLayout.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import { Bell, ChevronLeft, Clock, FolderKanban, Send, Sparkles } from 'lucide-vue-next';
+import { ref } from 'vue';
+
+type ChannelKind = 'email' | 'slack' | 'webhook';
+
+interface Preference {
+    enabled: boolean;
+    delivery_time: string;
+    timezone: string;
+    channel_id: number | null;
+    include_projects: number[];
+    last_sent_for_date: string | null;
+}
+
+interface Channel {
+    id: number;
+    kind: ChannelKind;
+    kind_label: string;
+    name: string;
+}
+
+interface ProjectOption {
+    id: number;
+    name: string;
+}
+
+interface BriefingStatus {
+    briefing_date: string;
+    status: 'pending' | 'generated' | 'delivered' | 'failed' | 'skipped';
+    generated_at: string | null;
+    delivered_at: string | null;
+    error_message: string | null;
+}
+
+const props = defineProps<{
+    preference: Preference;
+    channels: Channel[];
+    projects: ProjectOption[];
+    status: BriefingStatus | null;
+    timezones: string[];
+}>();
+
+const form = ref({
+    enabled: props.preference.enabled,
+    delivery_time: props.preference.delivery_time,
+    timezone: props.preference.timezone,
+    channel_id: props.preference.channel_id,
+    include_projects: [...props.preference.include_projects],
+});
+
+const save = () => {
+    router.patch(route('settings.daily-briefing.update'), form.value, {
+        preserveScroll: true,
+    });
+};
+
+const sendTest = () => {
+    router.post(route('settings.daily-briefing.test'), {}, { preserveScroll: true });
+};
+
+const statusTone = (status: BriefingStatus['status']) => {
+    switch (status) {
+        case 'delivered':
+            return 'success';
+        case 'failed':
+            return 'danger';
+        case 'skipped':
+            return 'muted';
+        default:
+            return 'info';
+    }
+};
+</script>
+
+<template>
+    <Head title="Daily briefing settings" />
+
+    <AppLayout>
+        <template #title>
+            <div class="flex flex-col">
+                <Link
+                    :href="route('settings.index')"
+                    class="inline-flex items-center gap-1 text-[11px] font-semibold uppercase tracking-[0.32em] text-accent-cyan transition hover:text-accent-cyan/80"
+                >
+                    <ChevronLeft class="h-3 w-3" aria-hidden="true" />
+                    Settings
+                </Link>
+                <h1 class="text-lg font-semibold text-text-primary">Daily briefing</h1>
+            </div>
+        </template>
+
+        <div class="space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+            <header class="flex flex-col gap-1">
+                <h2 class="flex items-center gap-2 text-xl font-semibold text-text-primary">
+                    <Sparkles class="h-5 w-5 text-accent-cyan" aria-hidden="true" />
+                    AI morning digest
+                </h2>
+                <p class="text-sm text-text-secondary">
+                    Opt in, choose when Nexus should generate yesterday's briefing, and route it through a verified notification channel.
+                </p>
+            </header>
+
+            <section class="glass-card p-5 sm:p-6">
+                <form class="space-y-6" @submit.prevent="save">
+                    <label class="flex items-start gap-3 rounded-lg border border-border-subtle bg-background-panel-hover/40 p-4">
+                        <input v-model="form.enabled" type="checkbox" class="mt-1">
+                        <span class="flex flex-col gap-1">
+                            <span class="text-sm font-semibold text-text-primary">Enable daily briefing</span>
+                            <span class="text-xs text-text-muted">Nexus only schedules briefings for users who explicitly opt in.</span>
+                        </span>
+                    </label>
+
+                    <div class="grid gap-4 sm:grid-cols-2">
+                        <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                            Delivery time
+                            <input
+                                v-model="form.delivery_time"
+                                type="time"
+                                required
+                                class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                            >
+                        </label>
+
+                        <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                            Timezone
+                            <select
+                                v-model="form.timezone"
+                                required
+                                class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                            >
+                                <option v-for="timezone in props.timezones" :key="timezone" :value="timezone">
+                                    {{ timezone }}
+                                </option>
+                            </select>
+                        </label>
+                    </div>
+
+                    <label class="flex flex-col gap-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                        Verified delivery channel
+                        <select
+                            v-model="form.channel_id"
+                            class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 text-sm text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                        >
+                            <option :value="null">First verified email channel</option>
+                            <option v-for="channel in props.channels" :key="channel.id" :value="channel.id">
+                                {{ channel.name }} ({{ channel.kind_label }})
+                            </option>
+                        </select>
+                        <span class="text-xs normal-case tracking-normal text-text-muted">
+                            Selected channels must stay enabled and verified. Fallback email is only used when no channel is selected.
+                        </span>
+                    </label>
+
+                    <fieldset class="space-y-2">
+                        <legend class="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">
+                            <FolderKanban class="h-3.5 w-3.5" aria-hidden="true" />
+                            Project filter
+                        </legend>
+                        <div v-if="props.projects.length > 0" class="grid gap-2 sm:grid-cols-2">
+                            <label
+                                v-for="project in props.projects"
+                                :key="project.id"
+                                class="inline-flex items-center gap-2 rounded-lg border border-border-subtle bg-background-panel-hover/40 px-3 py-2 text-sm text-text-secondary"
+                            >
+                                <input v-model="form.include_projects" type="checkbox" :value="project.id">
+                                {{ project.name }}
+                            </label>
+                        </div>
+                        <p class="text-xs text-text-muted">
+                            Leave every project unchecked to include all of your projects.
+                        </p>
+                    </fieldset>
+
+                    <div class="flex flex-wrap gap-3">
+                        <button
+                            type="submit"
+                            class="inline-flex items-center gap-2 rounded-lg bg-accent-cyan px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-accent-cyan/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                        >
+                            <Clock class="h-4 w-4" aria-hidden="true" />
+                            Save preferences
+                        </button>
+                        <button
+                            type="button"
+                            class="inline-flex items-center gap-2 rounded-lg border border-border-subtle bg-background-panel-hover px-4 py-2 text-sm font-semibold text-text-secondary transition hover:border-accent-cyan/40 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60 disabled:cursor-not-allowed disabled:opacity-50"
+                            :disabled="!form.enabled"
+                            @click="sendTest"
+                        >
+                            <Send class="h-4 w-4" aria-hidden="true" />
+                            Send test briefing
+                        </button>
+                    </div>
+                </form>
+            </section>
+
+            <section class="glass-card p-5 sm:p-6">
+                <div class="flex items-start gap-3">
+                    <Bell class="mt-0.5 h-5 w-5 text-accent-cyan" aria-hidden="true" />
+                    <div class="flex min-w-0 flex-1 flex-col gap-3">
+                        <div class="flex flex-wrap items-center gap-2">
+                            <h3 class="text-sm font-semibold text-text-primary">Latest briefing status</h3>
+                            <StatusBadge v-if="props.status" :tone="statusTone(props.status.status)">
+                                {{ props.status.status }}
+                            </StatusBadge>
+                            <StatusBadge v-else tone="muted">No briefing yet</StatusBadge>
+                        </div>
+                        <dl v-if="props.status" class="grid gap-3 text-sm sm:grid-cols-3">
+                            <div>
+                                <dt class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">Date</dt>
+                                <dd class="font-mono text-text-secondary">{{ props.status.briefing_date }}</dd>
+                            </div>
+                            <div>
+                                <dt class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">Generated</dt>
+                                <dd class="text-text-secondary">{{ props.status.generated_at ?? '—' }}</dd>
+                            </div>
+                            <div>
+                                <dt class="text-[11px] font-semibold uppercase tracking-[0.18em] text-text-muted">Delivered</dt>
+                                <dd class="text-text-secondary">{{ props.status.delivered_at ?? '—' }}</dd>
+                            </div>
+                        </dl>
+                        <p v-if="props.preference.last_sent_for_date" class="text-xs text-text-muted">
+                            Last successful send for {{ props.preference.last_sent_for_date }}.
+                        </p>
+                        <p v-if="props.status?.error_message" class="rounded-lg border border-status-danger/30 bg-status-danger/10 p-3 text-xs text-status-danger">
+                            {{ props.status.error_message }}
+                        </p>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/Pages/Settings/Index.vue
+++ b/resources/js/Pages/Settings/Index.vue
@@ -15,6 +15,7 @@ import {
     Plug,
     PlugZap,
     ShieldCheck,
+    Sparkles,
     Sun,
     SunMoon,
     Unplug,
@@ -307,6 +308,27 @@ const disconnect = () => {
                         </span>
                         <span class="text-xs text-text-muted">
                             Route alerts to email, Slack, or generic webhooks.
+                        </span>
+                    </div>
+                </div>
+                <ExternalLink class="h-4 w-4 text-text-muted" aria-hidden="true" />
+            </Link>
+
+            <!-- Spec 044 — AI daily briefing settings entry point. -->
+            <Link
+                :href="route('settings.daily-briefing.index')"
+                class="glass-card flex items-center justify-between gap-3 p-5 transition hover:border-accent-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+            >
+                <div class="flex items-center gap-3">
+                    <span class="flex h-10 w-10 items-center justify-center rounded-lg border border-border-subtle bg-background-panel-hover">
+                        <Sparkles class="h-5 w-5 text-accent-cyan" aria-hidden="true" />
+                    </span>
+                    <div class="flex min-w-0 flex-col">
+                        <span class="text-sm font-semibold text-text-primary">
+                            Daily briefing
+                        </span>
+                        <span class="text-xs text-text-muted">
+                            Configure your AI morning digest and test delivery.
                         </span>
                     </div>
                 </div>

--- a/resources/js/lib/commands.ts
+++ b/resources/js/lib/commands.ts
@@ -14,6 +14,7 @@ import {
     Globe2,
     LayoutDashboard,
     LogOut,
+    Newspaper,
     Plug,
     Plus,
     RefreshCw,
@@ -217,6 +218,14 @@ export function getCommands(): Command[] {
             keywords: ['preferences', 'integrations'],
             run: () => router.visit(route('settings.index')),
         },
+        {
+            id: 'open-daily-briefings',
+            label: 'Open daily briefings',
+            group: 'navigation',
+            icon: Newspaper,
+            keywords: ['ai', 'briefing', 'digest', 'history', 'summary'],
+            run: () => router.visit(route('daily-briefings.index')),
+        },
 
         // ────── Actions ────── //
         {
@@ -284,6 +293,14 @@ export function getCommands(): Command[] {
                 'threshold',
             ],
             run: () => router.visit(route('settings.rules.index')),
+        },
+        {
+            id: 'daily-briefing-settings',
+            label: 'Daily briefing settings',
+            group: 'actions',
+            icon: SettingsIcon,
+            keywords: ['ai', 'briefing', 'digest', 'preferences', 'schedule', 'delivery'],
+            run: () => router.visit(route('settings.daily-briefing.index')),
         },
 
         // ────── System ────── //
@@ -419,4 +436,3 @@ export { Clock as PaletteLoadingIcon };
 export function compareGroups(a: CommandGroup, b: CommandGroup): number {
     return groupOrder.indexOf(a) - groupOrder.indexOf(b);
 }
-

--- a/resources/views/emails/daily-briefing.blade.php
+++ b/resources/views/emails/daily-briefing.blade.php
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{{ $payload->title() }}</title>
+</head>
+<body style="margin:0;padding:0;background:#0f172a;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Oxygen,sans-serif;color:#e2e8f0;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0f172a;padding:32px 16px;">
+        <tr>
+            <td align="center">
+                <table role="presentation" width="560" cellpadding="0" cellspacing="0" style="max-width:560px;background:#1e293b;border:1px solid rgba(148,163,184,0.24);border-radius:16px;overflow:hidden;">
+                    <tr>
+                        <td style="padding:20px 24px;background:#155e75;color:#f8fafc;font-size:12px;letter-spacing:0.12em;text-transform:uppercase;font-weight:600;">
+                            Daily Briefing · {{ $payload->briefingDate }}
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding:24px;">
+                            <p style="margin:0 0 20px;font-size:14px;line-height:1.6;color:#cbd5e1;white-space:pre-line;">{{ $payload->summary }}</p>
+
+                            @if ($payload->highlights !== [])
+                                <p style="margin:0 0 8px;font-size:13px;font-weight:700;color:#f8fafc;">Highlights</p>
+                                <ul style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.6;color:#cbd5e1;">
+                                    @foreach ($payload->highlights as $highlight)
+                                        <li>{{ $highlight }}</li>
+                                    @endforeach
+                                </ul>
+                            @endif
+
+                            @if ($payload->risks !== [])
+                                <p style="margin:0 0 8px;font-size:13px;font-weight:700;color:#f8fafc;">Risks</p>
+                                <ul style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.6;color:#cbd5e1;">
+                                    @foreach ($payload->risks as $risk)
+                                        <li>{{ $risk }}</li>
+                                    @endforeach
+                                </ul>
+                            @endif
+
+                            <a href="{{ $payload->link }}" style="display:inline-block;padding:10px 18px;background:#22d3ee;color:#0f172a;font-weight:600;text-decoration:none;border-radius:8px;font-size:14px;">View in Nexus</a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding:16px 24px;background:#0f172a;color:#64748b;font-size:12px;">
+                            You're receiving this because daily briefings are enabled in your Nexus settings.
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,6 +2,7 @@
 
 use App\Domain\Alerts\Jobs\EvaluateAlertRulesJob;
 use App\Domain\Analytics\Jobs\RecomputeAllProjectHealthScoresJob;
+use App\Domain\DailyBriefings\Jobs\DispatchDueDailyBriefingsJob;
 use App\Domain\Docker\Jobs\DetectOfflineHostsJob;
 use App\Domain\Monitoring\Jobs\DispatchDueWebsiteChecksJob;
 use App\Domain\Observability\Jobs\CheckGitHubRateLimitJob;
@@ -85,4 +86,12 @@ Schedule::job(new CheckGitHubRateLimitJob)
 Schedule::job(new EvaluateAlertRulesJob)
     ->everyFiveMinutes()
     ->name('alerts:evaluate-rules')
+    ->withoutOverlapping();
+
+// Spec 044 — every-15-minute daily briefing dispatcher. It only fans
+// out generation jobs for opted-in users whose local delivery time has
+// passed; delivery stays in the later SendDailyBriefingJob slice.
+Schedule::job(new DispatchDueDailyBriefingsJob)
+    ->everyFifteenMinutes()
+    ->name('daily-briefings:dispatch-due')
     ->withoutOverlapping();

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,7 @@ use App\Http\Controllers\RepositoryPullRequestsSyncController;
 use App\Http\Controllers\RepositorySyncAllController;
 use App\Http\Controllers\RepositorySyncController;
 use App\Http\Controllers\RepositoryWorkflowRunsSyncController;
+use App\Http\Controllers\Settings\DailyBriefingPreferenceController;
 use App\Http\Controllers\Settings\NotificationsController;
 use App\Http\Controllers\Settings\RulesController;
 use App\Http\Controllers\Settings\ThemeController;
@@ -93,6 +94,18 @@ Route::middleware(['auth', 'verified'])->group(function () {
     // fans out mutations across channels + preferences + deliveries.
     Route::get('/settings/notifications', [NotificationsController::class, 'index'])
         ->name('settings.notifications.index');
+
+    // Spec 044 — per-user AI daily briefing settings. Updates are
+    // separate from the throttled immediate test-send action.
+    Route::get('/settings/daily-briefing', [DailyBriefingPreferenceController::class, 'index'])
+        ->name('settings.daily-briefing.index');
+    Route::patch('/settings/daily-briefing', [DailyBriefingPreferenceController::class, 'update'])
+        ->middleware('throttle:20,1')
+        ->name('settings.daily-briefing.update');
+    Route::post('/settings/daily-briefing/test', [DailyBriefingPreferenceController::class, 'sendTest'])
+        ->middleware('throttle:5,1')
+        ->name('settings.daily-briefing.test');
+
     Route::post('/settings/notifications/channels', [NotificationsController::class, 'storeChannel'])
         ->middleware('throttle:10,1')
         ->name('settings.notifications.channels.store');

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\AlertController;
 use App\Http\Controllers\AlertMuteController;
 use App\Http\Controllers\AlertResolveController;
 use App\Http\Controllers\AnalyticsController;
+use App\Http\Controllers\DailyBriefingController;
 use App\Http\Controllers\DeploymentController;
 use App\Http\Controllers\GithubConnectionController;
 use App\Http\Controllers\GithubRepositoryImportController;
@@ -105,6 +106,11 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/settings/daily-briefing/test', [DailyBriefingPreferenceController::class, 'sendTest'])
         ->middleware('throttle:5,1')
         ->name('settings.daily-briefing.test');
+
+    // Spec 044 — generated daily briefing history. Read-only and scoped
+    // to the authenticated user's generated content.
+    Route::get('/daily-briefings', [DailyBriefingController::class, 'index'])
+        ->name('daily-briefings.index');
 
     Route::post('/settings/notifications/channels', [NotificationsController::class, 'storeChannel'])
         ->middleware('throttle:10,1')

--- a/specs/phase-10-innovation/044-ai-daily-briefing.md
+++ b/specs/phase-10-innovation/044-ai-daily-briefing.md
@@ -287,11 +287,21 @@ Track actual files as implementation progresses. Expected touchpoints:
 - `tests/Feature/DailyBriefings/DispatchDueDailyBriefingsJobTest.php` — covered timezone due checks, opt-in, AI gate, `last_sent_for_date`, and generated-row idempotency.
 - `tests/Feature/DailyBriefings/GenerateDailyBriefingActionTest.php` — covered prompt construction, fake-client generation, output sanitization, failed LLM calls, disabled AI fail-closed behavior, invalid output, and same-day row reuse.
 - `tests/Feature/DailyBriefings/GenerateDailyBriefingJobTest.php` — covered unique ID, query-to-generate orchestration, opt-in/AI gates, and generated-row idempotency.
+- `app/Domain/Notifications/Contracts/NotificationPayload.php` — added a minimal payload contract so spec 042 channel drivers can send alert and daily briefing payloads.
+- `app/Domain/Notifications/Contracts/NotificationChannelDriver.php` — generalized driver input from alert-only payloads to the shared notification payload contract.
+- `app/Domain/Notifications/DataTransferObjects/AlertNotificationPayload.php` — adapted alert notifications to the shared payload contract without changing alert delivery semantics.
+- `app/Domain/Notifications/Drivers/EmailChannelDriver.php` — reused the existing email channel driver for any payload-provided mailable.
+- `app/Domain/Notifications/Drivers/SlackChannelDriver.php` — reused the existing Slack driver by delegating Block Kit payload construction to the notification payload.
+- `app/Domain/Notifications/Drivers/GenericWebhookChannelDriver.php` — reused the existing generic webhook driver for daily briefing JSON payloads.
+- `app/Domain/DailyBriefings/DataTransferObjects/DailyBriefingPayload.php` — added the daily briefing payload adapter for email, Slack, and webhook delivery.
+- `app/Mail/DailyBriefingMail.php` — added the daily briefing email mailable.
+- `resources/views/emails/daily-briefing.blade.php` — added the operator-facing daily briefing email template.
+- `app/Domain/DailyBriefings/Jobs/SendDailyBriefingJob.php` — added delivery through selected verified channel or fallback verified email, delivered/failure persistence, and `last_sent_for_date` update only after successful delivery.
+- `app/Domain/DailyBriefings/Jobs/GenerateDailyBriefingJob.php` — dispatches `SendDailyBriefingJob` after successful generated persistence.
+- `tests/Feature/DailyBriefings/SendDailyBriefingJobTest.php` — covered selected channel delivery, fallback verified email delivery, failure handling, successful retry of failed generated rows, delivered status/timestamps, and `last_sent_for_date` semantics.
 
 Expected future touchpoints:
 
-- `app/Domain/DailyBriefings/DataTransferObjects/DailyBriefingPayload.php`
-- `app/Domain/DailyBriefings/Jobs/SendDailyBriefingJob.php`
 - `app/Http/Controllers/Settings/DailyBriefingPreferenceController.php`
 - `app/Http/Controllers/DailyBriefingController.php`
 - `resources/js/Pages/Settings/DailyBriefing.vue`
@@ -302,8 +312,6 @@ Expected future touchpoints:
 - `docs/env.production.example`
 - `docs/security/operator-checklist.md`
 - `tests/Feature/DailyBriefings/DailyBriefingPreferenceControllerTest.php`
-- `tests/Feature/DailyBriefings/SendDailyBriefingJobTest.php`
-- `tests/Feature/DailyBriefings/GetDailyBriefingInputQueryTest.php`
 - `tests/Feature/DailyBriefings/DailyBriefingHistoryControllerTest.php`
 
 ## Work log
@@ -374,13 +382,21 @@ Dated notes as work progresses.
   `GenerateDailyBriefingAction`. Deliberately deferred delivery,
   `SendDailyBriefingJob`, settings UI/controller, history UI, palette, and
   docs.
+- Implemented the delivery work unit: generalized spec 042 channel drivers
+  behind a small `NotificationPayload` contract, kept alert notification
+  semantics intact, added `DailyBriefingPayload`, email rendering, and
+  `SendDailyBriefingJob`. The send job resolves the selected verified
+  channel, falls back to the user's first verified email channel only when no
+  channel is selected, marks the briefing delivered with `delivered_at`, and
+  updates `last_sent_for_date` only inside the successful-delivery path.
+  Delivery failures mark the existing generated briefing `failed` while
+  keeping its generated content so it can be retried. `GenerateDailyBriefingJob`
+  now dispatches the send job after successful generation. Deliberately
+  deferred settings UI/controller, history UI/controller, command palette, and
+  docs.
 
 ## Open questions / blockers
 
-- **Delivery adapter shape.** Confirm during implementation whether spec
-  042 exposes reusable notification drivers for non-alert payloads. If
-  not, ship a small briefing-specific payload adapter without changing
-  alert semantics.
 - **Default channel behavior.** Draft assumes "selected verified channel,
   else first verified email channel." If operators should receive Slack
   by default when available, adjust before implementation.

--- a/specs/phase-10-innovation/044-ai-daily-briefing.md
+++ b/specs/phase-10-innovation/044-ai-daily-briefing.md
@@ -274,14 +274,17 @@ Track actual files as implementation progresses. Expected touchpoints:
 - `tests/Feature/DailyBriefings/DailyBriefingPersistenceTest.php`
 - `app/Domain/DailyBriefings/Queries/GetDailyBriefingInputQuery.php` — added scoped, timezone-aware bounded input snapshot query.
 - `tests/Feature/DailyBriefings/GetDailyBriefingInputQueryTest.php` — covered user/project scoping, timezone conversion, counts, and sample caps.
+- `app/Domain/AI/Contracts/LlmClient.php` — added the provider-swappable LLM completion contract.
+- `app/Domain/AI/DataTransferObjects/LlmPrompt.php` — added the versioned prompt DTO.
+- `app/Domain/AI/DataTransferObjects/LlmResponse.php` — added the structured client response DTO.
+- `app/Domain/AI/Services/AnthropicLlmClient.php` — added the Anthropic Messages API implementation with configured model, timeout, API key, and one transient retry.
+- `app/Domain/DailyBriefings/Actions/GenerateDailyBriefingAction.php` — added prompt v1 construction, LLM invocation, structured output validation/sanitization, generated persistence, and failed-state persistence.
+- `app/Providers/AppServiceProvider.php` — bound `LlmClient` to the configured Anthropic implementation.
+- `tests/Feature/DailyBriefings/AnthropicLlmClientTest.php` — covered the LLM binding and Anthropic HTTP request/response mapping with `Http::fake`.
+- `tests/Feature/DailyBriefings/GenerateDailyBriefingActionTest.php` — covered prompt construction, fake-client generation, output sanitization, failed LLM calls, disabled AI fail-closed behavior, invalid output, and same-day row reuse.
 
 Expected future touchpoints:
 
-- `app/Domain/AI/Contracts/LlmClient.php`
-- `app/Domain/AI/DataTransferObjects/LlmPrompt.php`
-- `app/Domain/AI/DataTransferObjects/LlmResponse.php`
-- `app/Domain/AI/Services/AnthropicLlmClient.php`
-- `app/Domain/DailyBriefings/Actions/GenerateDailyBriefingAction.php`
 - `app/Domain/DailyBriefings/DataTransferObjects/DailyBriefingPayload.php`
 - `app/Domain/DailyBriefings/Jobs/DispatchDueDailyBriefingsJob.php`
 - `app/Domain/DailyBriefings/Jobs/GenerateDailyBriefingJob.php`
@@ -347,6 +350,19 @@ Dated notes as work progresses.
   score deltas. The input snapshot therefore returns current
   `worst_projects` and an empty `health.deltas` array until a future slice
   adds score history or defines a persisted delta source.
+- Implemented the generation/client work unit: `LlmClient`, prompt/response
+  DTOs, Anthropic client binding, and `GenerateDailyBriefingAction`. The
+  action receives the already-built input snapshot, builds prompt version
+  `daily-briefing-v1`, calls the LLM client only when AI features are
+  enabled, validates JSON output, strips tags/control characters from
+  summary/highlights/risks, persists generated rows, and persists failed
+  rows for disabled AI, provider exceptions, or invalid output. Added
+  `Http::fake` coverage for the Anthropic request/response shape.
+  Deliberately deferred scheduler jobs, delivery, UI/history, palette, and
+  docs.
+- Discovery: `daily_briefings.briefing_date` is cast as an immutable date;
+  when reusing a row for the unique `(user_id, briefing_date)` key, an
+  explicit `whereDate` lookup avoids date-cast mismatches before save.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/044-ai-daily-briefing.md
+++ b/specs/phase-10-innovation/044-ai-daily-briefing.md
@@ -272,6 +272,8 @@ Track actual files as implementation progresses. Expected touchpoints:
 - `database/factories/DailyBriefingPreferenceFactory.php`
 - `database/factories/DailyBriefingFactory.php`
 - `tests/Feature/DailyBriefings/DailyBriefingPersistenceTest.php`
+- `app/Domain/DailyBriefings/Queries/GetDailyBriefingInputQuery.php` — added scoped, timezone-aware bounded input snapshot query.
+- `tests/Feature/DailyBriefings/GetDailyBriefingInputQueryTest.php` — covered user/project scoping, timezone conversion, counts, and sample caps.
 
 Expected future touchpoints:
 
@@ -279,7 +281,6 @@ Expected future touchpoints:
 - `app/Domain/AI/DataTransferObjects/LlmPrompt.php`
 - `app/Domain/AI/DataTransferObjects/LlmResponse.php`
 - `app/Domain/AI/Services/AnthropicLlmClient.php`
-- `app/Domain/DailyBriefings/Queries/GetDailyBriefingInputQuery.php`
 - `app/Domain/DailyBriefings/Actions/GenerateDailyBriefingAction.php`
 - `app/Domain/DailyBriefings/DataTransferObjects/DailyBriefingPayload.php`
 - `app/Domain/DailyBriefings/Jobs/DispatchDueDailyBriefingsJob.php`
@@ -333,6 +334,19 @@ Dated notes as work progresses.
   factories, relationships, and persistence tests. Deliberately deferred
   input query, LLM client, jobs, delivery, UI, palette, and docs to keep
   the commit independently reviewable.
+- Implemented the input-query work unit: `GetDailyBriefingInputQuery`
+  builds a deterministic, bounded snapshot for one user and local briefing
+  date, converts the local midnight-to-midnight window to UTC for database
+  reads, scopes all data through the user's owned projects plus any
+  included-project filter, and caps project/work-item/alert/activity
+  samples. Added focused tests for scoping, timezone conversion, counts,
+  and caps. Deliberately deferred LLM client/action, scheduler jobs,
+  delivery, UI/history, palette, and docs.
+- Discovery: current health-score storage only keeps `projects.health_score`
+  as the latest value; there is no historical score table to compute true
+  score deltas. The input snapshot therefore returns current
+  `worst_projects` and an empty `health.deltas` array until a future slice
+  adds score history or defines a persisted delta source.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/044-ai-daily-briefing.md
+++ b/specs/phase-10-innovation/044-ai-daily-briefing.md
@@ -261,13 +261,20 @@ README LLM dependencies, spec 042 delivery layer.
 
 Track actual files as implementation progresses. Expected touchpoints:
 
-- `database/migrations/*_create_daily_briefing_preferences_table.php`
-- `database/migrations/*_create_daily_briefings_table.php`
+- `config/services.php` — added disabled-by-default `services.llm.*` config.
+- `database/migrations/2026_07_21_140000_create_daily_briefing_preferences_table.php`
+- `database/migrations/2026_07_21_140001_create_daily_briefings_table.php`
 - `app/Enums/DailyBriefingStatus.php`
 - `app/Models/DailyBriefingPreference.php`
 - `app/Models/DailyBriefing.php`
+- `app/Models/User.php` — added daily briefing relationships.
+- `app/Models/AlertNotificationChannel.php` — added daily briefing preference relationship.
 - `database/factories/DailyBriefingPreferenceFactory.php`
 - `database/factories/DailyBriefingFactory.php`
+- `tests/Feature/DailyBriefings/DailyBriefingPersistenceTest.php`
+
+Expected future touchpoints:
+
 - `app/Domain/AI/Contracts/LlmClient.php`
 - `app/Domain/AI/DataTransferObjects/LlmPrompt.php`
 - `app/Domain/AI/DataTransferObjects/LlmResponse.php`
@@ -286,7 +293,6 @@ Track actual files as implementation progresses. Expected touchpoints:
 - `resources/js/lib/commands.ts`
 - `routes/web.php`
 - `routes/console.php`
-- `config/services.php`
 - `docs/env.production.example`
 - `docs/security/operator-checklist.md`
 - `tests/Feature/DailyBriefings/DailyBriefingPreferenceControllerTest.php`
@@ -322,6 +328,11 @@ Dated notes as work progresses.
 - Kept AI incident summaries and PR risk scoring out of scope because
   the roadmap lists them separately and spec 045 owns PR risk + health
   explanations.
+- Implemented the first backend-foundation work unit: disabled-by-default
+  AI/LLM config, daily briefing persistence migrations, enum, models,
+  factories, relationships, and persistence tests. Deliberately deferred
+  input query, LLM client, jobs, delivery, UI, palette, and docs to keep
+  the commit independently reviewable.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/044-ai-daily-briefing.md
+++ b/specs/phase-10-innovation/044-ai-daily-briefing.md
@@ -1,0 +1,337 @@
+---
+spec: ai-daily-briefing
+phase: 10
+status: in-progress   # not-started | in-progress | blocked | done
+owner: Yoany
+created: 2026-07-21
+updated: 2026-07-21
+---
+
+# 044 — AI daily briefing: scheduled operator digest
+
+## Goal
+
+Phase 10 adds the first proactive AI surface to Nexus: a morning
+briefing that tells an operator what changed yesterday, what needs
+attention today, and what looks unusual across their projects.
+
+The roadmap only names this as "AI daily briefing." The Phase 10 README
+narrows the slice: "yesterday: X new issues, Y merged PRs, Z alerts, N
+things that look off," delivered through spec 042, with per-user opt-in
+and delivery time. This spec turns that into a shippable feature without
+building a general AI assistant or report builder.
+
+Roadmap refs: §Phase 10 Future Features ("AI daily briefing"), §4.4
+Background Jobs (daily summaries), §3.2 Signal Over Noise, Phase 10
+README LLM dependencies, spec 042 delivery layer.
+
+## Scope
+
+**In scope:**
+
+- **Environment gate + LLM config.** The feature is disabled unless
+  `AI_FEATURES_ENABLED=true`. LLM settings live under
+  `config('services.llm.*')` with Anthropic as the reference provider,
+  matching the Phase 10 README. The implementation should keep the
+  provider swappable behind a small client contract.
+
+- **Migration: `daily_briefing_preferences`.** One row per user.
+  Columns:
+  - `id`, `user_id` (FK -> `users`, cascade delete)
+  - `enabled` (boolean, default false)
+  - `delivery_time` (time, default `08:00:00`)
+  - `timezone` (string, default from the user's profile/app default)
+  - `channel_id` (nullable FK -> `alert_notification_channels`)
+  - `include_projects` (JSON array of project IDs; null/empty = all
+    user projects)
+  - `last_sent_for_date` (nullable date, idempotency marker)
+  - Timestamps.
+
+- **Migration: `daily_briefings`.** Persist each generated briefing so
+  operators can inspect what was sent and so retries do not regenerate
+  different prose. Columns:
+  - `id`, `user_id` (FK -> users, cascade delete)
+  - `briefing_date` (date in the user's timezone; represents
+    "yesterday")
+  - `status` (`pending` | `generated` | `delivered` | `failed` |
+    `skipped`)
+  - `input_snapshot` (JSON, bounded summary counts + sampled entities)
+  - `summary` (text, final operator-facing LLM output)
+  - `highlights` (JSON array of short bullets)
+  - `risks` (JSON array of "things that look off")
+  - `prompt_version` (string, e.g. `daily-briefing-v1`)
+  - `generated_at`, `delivered_at` (nullable timestamps)
+  - `error_message` (nullable text)
+  - Timestamps.
+  - Unique index on `(user_id, briefing_date)`.
+
+- **`DailyBriefingPreference` + `DailyBriefing` models.** Cast JSON
+  columns to arrays, status to an enum, and date/timestamp columns to
+  immutable date objects where the repo pattern supports it.
+
+- **`GetDailyBriefingInputQuery`.** Builds a bounded, deterministic
+  snapshot for one user + date window. The window is midnight-to-midnight
+  in the user's configured timezone, converted to UTC for database
+  queries. Include:
+  - Issues opened/closed and PRs opened/merged/closed.
+  - Failed workflows/deployments and successful deploy count.
+  - Alerts triggered/resolved, grouped by severity/source/project.
+  - Website/host/container health changes from yesterday.
+  - Project health-score deltas and the worst-scoring projects.
+  - Activity volume by project, with top changed entities.
+
+- **Bounded input shaping.** The query returns counts plus capped sample
+  lists, not raw event dumps. Default caps: top 5 projects, top 10 work
+  items, top 10 alerts, top 10 activity events. This keeps cost and
+  prompt size predictable.
+
+- **`LlmClient` contract + Anthropic implementation.** A minimal
+  interface for `complete(LlmPrompt $prompt): LlmResponse`. The client
+  reads API key/model/timeout from `services.llm`; request timeout 20s;
+  retry once on transient 429/5xx; fail closed with a stored error.
+
+- **`GenerateDailyBriefingAction`.** Takes the input snapshot, builds a
+  versioned prompt, calls the LLM client, validates/sanitizes the
+  response, and persists a `daily_briefings` row. Output format:
+  - `summary` — 2-4 concise paragraphs.
+  - `highlights` — 3-6 bullets.
+  - `risks` — 0-5 bullets, each tied to a concrete source entity.
+  - `next_steps` — optional short list when the data supports it.
+
+- **Fallback when AI is unavailable.** If `AI_FEATURES_ENABLED=false`,
+  no jobs are dispatched. If the LLM call fails for an opted-in user,
+  persist `status: failed` with the error and do not send a fabricated
+  briefing. A later retry can use the same input window.
+
+- **Scheduler + jobs.**
+  - `DispatchDueDailyBriefingsJob` runs every 15 minutes.
+  - It finds enabled preferences whose local `delivery_time` has passed
+    and whose `(user_id, briefing_date)` has not been sent.
+  - It dispatches `GenerateDailyBriefingJob` per due user.
+  - `GenerateDailyBriefingJob` is unique by `(user_id, briefing_date)`
+    and creates or reuses the `daily_briefings` row.
+  - `SendDailyBriefingJob` sends the generated briefing via the selected
+    spec 042 channel, then marks `daily_briefings.status=delivered` and
+    updates `daily_briefing_preferences.last_sent_for_date`.
+
+- **Delivery through spec 042.** Reuse the notification channel settings
+  and drivers shipped in spec 042. The selected channel is the
+  preference's `channel_id`; if null, use the user's first verified email
+  channel. If the current spec 042 implementation is alert-payload-only,
+  add a narrow `DailyBriefingPayload` adapter rather than refactoring the
+  whole alert notification service.
+
+- **Settings UI: `/settings/daily-briefing`.**
+  - Enable/disable toggle.
+  - Delivery time + timezone fields.
+  - Channel selector showing verified spec 042 channels.
+  - Project filter multi-select, defaulting to all projects.
+  - "Send test briefing" button that generates from yesterday's current
+    snapshot and delivers immediately to the selected channel.
+  - Last generated / last delivered status with error text when failed.
+  - Endpoint throttle: update 20/min, test send 5/min.
+
+- **Operator-facing briefing page.** Add a simple authenticated history
+  view at `/daily-briefings` listing prior generated briefings with
+  status, date, channel, summary preview, and a detail drawer/page for
+  the full content. This gives users a durable record even if email or
+  Slack delivery fails.
+
+- **Prompt safety + privacy.** Do not send secrets, webhook URLs, access
+  tokens, raw logs, or full issue/PR bodies to the LLM. Entity titles,
+  statuses, counts, timestamps, labels, and short sanitized snippets are
+  allowed. Store `input_snapshot`, not the full prompt with secrets.
+
+- **Palette command.** Add "Open daily briefings" and "Daily briefing
+  settings" to the spec 043 command palette action/navigation groups.
+
+- **Docs.** Update `docs/env.production.example` with commented
+  `AI_FEATURES_ENABLED` and `LLM_*` values if those keys do not already
+  exist. Update `docs/security/operator-checklist.md` §5 with the new
+  settings/test-send endpoints and the scheduler behavior.
+
+- **Tests.**
+  - `DailyBriefingPreferenceControllerTest` — update settings, guest
+    rejection, throttle, channel ownership/verification guard.
+  - `DispatchDueDailyBriefingsJobTest` — respects user timezone,
+    delivery time, opt-in, `last_sent_for_date`, and disabled AI gate.
+  - `GenerateDailyBriefingActionTest` — builds bounded input, calls the
+    LLM client, persists generated output, stores failed status on client
+    error.
+  - `GenerateDailyBriefingJobTest` — unique/idempotent by user + date.
+  - `SendDailyBriefingJobTest` — sends through the selected spec 042
+    channel, falls back to verified email, marks delivered, records
+    failures.
+  - `GetDailyBriefingInputQueryTest` — scopes data to the user's projects
+    and date window, includes counts, caps sample lists, excludes other
+    users' data.
+  - `DailyBriefingHistoryControllerTest` — authenticated users only see
+    their own generated briefings.
+
+**Out of scope:**
+
+- **Chat UI / AI assistant.** This is a scheduled digest, not an
+  interactive assistant.
+- **AI incident postmortems.** Roadmap lists AI incident summary as a
+  separate item. Spec 044 may mention incidents in the daily digest, but
+  it does not generate long-form incident reports.
+- **AI PR risk scoring.** Spec 045 owns per-PR risk tags and health-score
+  explanations. Spec 044 can count risky signals already present in data,
+  but it does not score individual PRs.
+- **Weekly/team reports.** Team reports are explicitly deferred in the
+  Phase 10 README. This spec ships one daily per-user briefing.
+- **Natural-language querying.** No "ask Nexus" search or Q&A over the
+  database.
+- **Digest batching for arbitrary alerts.** Spec 042 explicitly deferred
+  general alert batching. This spec sends one scheduled daily briefing;
+  it does not change alert notification cadence.
+- **Per-team routing.** The current product shape is per-user/single-
+  tenant. Preferences stay per-user.
+- **Model fine-tuning or embeddings.** A deterministic summarized prompt
+  is enough for v1.
+
+## Plan
+
+1. **Config + gate.** Add `AI_FEATURES_ENABLED` and `services.llm.*`
+   config. Keep the feature disabled by default unless the operator opts
+   in and config is present.
+
+2. **Migrations + models.** Create `daily_briefing_preferences` and
+   `daily_briefings`, enum status, model casts, factories.
+
+3. **Input query.** Build `GetDailyBriefingInputQuery` with strict user
+   scoping, timezone windowing, and sample caps.
+
+4. **LLM client.** Add `LlmClient` contract, Anthropic implementation,
+   prompt/response DTOs, and fake client for tests.
+
+5. **Generation action.** Implement prompt v1, response validation,
+   output sanitization, persistence, and failed-state handling.
+
+6. **Scheduler jobs.** Add `DispatchDueDailyBriefingsJob`,
+   `GenerateDailyBriefingJob`, and `SendDailyBriefingJob`; register the
+   dispatcher on a 15-minute schedule.
+
+7. **Delivery adapter.** Reuse spec 042 channels/drivers. If needed,
+   add a `DailyBriefingPayload` DTO that existing channel drivers can
+   render to email/Slack/webhook without pretending the briefing is an
+   alert.
+
+8. **Settings UI.** Ship `/settings/daily-briefing` with opt-in,
+   schedule, timezone, channel, project filter, status, and test-send.
+
+9. **History UI.** Ship `/daily-briefings` index + detail so generated
+   briefings are visible inside Nexus.
+
+10. **Palette + docs.** Add command palette entries and update env / operator
+    docs for AI config, endpoint throttles, and scheduler expectations.
+
+11. **Tests + verification.** Cover the tests listed above, run Pint,
+    `php artisan test`, `npm run build`, self-review, PR.
+
+## Acceptance criteria
+
+- [ ] Feature stays inert unless `AI_FEATURES_ENABLED=true`, LLM config is
+      present, and the user has enabled daily briefings.
+- [ ] Users can configure daily briefing opt-in, delivery time, timezone,
+      channel, and included projects at `/settings/daily-briefing`.
+- [ ] Scheduler dispatches at most one briefing per user per local
+      briefing date, respecting timezone and `last_sent_for_date`.
+- [ ] Generated input snapshot is scoped to the user's projects and
+      contains bounded counts/samples for issues, PRs, deployments,
+      alerts, monitoring/host health, health-score deltas, and activity.
+- [ ] LLM output persists in `daily_briefings` with summary, highlights,
+      risks, prompt version, status, and timestamps.
+- [ ] Failed LLM generation records `status: failed` and does not send a
+      fabricated briefing.
+- [ ] Delivery uses a verified spec 042 channel; selected channel wins,
+      otherwise first verified email channel is used when available.
+- [ ] Test-send endpoint generates and delivers a briefing immediately,
+      throttled at 5/min.
+- [ ] `/daily-briefings` shows only the authenticated user's generated
+      briefings and their delivery status.
+- [ ] No secrets, tokens, webhook URLs, raw logs, or full bodies are sent
+      to the LLM provider.
+- [ ] Palette includes "Open daily briefings" and "Daily briefing
+      settings" commands.
+- [ ] Every test in the §Tests block is green.
+- [ ] Pint clean, `php artisan test` green, `npm run build` clean.
+
+## Files touched
+
+Track actual files as implementation progresses. Expected touchpoints:
+
+- `database/migrations/*_create_daily_briefing_preferences_table.php`
+- `database/migrations/*_create_daily_briefings_table.php`
+- `app/Enums/DailyBriefingStatus.php`
+- `app/Models/DailyBriefingPreference.php`
+- `app/Models/DailyBriefing.php`
+- `database/factories/DailyBriefingPreferenceFactory.php`
+- `database/factories/DailyBriefingFactory.php`
+- `app/Domain/AI/Contracts/LlmClient.php`
+- `app/Domain/AI/DataTransferObjects/LlmPrompt.php`
+- `app/Domain/AI/DataTransferObjects/LlmResponse.php`
+- `app/Domain/AI/Services/AnthropicLlmClient.php`
+- `app/Domain/DailyBriefings/Queries/GetDailyBriefingInputQuery.php`
+- `app/Domain/DailyBriefings/Actions/GenerateDailyBriefingAction.php`
+- `app/Domain/DailyBriefings/DataTransferObjects/DailyBriefingPayload.php`
+- `app/Domain/DailyBriefings/Jobs/DispatchDueDailyBriefingsJob.php`
+- `app/Domain/DailyBriefings/Jobs/GenerateDailyBriefingJob.php`
+- `app/Domain/DailyBriefings/Jobs/SendDailyBriefingJob.php`
+- `app/Http/Controllers/Settings/DailyBriefingPreferenceController.php`
+- `app/Http/Controllers/DailyBriefingController.php`
+- `resources/js/Pages/Settings/DailyBriefing.vue`
+- `resources/js/Pages/DailyBriefings/Index.vue`
+- `resources/js/Pages/DailyBriefings/Show.vue`
+- `resources/js/lib/commands.ts`
+- `routes/web.php`
+- `routes/console.php`
+- `config/services.php`
+- `docs/env.production.example`
+- `docs/security/operator-checklist.md`
+- `tests/Feature/DailyBriefings/DailyBriefingPreferenceControllerTest.php`
+- `tests/Feature/DailyBriefings/DispatchDueDailyBriefingsJobTest.php`
+- `tests/Feature/DailyBriefings/GenerateDailyBriefingActionTest.php`
+- `tests/Feature/DailyBriefings/GenerateDailyBriefingJobTest.php`
+- `tests/Feature/DailyBriefings/SendDailyBriefingJobTest.php`
+- `tests/Feature/DailyBriefings/GetDailyBriefingInputQueryTest.php`
+- `tests/Feature/DailyBriefings/DailyBriefingHistoryControllerTest.php`
+
+## Work log
+
+Dated notes as work progresses.
+
+### 2026-07-21
+
+- Opened GitHub issue #131 and started branch
+  `spec/044-ai-daily-briefing` after user approval of the draft scope.
+- Drafted from `_template.md`; scope was approved, so the spec moved to
+  `in-progress` with issue and branch tracking in place.
+- Roadmap source is intentionally thin (one bullet). Scope is based on
+  the Phase 10 README's narrower acceptance note: morning digest,
+  yesterday's activity, delivery through spec 042, per-user opt-in,
+  configurable delivery time + timezone.
+- Assumption: spec 042's channel configuration and drivers can be reused
+  for non-alert payload delivery. If the implementation is tightly bound
+  to alert payloads, add a narrow `DailyBriefingPayload` adapter instead
+  of broadening the alert lifecycle.
+- Assumption: Anthropic is the reference provider because the Phase 10
+  README says the surrounding codebase's AI usage points there; the
+  implementation still hides this behind `LlmClient` so the provider can
+  be swapped.
+- Kept AI incident summaries and PR risk scoring out of scope because
+  the roadmap lists them separately and spec 045 owns PR risk + health
+  explanations.
+
+## Open questions / blockers
+
+- **Delivery adapter shape.** Confirm during implementation whether spec
+  042 exposes reusable notification drivers for non-alert payloads. If
+  not, ship a small briefing-specific payload adapter without changing
+  alert semantics.
+- **Default channel behavior.** Draft assumes "selected verified channel,
+  else first verified email channel." If operators should receive Slack
+  by default when available, adjust before implementation.
+- **Briefing history retention.** Draft persists every generated briefing
+  indefinitely. If storage becomes a concern, add a retention policy in a
+  follow-up rather than deleting operator-visible history in v1.

--- a/specs/phase-10-innovation/044-ai-daily-briefing.md
+++ b/specs/phase-10-innovation/044-ai-daily-briefing.md
@@ -299,19 +299,21 @@ Track actual files as implementation progresses. Expected touchpoints:
 - `app/Domain/DailyBriefings/Jobs/SendDailyBriefingJob.php` — added delivery through selected verified channel or fallback verified email, delivered/failure persistence, and `last_sent_for_date` update only after successful delivery.
 - `app/Domain/DailyBriefings/Jobs/GenerateDailyBriefingJob.php` — dispatches `SendDailyBriefingJob` after successful generated persistence.
 - `tests/Feature/DailyBriefings/SendDailyBriefingJobTest.php` — covered selected channel delivery, fallback verified email delivery, failure handling, successful retry of failed generated rows, delivered status/timestamps, and `last_sent_for_date` semantics.
+- `app/Http/Controllers/Settings/DailyBriefingPreferenceController.php` — added `/settings/daily-briefing` Inertia settings, guarded preference updates, and throttled synchronous test send.
+- `resources/js/Pages/Settings/DailyBriefing.vue` — added the daily briefing settings UI with opt-in, schedule, timezone, channel, project filter, status, and test send.
+- `resources/js/Pages/Settings/Index.vue` — linked Settings to the daily briefing settings page.
+- `routes/web.php` — added daily briefing settings routes with 20/min update and 5/min test-send throttles.
+- `tests/Feature/DailyBriefings/DailyBriefingPreferenceControllerTest.php` — covered settings render/update, guest rejection, channel ownership/verification/enabled guard, project ownership guard, test send, and throttling.
 
 Expected future touchpoints:
 
-- `app/Http/Controllers/Settings/DailyBriefingPreferenceController.php`
 - `app/Http/Controllers/DailyBriefingController.php`
-- `resources/js/Pages/Settings/DailyBriefing.vue`
 - `resources/js/Pages/DailyBriefings/Index.vue`
 - `resources/js/Pages/DailyBriefings/Show.vue`
 - `resources/js/lib/commands.ts`
 - `routes/web.php`
 - `docs/env.production.example`
 - `docs/security/operator-checklist.md`
-- `tests/Feature/DailyBriefings/DailyBriefingPreferenceControllerTest.php`
 - `tests/Feature/DailyBriefings/DailyBriefingHistoryControllerTest.php`
 
 ## Work log
@@ -394,6 +396,15 @@ Dated notes as work progresses.
   now dispatches the send job after successful generation. Deliberately
   deferred settings UI/controller, history UI/controller, command palette, and
   docs.
+- Implemented the settings UI/controller work unit: `/settings/daily-briefing`
+  now renders per-user preferences, verified delivery channels, owned projects,
+  and latest briefing status; updates persist opt-in, delivery time, timezone,
+  selected verified channel, and owned-project filters behind a 20/min throttle;
+  test send generates yesterday's current snapshot and delivers synchronously
+  through the selected channel/fallback email behind a 5/min throttle. The
+  controller rejects channels that are not owned, enabled, and verified, and
+  rejects project filters outside the authenticated user's ownership. Deliberately
+  deferred history UI/controller, command palette entries, and docs.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/044-ai-daily-briefing.md
+++ b/specs/phase-10-innovation/044-ai-daily-briefing.md
@@ -279,15 +279,18 @@ Track actual files as implementation progresses. Expected touchpoints:
 - `app/Domain/AI/DataTransferObjects/LlmResponse.php` — added the structured client response DTO.
 - `app/Domain/AI/Services/AnthropicLlmClient.php` — added the Anthropic Messages API implementation with configured model, timeout, API key, and one transient retry.
 - `app/Domain/DailyBriefings/Actions/GenerateDailyBriefingAction.php` — added prompt v1 construction, LLM invocation, structured output validation/sanitization, generated persistence, and failed-state persistence.
+- `app/Domain/DailyBriefings/Jobs/DispatchDueDailyBriefingsJob.php` — added the scheduler-bound dispatcher for opted-in, locally due users, gated by AI config and idempotent against sent/generated/pending rows.
+- `app/Domain/DailyBriefings/Jobs/GenerateDailyBriefingJob.php` — added the unique per-user/date generation job that builds the input snapshot and delegates persistence to `GenerateDailyBriefingAction`.
 - `app/Providers/AppServiceProvider.php` — bound `LlmClient` to the configured Anthropic implementation.
+- `routes/console.php` — registered the daily briefing dispatcher every 15 minutes with `withoutOverlapping()`.
 - `tests/Feature/DailyBriefings/AnthropicLlmClientTest.php` — covered the LLM binding and Anthropic HTTP request/response mapping with `Http::fake`.
+- `tests/Feature/DailyBriefings/DispatchDueDailyBriefingsJobTest.php` — covered timezone due checks, opt-in, AI gate, `last_sent_for_date`, and generated-row idempotency.
 - `tests/Feature/DailyBriefings/GenerateDailyBriefingActionTest.php` — covered prompt construction, fake-client generation, output sanitization, failed LLM calls, disabled AI fail-closed behavior, invalid output, and same-day row reuse.
+- `tests/Feature/DailyBriefings/GenerateDailyBriefingJobTest.php` — covered unique ID, query-to-generate orchestration, opt-in/AI gates, and generated-row idempotency.
 
 Expected future touchpoints:
 
 - `app/Domain/DailyBriefings/DataTransferObjects/DailyBriefingPayload.php`
-- `app/Domain/DailyBriefings/Jobs/DispatchDueDailyBriefingsJob.php`
-- `app/Domain/DailyBriefings/Jobs/GenerateDailyBriefingJob.php`
 - `app/Domain/DailyBriefings/Jobs/SendDailyBriefingJob.php`
 - `app/Http/Controllers/Settings/DailyBriefingPreferenceController.php`
 - `app/Http/Controllers/DailyBriefingController.php`
@@ -296,13 +299,9 @@ Expected future touchpoints:
 - `resources/js/Pages/DailyBriefings/Show.vue`
 - `resources/js/lib/commands.ts`
 - `routes/web.php`
-- `routes/console.php`
 - `docs/env.production.example`
 - `docs/security/operator-checklist.md`
 - `tests/Feature/DailyBriefings/DailyBriefingPreferenceControllerTest.php`
-- `tests/Feature/DailyBriefings/DispatchDueDailyBriefingsJobTest.php`
-- `tests/Feature/DailyBriefings/GenerateDailyBriefingActionTest.php`
-- `tests/Feature/DailyBriefings/GenerateDailyBriefingJobTest.php`
 - `tests/Feature/DailyBriefings/SendDailyBriefingJobTest.php`
 - `tests/Feature/DailyBriefings/GetDailyBriefingInputQueryTest.php`
 - `tests/Feature/DailyBriefings/DailyBriefingHistoryControllerTest.php`
@@ -363,6 +362,18 @@ Dated notes as work progresses.
 - Discovery: `daily_briefings.briefing_date` is cast as an immutable date;
   when reusing a row for the unique `(user_id, briefing_date)` key, an
   explicit `whereDate` lookup avoids date-cast mismatches before save.
+- Implemented the scheduler/generation jobs work unit: `DispatchDueDailyBriefingsJob`
+  runs from `routes/console.php` every 15 minutes, gates on
+  `services.llm.enabled`, filters to enabled preferences whose local
+  delivery time has passed, skips `last_sent_for_date`, and avoids
+  dispatching when a pending/generated/delivered row already exists for the
+  local briefing date. `GenerateDailyBriefingJob` is unique by
+  `(user_id, briefing_date)`, re-checks AI/opt-in/idempotency gates, creates
+  a pending row for the unique key, builds the snapshot with the saved
+  timezone/project filter, and delegates LLM persistence to
+  `GenerateDailyBriefingAction`. Deliberately deferred delivery,
+  `SendDailyBriefingJob`, settings UI/controller, history UI, palette, and
+  docs.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/044-ai-daily-briefing.md
+++ b/specs/phase-10-innovation/044-ai-daily-briefing.md
@@ -231,31 +231,31 @@ README LLM dependencies, spec 042 delivery layer.
 
 ## Acceptance criteria
 
-- [ ] Feature stays inert unless `AI_FEATURES_ENABLED=true`, LLM config is
+- [x] Feature stays inert unless `AI_FEATURES_ENABLED=true`, LLM config is
       present, and the user has enabled daily briefings.
-- [ ] Users can configure daily briefing opt-in, delivery time, timezone,
+- [x] Users can configure daily briefing opt-in, delivery time, timezone,
       channel, and included projects at `/settings/daily-briefing`.
-- [ ] Scheduler dispatches at most one briefing per user per local
+- [x] Scheduler dispatches at most one briefing per user per local
       briefing date, respecting timezone and `last_sent_for_date`.
-- [ ] Generated input snapshot is scoped to the user's projects and
+- [x] Generated input snapshot is scoped to the user's projects and
       contains bounded counts/samples for issues, PRs, deployments,
       alerts, monitoring/host health, health-score deltas, and activity.
-- [ ] LLM output persists in `daily_briefings` with summary, highlights,
+- [x] LLM output persists in `daily_briefings` with summary, highlights,
       risks, prompt version, status, and timestamps.
-- [ ] Failed LLM generation records `status: failed` and does not send a
+- [x] Failed LLM generation records `status: failed` and does not send a
       fabricated briefing.
-- [ ] Delivery uses a verified spec 042 channel; selected channel wins,
+- [x] Delivery uses a verified spec 042 channel; selected channel wins,
       otherwise first verified email channel is used when available.
-- [ ] Test-send endpoint generates and delivers a briefing immediately,
+- [x] Test-send endpoint generates and delivers a briefing immediately,
       throttled at 5/min.
-- [ ] `/daily-briefings` shows only the authenticated user's generated
+- [x] `/daily-briefings` shows only the authenticated user's generated
       briefings and their delivery status.
-- [ ] No secrets, tokens, webhook URLs, raw logs, or full bodies are sent
+- [x] No secrets, tokens, webhook URLs, raw logs, or full bodies are sent
       to the LLM provider.
-- [ ] Palette includes "Open daily briefings" and "Daily briefing
+- [x] Palette includes "Open daily briefings" and "Daily briefing
       settings" commands.
-- [ ] Every test in the §Tests block is green.
-- [ ] Pint clean, `php artisan test` green, `npm run build` clean.
+- [x] Every test in the §Tests block is green.
+- [x] Pint clean, `php artisan test` green, `npm run build` clean.
 
 ## Files touched
 
@@ -307,12 +307,9 @@ Track actual files as implementation progresses. Expected touchpoints:
 - `app/Http/Controllers/DailyBriefingController.php` — added authenticated briefing history payloads scoped to the current user's generated content.
 - `resources/js/Pages/DailyBriefings/Index.vue` — added the `/daily-briefings` history list with status, date, configured channel, summary preview, empty state, and inline expandable detail panel for full content.
 - `tests/Feature/DailyBriefings/DailyBriefingHistoryControllerTest.php` — covered authenticated-only access, user scoping, generated-content filtering, row payloads, and detail drawer payloads.
-
-Expected future touchpoints:
-
-- `resources/js/lib/commands.ts`
-- `docs/env.production.example`
-- `docs/security/operator-checklist.md`
+- `resources/js/lib/commands.ts` — added command palette entries for daily briefing history and settings, following spec 043 static command conventions.
+- `docs/env.production.example` — documented the production AI/LLM env gate and provider keys for daily briefings.
+- `docs/security/operator-checklist.md` — documented daily briefing settings/test-send throttles, scheduler behavior, verified-channel delivery posture, and sanitized LLM input expectations.
 
 ## Work log
 
@@ -413,6 +410,11 @@ Dated notes as work progresses.
   setting open state and null close timestamps. The factory can randomly create
   closed issues, which made opened-boundary sample assertions flaky when the full
   DailyBriefings suite ran with different generated timestamps.
+- Implemented the final palette/docs work unit: added static command palette
+  entries for `Open daily briefings` and `Daily briefing settings`, documented
+  production AI/LLM env keys, and extended the operator checklist with the
+  daily briefing settings/test-send throttles, scheduler behavior, verified
+  delivery channel posture, and sanitized LLM input expectations.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/044-ai-daily-briefing.md
+++ b/specs/phase-10-innovation/044-ai-daily-briefing.md
@@ -304,17 +304,15 @@ Track actual files as implementation progresses. Expected touchpoints:
 - `resources/js/Pages/Settings/Index.vue` — linked Settings to the daily briefing settings page.
 - `routes/web.php` — added daily briefing settings routes with 20/min update and 5/min test-send throttles.
 - `tests/Feature/DailyBriefings/DailyBriefingPreferenceControllerTest.php` — covered settings render/update, guest rejection, channel ownership/verification/enabled guard, project ownership guard, test send, and throttling.
+- `app/Http/Controllers/DailyBriefingController.php` — added authenticated briefing history payloads scoped to the current user's generated content.
+- `resources/js/Pages/DailyBriefings/Index.vue` — added the `/daily-briefings` history list with status, date, configured channel, summary preview, empty state, and inline expandable detail panel for full content.
+- `tests/Feature/DailyBriefings/DailyBriefingHistoryControllerTest.php` — covered authenticated-only access, user scoping, generated-content filtering, row payloads, and detail drawer payloads.
 
 Expected future touchpoints:
 
-- `app/Http/Controllers/DailyBriefingController.php`
-- `resources/js/Pages/DailyBriefings/Index.vue`
-- `resources/js/Pages/DailyBriefings/Show.vue`
 - `resources/js/lib/commands.ts`
-- `routes/web.php`
 - `docs/env.production.example`
 - `docs/security/operator-checklist.md`
-- `tests/Feature/DailyBriefings/DailyBriefingHistoryControllerTest.php`
 
 ## Work log
 
@@ -405,6 +403,16 @@ Dated notes as work progresses.
   controller rejects channels that are not owned, enabled, and verified, and
   rejects project filters outside the authenticated user's ownership. Deliberately
   deferred history UI/controller, command palette entries, and docs.
+- Implemented the history UI/controller work unit: `/daily-briefings` now lists
+  the authenticated user's generated briefing rows only, with status, briefing
+  date, configured delivery channel, summary preview, and an inline expandable
+  detail panel showing full summary/highlights/risks/error context. Pending or
+  failed-before-generation rows are hidden because they have no generated content
+  to inspect. Deliberately deferred command palette entries and docs.
+- Hardened `GetDailyBriefingInputQueryTest` opened-issue fixtures by explicitly
+  setting open state and null close timestamps. The factory can randomly create
+  closed issues, which made opened-boundary sample assertions flaky when the full
+  DailyBriefings suite ran with different generated timestamps.
 
 ## Open questions / blockers
 

--- a/tests/Feature/DailyBriefings/AnthropicLlmClientTest.php
+++ b/tests/Feature/DailyBriefings/AnthropicLlmClientTest.php
@@ -56,4 +56,30 @@ class AnthropicLlmClientTest extends TestCase
                 && $request['messages'] === [['role' => 'user', 'content' => 'User prompt']];
         });
     }
+
+    public function test_anthropic_client_retries_once_for_transient_provider_errors(): void
+    {
+        config([
+            'services.llm.api_key' => 'test-key',
+            'services.llm.model' => 'claude-test-model',
+        ]);
+
+        Http::fakeSequence('api.anthropic.com/v1/messages')
+            ->push(['error' => ['message' => 'rate limited']], 429)
+            ->push([
+                'model' => 'claude-test-model',
+                'content' => [
+                    ['type' => 'text', 'text' => '{"summary":"retried"}'],
+                ],
+            ], 200);
+
+        $response = app(AnthropicLlmClient::class)->complete(new LlmPrompt(
+            version: 'daily-briefing-v1',
+            system: 'System instructions',
+            user: 'User prompt',
+        ));
+
+        $this->assertSame('{"summary":"retried"}', $response->text);
+        Http::assertSentCount(2);
+    }
 }

--- a/tests/Feature/DailyBriefings/AnthropicLlmClientTest.php
+++ b/tests/Feature/DailyBriefings/AnthropicLlmClientTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\DailyBriefings;
+
+use App\Domain\AI\Contracts\LlmClient;
+use App\Domain\AI\DataTransferObjects\LlmPrompt;
+use App\Domain\AI\Services\AnthropicLlmClient;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class AnthropicLlmClientTest extends TestCase
+{
+    public function test_container_binds_llm_client_to_anthropic_provider(): void
+    {
+        config(['services.llm.provider' => 'anthropic']);
+
+        $this->assertInstanceOf(AnthropicLlmClient::class, app(LlmClient::class));
+    }
+
+    public function test_anthropic_client_sends_configured_message_request_and_returns_text_response(): void
+    {
+        config([
+            'services.llm.api_key' => 'test-key',
+            'services.llm.model' => 'claude-test-model',
+            'services.llm.timeout' => 7,
+        ]);
+
+        Http::fake([
+            'api.anthropic.com/v1/messages' => Http::response([
+                'model' => 'claude-test-model',
+                'content' => [
+                    ['type' => 'text', 'text' => '{"summary":"ok"}'],
+                ],
+                'usage' => ['input_tokens' => 10, 'output_tokens' => 5],
+            ]),
+        ]);
+
+        $response = app(AnthropicLlmClient::class)->complete(new LlmPrompt(
+            version: 'daily-briefing-v1',
+            system: 'System instructions',
+            user: 'User prompt',
+            maxTokens: 321,
+        ));
+
+        $this->assertSame('{"summary":"ok"}', $response->text);
+        $this->assertSame('claude-test-model', $response->model);
+        $this->assertSame(['input_tokens' => 10, 'output_tokens' => 5], $response->metadata['usage']);
+
+        Http::assertSent(function ($request): bool {
+            return $request->url() === 'https://api.anthropic.com/v1/messages'
+                && $request->hasHeader('x-api-key', 'test-key')
+                && $request->hasHeader('anthropic-version', '2023-06-01')
+                && $request['model'] === 'claude-test-model'
+                && $request['max_tokens'] === 321
+                && $request['system'] === 'System instructions'
+                && $request['messages'] === [['role' => 'user', 'content' => 'User prompt']];
+        });
+    }
+}

--- a/tests/Feature/DailyBriefings/DailyBriefingHistoryControllerTest.php
+++ b/tests/Feature/DailyBriefings/DailyBriefingHistoryControllerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Feature\DailyBriefings;
+
+use App\Enums\DailyBriefingStatus;
+use App\Models\AlertNotificationChannel;
+use App\Models\DailyBriefing;
+use App\Models\DailyBriefingPreference;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class DailyBriefingHistoryControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_history_lists_only_the_authenticated_users_generated_briefings(): void
+    {
+        $user = $this->verifiedUser();
+        $otherUser = User::factory()->create();
+        $channel = AlertNotificationChannel::factory()->email('ops@example.com')->for($user)->create();
+        DailyBriefingPreference::factory()->enabled()->create([
+            'user_id' => $user->id,
+            'channel_id' => $channel->id,
+        ]);
+
+        $delivered = DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+            'status' => DailyBriefingStatus::Delivered->value,
+            'summary' => 'A delivered briefing owned by the authenticated user.',
+            'delivered_at' => now(),
+        ]);
+        $failedDelivery = DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-19',
+            'status' => DailyBriefingStatus::Failed->value,
+            'summary' => 'Generated content remains visible after delivery failure.',
+            'error_message' => 'Slack timed out',
+        ]);
+        DailyBriefing::factory()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-18',
+            'status' => DailyBriefingStatus::Pending->value,
+            'summary' => null,
+        ]);
+        DailyBriefing::factory()->generated()->create([
+            'user_id' => $otherUser->id,
+            'briefing_date' => '2026-07-20',
+            'summary' => 'Other user briefing must not leak.',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('daily-briefings.index'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('DailyBriefings/Index')
+                    ->has('briefings', 2)
+                    ->where('briefings.0.id', $delivered->id)
+                    ->where('briefings.0.status', 'delivered')
+                    ->where('briefings.0.channel.name', 'Ops email')
+                    ->where('briefings.1.id', $failedDelivery->id)
+                    ->where('briefings.1.status', 'failed')
+            );
+    }
+
+    public function test_user_can_view_owned_generated_briefing_detail(): void
+    {
+        $user = $this->verifiedUser();
+        $briefing = DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+            'summary' => "Paragraph one.\n\nParagraph two.",
+            'highlights' => ['Merged billing fix'],
+            'risks' => ['API latency is elevated'],
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('daily-briefings.index'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->where('briefings.0.id', $briefing->id)
+                    ->where('briefings.0.summary', "Paragraph one.\n\nParagraph two.")
+                    ->where('briefings.0.highlights.0', 'Merged billing fix')
+                    ->where('briefings.0.risks.0', 'API latency is elevated')
+            );
+    }
+
+    public function test_guest_cannot_access_daily_briefing_history(): void
+    {
+        $this->get(route('daily-briefings.index'))->assertRedirect(route('login'));
+    }
+}

--- a/tests/Feature/DailyBriefings/DailyBriefingHistoryControllerTest.php
+++ b/tests/Feature/DailyBriefings/DailyBriefingHistoryControllerTest.php
@@ -39,6 +39,12 @@ class DailyBriefingHistoryControllerTest extends TestCase
             'summary' => 'Generated content remains visible after delivery failure.',
             'error_message' => 'Slack timed out',
         ]);
+        DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+            'is_test' => true,
+            'summary' => 'Test briefing must not appear in production history.',
+        ]);
         DailyBriefing::factory()->create([
             'user_id' => $user->id,
             'briefing_date' => '2026-07-18',

--- a/tests/Feature/DailyBriefings/DailyBriefingPersistenceTest.php
+++ b/tests/Feature/DailyBriefings/DailyBriefingPersistenceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Feature\DailyBriefings;
+
+use App\Enums\DailyBriefingStatus;
+use App\Models\AlertNotificationChannel;
+use App\Models\DailyBriefing;
+use App\Models\DailyBriefingPreference;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DailyBriefingPersistenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_llm_config_defaults_to_disabled_anthropic_provider(): void
+    {
+        $this->assertFalse(config('services.llm.enabled'));
+        $this->assertSame('anthropic', config('services.llm.provider'));
+        $this->assertSame('claude-3-5-haiku-latest', config('services.llm.model'));
+        $this->assertSame(20, config('services.llm.timeout'));
+    }
+
+    public function test_daily_briefing_preference_defaults_and_relationships(): void
+    {
+        $user = User::factory()->create();
+        $channel = AlertNotificationChannel::factory()->email()->for($user)->create();
+        $project = Project::factory()->for($user, 'owner')->create();
+
+        $preference = DailyBriefingPreference::factory()
+            ->for($user)
+            ->for($channel, 'channel')
+            ->create([
+                'enabled' => true,
+                'timezone' => 'America/New_York',
+                'include_projects' => [$project->id],
+                'last_sent_for_date' => '2026-07-20',
+            ]);
+
+        $this->assertTrue($preference->enabled);
+        $this->assertSame('08:00:00', $preference->delivery_time);
+        $this->assertSame('America/New_York', $preference->timezone);
+        $this->assertSame([$project->id], $preference->include_projects);
+        $this->assertSame('2026-07-20', $preference->last_sent_for_date->toDateString());
+        $this->assertTrue($preference->user->is($user));
+        $this->assertTrue($preference->channel->is($channel));
+        $this->assertTrue($user->dailyBriefingPreference->is($preference));
+        $this->assertTrue($channel->dailyBriefingPreferences->first()->is($preference));
+    }
+
+    public function test_daily_briefing_casts_status_dates_and_json_payloads(): void
+    {
+        $user = User::factory()->create();
+
+        $briefing = DailyBriefing::factory()
+            ->generated()
+            ->for($user)
+            ->create([
+                'briefing_date' => '2026-07-20',
+                'delivered_at' => '2026-07-21 08:15:00',
+            ]);
+
+        $this->assertSame(DailyBriefingStatus::Generated, $briefing->status);
+        $this->assertSame('2026-07-20', $briefing->briefing_date->toDateString());
+        $this->assertSame(['counts' => ['alerts' => 2]], $briefing->input_snapshot);
+        $this->assertSame(['Two alerts triggered', 'One deployment succeeded'], $briefing->highlights);
+        $this->assertSame(['Billing API health score dropped'], $briefing->risks);
+        $this->assertSame('2026-07-21 08:15:00', $briefing->delivered_at->format('Y-m-d H:i:s'));
+        $this->assertTrue($briefing->user->is($user));
+        $this->assertTrue($user->dailyBriefings->first()->is($briefing));
+    }
+
+    public function test_user_can_have_one_preference_and_one_briefing_per_date(): void
+    {
+        $user = User::factory()->create();
+
+        DailyBriefingPreference::factory()->for($user)->create();
+        DailyBriefing::factory()->for($user)->create(['briefing_date' => '2026-07-20']);
+
+        $this->expectException(UniqueConstraintViolationException::class);
+
+        DailyBriefingPreference::factory()->for($user)->create();
+    }
+
+    public function test_daily_briefing_is_unique_per_user_and_briefing_date(): void
+    {
+        $user = User::factory()->create();
+
+        DailyBriefing::factory()->for($user)->create(['briefing_date' => '2026-07-20']);
+
+        $this->expectException(UniqueConstraintViolationException::class);
+
+        DailyBriefing::factory()->for($user)->create(['briefing_date' => '2026-07-20']);
+    }
+}

--- a/tests/Feature/DailyBriefings/DailyBriefingPersistenceTest.php
+++ b/tests/Feature/DailyBriefings/DailyBriefingPersistenceTest.php
@@ -65,6 +65,7 @@ class DailyBriefingPersistenceTest extends TestCase
 
         $this->assertSame(DailyBriefingStatus::Generated, $briefing->status);
         $this->assertSame('2026-07-20', $briefing->briefing_date->toDateString());
+        $this->assertFalse($briefing->is_test);
         $this->assertSame(['counts' => ['alerts' => 2]], $briefing->input_snapshot);
         $this->assertSame(['Two alerts triggered', 'One deployment succeeded'], $briefing->highlights);
         $this->assertSame(['Billing API health score dropped'], $briefing->risks);
@@ -85,11 +86,15 @@ class DailyBriefingPersistenceTest extends TestCase
         DailyBriefingPreference::factory()->for($user)->create();
     }
 
-    public function test_daily_briefing_is_unique_per_user_and_briefing_date(): void
+    public function test_daily_briefing_is_unique_per_user_date_and_test_scope(): void
     {
         $user = User::factory()->create();
 
         DailyBriefing::factory()->for($user)->create(['briefing_date' => '2026-07-20']);
+        DailyBriefing::factory()->for($user)->create([
+            'briefing_date' => '2026-07-20',
+            'is_test' => true,
+        ]);
 
         $this->expectException(UniqueConstraintViolationException::class);
 

--- a/tests/Feature/DailyBriefings/DailyBriefingPreferenceControllerTest.php
+++ b/tests/Feature/DailyBriefings/DailyBriefingPreferenceControllerTest.php
@@ -130,7 +130,7 @@ class DailyBriefingPreferenceControllerTest extends TestCase
             ->assertSessionHasErrors('include_projects');
     }
 
-    public function test_test_send_generates_and_delivers_immediately(): void
+    public function test_test_send_generates_and_delivers_without_consuming_scheduled_briefing(): void
     {
         config(['services.llm.enabled' => true]);
         Mail::fake();
@@ -142,6 +142,11 @@ class DailyBriefingPreferenceControllerTest extends TestCase
             'channel_id' => $channel->id,
             'timezone' => 'UTC',
         ]);
+        $scheduled = DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => now('UTC')->subDay()->toDateString(),
+            'summary' => 'Production briefing must not be overwritten by a test send.',
+        ]);
         $this->app->instance(LlmClient::class, new PreferenceFakeLlmClient);
 
         $this->actingAs($user)
@@ -152,10 +157,16 @@ class DailyBriefingPreferenceControllerTest extends TestCase
         Mail::assertSent(DailyBriefingMail::class);
         $this->assertDatabaseHas('daily_briefings', [
             'user_id' => $user->id,
+            'is_test' => true,
             'status' => DailyBriefingStatus::Delivered->value,
             'error_message' => null,
         ]);
-        $this->assertNotNull(DailyBriefingPreference::query()->where('user_id', $user->id)->firstOrFail()->last_sent_for_date);
+        $this->assertDatabaseHas('daily_briefings', [
+            'id' => $scheduled->id,
+            'is_test' => false,
+            'summary' => 'Production briefing must not be overwritten by a test send.',
+        ]);
+        $this->assertNull(DailyBriefingPreference::query()->where('user_id', $user->id)->firstOrFail()->last_sent_for_date);
     }
 
     public function test_test_send_is_throttled(): void

--- a/tests/Feature/DailyBriefings/DailyBriefingPreferenceControllerTest.php
+++ b/tests/Feature/DailyBriefings/DailyBriefingPreferenceControllerTest.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Tests\Feature\DailyBriefings;
+
+use App\Domain\AI\Contracts\LlmClient;
+use App\Domain\AI\DataTransferObjects\LlmPrompt;
+use App\Domain\AI\DataTransferObjects\LlmResponse;
+use App\Enums\DailyBriefingStatus;
+use App\Mail\DailyBriefingMail;
+use App\Models\AlertNotificationChannel;
+use App\Models\DailyBriefing;
+use App\Models\DailyBriefingPreference;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class DailyBriefingPreferenceControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_settings_page_creates_default_preference_and_renders_options(): void
+    {
+        $user = $this->verifiedUser();
+        $channel = AlertNotificationChannel::factory()->email('ops@example.com')->for($user)->create();
+        AlertNotificationChannel::factory()->unverified()->for($user)->create();
+        $project = Project::factory()->for($user, 'owner')->create(['name' => 'Billing API']);
+        DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+            'status' => DailyBriefingStatus::Failed->value,
+            'error_message' => 'Provider timed out',
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('settings.daily-briefing.index'))
+            ->assertSuccessful()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Settings/DailyBriefing')
+                    ->where('preference.enabled', false)
+                    ->where('preference.delivery_time', '08:00')
+                    ->where('channels.0.id', $channel->id)
+                    ->where('projects.0.id', $project->id)
+                    ->where('status.status', 'failed')
+                    ->where('status.error_message', 'Provider timed out')
+                    ->has('timezones')
+            );
+
+        $this->assertDatabaseHas('daily_briefing_preferences', [
+            'user_id' => $user->id,
+            'enabled' => false,
+        ]);
+    }
+
+    public function test_user_can_update_daily_briefing_preferences(): void
+    {
+        $user = $this->verifiedUser();
+        $channel = AlertNotificationChannel::factory()->slack()->for($user)->create();
+        $project = Project::factory()->for($user, 'owner')->create();
+
+        $this->actingAs($user)
+            ->patch(route('settings.daily-briefing.update'), [
+                'enabled' => true,
+                'delivery_time' => '07:30',
+                'timezone' => 'America/New_York',
+                'channel_id' => $channel->id,
+                'include_projects' => [$project->id],
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('status', 'Daily briefing preferences saved.');
+
+        $this->assertDatabaseHas('daily_briefing_preferences', [
+            'user_id' => $user->id,
+            'enabled' => true,
+            'delivery_time' => '07:30:00',
+            'timezone' => 'America/New_York',
+            'channel_id' => $channel->id,
+        ]);
+
+        $this->assertSame([$project->id], DailyBriefingPreference::query()->where('user_id', $user->id)->firstOrFail()->include_projects);
+    }
+
+    public function test_update_rejects_channels_not_owned_verified_and_enabled(): void
+    {
+        $user = $this->verifiedUser();
+        $otherUser = User::factory()->create();
+        $otherChannel = AlertNotificationChannel::factory()->for($otherUser)->create();
+        $unverified = AlertNotificationChannel::factory()->unverified()->for($user)->create();
+        $disabled = AlertNotificationChannel::factory()->disabled()->for($user)->create();
+
+        foreach ([$otherChannel, $unverified, $disabled] as $channel) {
+            $this->actingAs($user)
+                ->from(route('settings.daily-briefing.index'))
+                ->patch(route('settings.daily-briefing.update'), [
+                    'enabled' => true,
+                    'delivery_time' => '08:00',
+                    'timezone' => 'UTC',
+                    'channel_id' => $channel->id,
+                    'include_projects' => [],
+                ])
+                ->assertRedirect(route('settings.daily-briefing.index'))
+                ->assertSessionHasErrors('channel_id');
+        }
+
+        $this->assertDatabaseMissing('daily_briefing_preferences', [
+            'user_id' => $user->id,
+            'channel_id' => $otherChannel->id,
+        ]);
+    }
+
+    public function test_update_rejects_project_filters_not_owned_by_user(): void
+    {
+        $user = $this->verifiedUser();
+        $otherUser = User::factory()->create();
+        $otherProject = Project::factory()->for($otherUser, 'owner')->create();
+
+        $this->actingAs($user)
+            ->from(route('settings.daily-briefing.index'))
+            ->patch(route('settings.daily-briefing.update'), [
+                'enabled' => true,
+                'delivery_time' => '08:00',
+                'timezone' => 'UTC',
+                'channel_id' => null,
+                'include_projects' => [$otherProject->id],
+            ])
+            ->assertRedirect(route('settings.daily-briefing.index'))
+            ->assertSessionHasErrors('include_projects');
+    }
+
+    public function test_test_send_generates_and_delivers_immediately(): void
+    {
+        config(['services.llm.enabled' => true]);
+        Mail::fake();
+
+        $user = $this->verifiedUser();
+        $channel = AlertNotificationChannel::factory()->email('ops@example.com')->for($user)->create();
+        DailyBriefingPreference::factory()->enabled()->create([
+            'user_id' => $user->id,
+            'channel_id' => $channel->id,
+            'timezone' => 'UTC',
+        ]);
+        $this->app->instance(LlmClient::class, new PreferenceFakeLlmClient);
+
+        $this->actingAs($user)
+            ->post(route('settings.daily-briefing.test'))
+            ->assertRedirect()
+            ->assertSessionHas('status', 'Test daily briefing sent.');
+
+        Mail::assertSent(DailyBriefingMail::class);
+        $this->assertDatabaseHas('daily_briefings', [
+            'user_id' => $user->id,
+            'status' => DailyBriefingStatus::Delivered->value,
+            'error_message' => null,
+        ]);
+        $this->assertNotNull(DailyBriefingPreference::query()->where('user_id', $user->id)->firstOrFail()->last_sent_for_date);
+    }
+
+    public function test_test_send_is_throttled(): void
+    {
+        $user = $this->verifiedUser();
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->actingAs($user)
+                ->post(route('settings.daily-briefing.test'))
+                ->assertRedirect();
+        }
+
+        $this->actingAs($user)
+            ->post(route('settings.daily-briefing.test'))
+            ->assertStatus(429);
+    }
+
+    public function test_guest_cannot_access_daily_briefing_settings(): void
+    {
+        $this->get(route('settings.daily-briefing.index'))->assertRedirect(route('login'));
+        $this->patch(route('settings.daily-briefing.update'))->assertRedirect(route('login'));
+        $this->post(route('settings.daily-briefing.test'))->assertRedirect(route('login'));
+    }
+}
+
+class PreferenceFakeLlmClient implements LlmClient
+{
+    public function complete(LlmPrompt $prompt): LlmResponse
+    {
+        return new LlmResponse(json_encode([
+            'summary' => 'Yesterday was stable enough for a test briefing.',
+            'highlights' => [
+                'No critical alerts were found.',
+                'Project activity was summarized.',
+                'Delivery settings were verified.',
+            ],
+            'risks' => [],
+        ], JSON_THROW_ON_ERROR));
+    }
+}

--- a/tests/Feature/DailyBriefings/DispatchDueDailyBriefingsJobTest.php
+++ b/tests/Feature/DailyBriefings/DispatchDueDailyBriefingsJobTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature\DailyBriefings;
+
+use App\Domain\DailyBriefings\Jobs\DispatchDueDailyBriefingsJob;
+use App\Domain\DailyBriefings\Jobs\GenerateDailyBriefingJob;
+use App\Enums\DailyBriefingStatus;
+use App\Models\DailyBriefing;
+use App\Models\DailyBriefingPreference;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class DispatchDueDailyBriefingsJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_dispatches_generation_for_enabled_preference_after_local_delivery_time(): void
+    {
+        config(['services.llm.enabled' => true]);
+        Carbon::setTestNow('2026-07-21 12:30:00');
+        Queue::fake();
+        $user = User::factory()->create();
+        DailyBriefingPreference::factory()->enabled()->create([
+            'user_id' => $user->id,
+            'delivery_time' => '08:00:00',
+            'timezone' => 'America/New_York',
+        ]);
+
+        (new DispatchDueDailyBriefingsJob)->handle();
+
+        Queue::assertPushed(
+            GenerateDailyBriefingJob::class,
+            fn (GenerateDailyBriefingJob $job): bool => $job->userId === $user->id
+                && $job->briefingDate === '2026-07-20',
+        );
+    }
+
+    public function test_respects_timezone_when_delivery_time_has_not_passed(): void
+    {
+        config(['services.llm.enabled' => true]);
+        Carbon::setTestNow('2026-07-21 12:30:00');
+        Queue::fake();
+        DailyBriefingPreference::factory()->enabled()->create([
+            'delivery_time' => '08:00:00',
+            'timezone' => 'America/Los_Angeles',
+        ]);
+
+        (new DispatchDueDailyBriefingsJob)->handle();
+
+        Queue::assertNotPushed(GenerateDailyBriefingJob::class);
+    }
+
+    public function test_skips_disabled_preferences_and_disabled_ai_feature_gate(): void
+    {
+        config(['services.llm.enabled' => false]);
+        Queue::fake();
+        DailyBriefingPreference::factory()->enabled()->create();
+        DailyBriefingPreference::factory()->create(['enabled' => false]);
+
+        (new DispatchDueDailyBriefingsJob)->handle();
+
+        Queue::assertNothingPushed();
+    }
+
+    public function test_skips_when_briefing_date_was_already_sent(): void
+    {
+        config(['services.llm.enabled' => true]);
+        Carbon::setTestNow('2026-07-21 13:00:00');
+        Queue::fake();
+        DailyBriefingPreference::factory()->enabled()->create([
+            'delivery_time' => '08:00:00',
+            'timezone' => 'UTC',
+            'last_sent_for_date' => '2026-07-20',
+        ]);
+
+        (new DispatchDueDailyBriefingsJob)->handle();
+
+        Queue::assertNotPushed(GenerateDailyBriefingJob::class);
+    }
+
+    public function test_skips_existing_pending_generated_or_delivered_briefing_rows(): void
+    {
+        config(['services.llm.enabled' => true]);
+        Carbon::setTestNow('2026-07-21 13:00:00');
+        Queue::fake();
+        $user = User::factory()->create();
+        DailyBriefingPreference::factory()->enabled()->create([
+            'user_id' => $user->id,
+            'delivery_time' => '08:00:00',
+            'timezone' => 'UTC',
+        ]);
+        DailyBriefing::factory()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+            'status' => DailyBriefingStatus::Generated->value,
+        ]);
+
+        (new DispatchDueDailyBriefingsJob)->handle();
+
+        Queue::assertNotPushed(GenerateDailyBriefingJob::class);
+    }
+}

--- a/tests/Feature/DailyBriefings/DispatchDueDailyBriefingsJobTest.php
+++ b/tests/Feature/DailyBriefings/DispatchDueDailyBriefingsJobTest.php
@@ -88,7 +88,7 @@ class DispatchDueDailyBriefingsJobTest extends TestCase
         Queue::assertNotPushed(GenerateDailyBriefingJob::class);
     }
 
-    public function test_skips_existing_pending_generated_or_delivered_briefing_rows(): void
+    public function test_dispatches_when_existing_briefing_still_needs_generation_or_delivery(): void
     {
         config(['services.llm.enabled' => true]);
         Carbon::setTestNow('2026-07-21 13:00:00');
@@ -102,7 +102,29 @@ class DispatchDueDailyBriefingsJobTest extends TestCase
         DailyBriefing::factory()->create([
             'user_id' => $user->id,
             'briefing_date' => '2026-07-20',
-            'status' => DailyBriefingStatus::Generated->value,
+            'status' => DailyBriefingStatus::Pending->value,
+        ]);
+
+        (new DispatchDueDailyBriefingsJob)->handle();
+
+        Queue::assertPushed(GenerateDailyBriefingJob::class);
+    }
+
+    public function test_skips_existing_delivered_briefing_rows(): void
+    {
+        config(['services.llm.enabled' => true]);
+        Carbon::setTestNow('2026-07-21 13:00:00');
+        Queue::fake();
+        $user = User::factory()->create();
+        DailyBriefingPreference::factory()->enabled()->create([
+            'user_id' => $user->id,
+            'delivery_time' => '08:00:00',
+            'timezone' => 'UTC',
+        ]);
+        DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+            'status' => DailyBriefingStatus::Delivered->value,
         ]);
 
         (new DispatchDueDailyBriefingsJob)->handle();

--- a/tests/Feature/DailyBriefings/GenerateDailyBriefingActionTest.php
+++ b/tests/Feature/DailyBriefings/GenerateDailyBriefingActionTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Tests\Feature\DailyBriefings;
+
+use App\Domain\AI\Contracts\LlmClient;
+use App\Domain\AI\DataTransferObjects\LlmPrompt;
+use App\Domain\AI\DataTransferObjects\LlmResponse;
+use App\Domain\DailyBriefings\Actions\GenerateDailyBriefingAction;
+use App\Enums\DailyBriefingStatus;
+use App\Models\DailyBriefing;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use RuntimeException;
+use Tests\TestCase;
+
+class GenerateDailyBriefingActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_builds_versioned_prompt_calls_llm_and_persists_generated_output(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $user = User::factory()->create();
+        $client = new FakeLlmClient(new LlmResponse(json_encode([
+            'summary' => "Yesterday was mostly stable.\n\nTwo items need operator review.",
+            'highlights' => [
+                'Billing API had one merged pull request.',
+                'Checkout had one successful deployment.',
+                'No critical alerts were triggered.',
+            ],
+            'risks' => ['Checkout API has current health score 42.'],
+            'next_steps' => ['Review Checkout API health.'],
+        ], JSON_THROW_ON_ERROR)));
+
+        $this->app->instance(LlmClient::class, $client);
+
+        $briefing = app(GenerateDailyBriefingAction::class)->execute($user, $this->snapshot());
+
+        $this->assertSame(DailyBriefingStatus::Generated, $briefing->status);
+        $this->assertSame(GenerateDailyBriefingAction::PROMPT_VERSION, $briefing->prompt_version);
+        $this->assertSame($this->snapshot(), $briefing->input_snapshot);
+        $this->assertSame('Yesterday was mostly stable. Two items need operator review.', $briefing->summary);
+        $this->assertCount(3, $briefing->highlights);
+        $this->assertSame(['Checkout API has current health score 42.'], $briefing->risks);
+        $this->assertNotNull($briefing->generated_at);
+        $this->assertNull($briefing->error_message);
+
+        $this->assertNotNull($client->prompt);
+        $this->assertSame(GenerateDailyBriefingAction::PROMPT_VERSION, $client->prompt->version);
+        $this->assertStringContainsString('Return only valid JSON', $client->prompt->system);
+        $this->assertStringContainsString('"prompt_version":"daily-briefing-v1"', $client->prompt->user);
+        $this->assertStringContainsString('"Checkout API"', $client->prompt->user);
+    }
+
+    public function test_sanitizes_structured_output_before_persisting(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $user = User::factory()->create();
+        $this->app->instance(LlmClient::class, new FakeLlmClient(new LlmResponse(json_encode([
+            'summary' => '<strong>Stable</strong> day with one follow-up.',
+            'highlights' => [
+                '<b>Deployment succeeded</b>',
+                "Alert resolved\ncleanly",
+                'Health score held steady',
+            ],
+            'risks' => ['<script>bad()</script>Checkout API remains low.'],
+        ], JSON_THROW_ON_ERROR))));
+
+        $briefing = app(GenerateDailyBriefingAction::class)->execute($user, $this->snapshot());
+
+        $this->assertSame('Stable day with one follow-up.', $briefing->summary);
+        $this->assertSame(['Deployment succeeded', 'Alert resolved cleanly', 'Health score held steady'], $briefing->highlights);
+        $this->assertSame(['bad()Checkout API remains low.'], $briefing->risks);
+    }
+
+    public function test_persists_failed_status_when_llm_client_errors(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $user = User::factory()->create();
+        $this->app->instance(LlmClient::class, new FakeLlmClient(exception: new RuntimeException('Provider timed out')));
+
+        $briefing = app(GenerateDailyBriefingAction::class)->execute($user, $this->snapshot());
+
+        $this->assertSame(DailyBriefingStatus::Failed, $briefing->status);
+        $this->assertSame($this->snapshot(), $briefing->input_snapshot);
+        $this->assertNull($briefing->summary);
+        $this->assertNull($briefing->generated_at);
+        $this->assertSame('Provider timed out', $briefing->error_message);
+    }
+
+    public function test_fails_closed_without_calling_llm_when_ai_features_are_disabled(): void
+    {
+        config(['services.llm.enabled' => false]);
+
+        $user = User::factory()->create();
+        $client = new FakeLlmClient(new LlmResponse('{}'));
+        $this->app->instance(LlmClient::class, $client);
+
+        $briefing = app(GenerateDailyBriefingAction::class)->execute($user, $this->snapshot());
+
+        $this->assertSame(DailyBriefingStatus::Failed, $briefing->status);
+        $this->assertSame('AI features are disabled.', $briefing->error_message);
+        $this->assertNull($client->prompt);
+    }
+
+    public function test_invalid_llm_output_is_stored_as_failed_briefing(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $user = User::factory()->create();
+        $this->app->instance(LlmClient::class, new FakeLlmClient(new LlmResponse(json_encode([
+            'summary' => 'Missing enough highlights.',
+            'highlights' => ['Only one'],
+            'risks' => [],
+        ], JSON_THROW_ON_ERROR))));
+
+        $briefing = app(GenerateDailyBriefingAction::class)->execute($user, $this->snapshot());
+
+        $this->assertSame(DailyBriefingStatus::Failed, $briefing->status);
+        $this->assertSame('LLM response must include 3 to 6 highlights.', $briefing->error_message);
+    }
+
+    public function test_reuses_existing_daily_briefing_row_for_same_user_and_date(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $user = User::factory()->create();
+        $existing = DailyBriefing::factory()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+            'status' => DailyBriefingStatus::Failed->value,
+            'error_message' => 'Previous failure',
+        ]);
+        $this->app->instance(LlmClient::class, new FakeLlmClient(new LlmResponse(json_encode([
+            'summary' => 'A clean retry generated the daily briefing.',
+            'highlights' => ['One issue opened', 'One PR merged', 'No new alerts'],
+            'risks' => [],
+        ], JSON_THROW_ON_ERROR))));
+
+        $briefing = app(GenerateDailyBriefingAction::class)->execute($user, $this->snapshot());
+
+        $this->assertSame($existing->id, $briefing->id);
+        $this->assertSame(DailyBriefingStatus::Generated, $briefing->status);
+        $this->assertDatabaseCount('daily_briefings', 1);
+    }
+
+    /** @return array<string, mixed> */
+    private function snapshot(): array
+    {
+        return [
+            'window' => [
+                'briefing_date' => '2026-07-20',
+                'timezone' => 'UTC',
+                'starts_at_utc' => '2026-07-20T00:00:00+00:00',
+                'ends_at_utc' => '2026-07-21T00:00:00+00:00',
+            ],
+            'projects' => [
+                'total' => 1,
+                'sample' => [['id' => 1, 'name' => 'Checkout API', 'health_score' => 42]],
+            ],
+            'github' => [
+                'issues' => ['opened' => 1, 'closed' => 0],
+                'pull_requests' => ['opened' => 0, 'merged' => 1, 'closed' => 1],
+                'work_items' => [],
+            ],
+            'deployments' => ['successful' => 1, 'failed' => 0, 'failed_workflows' => []],
+            'alerts' => ['triggered' => 0, 'resolved' => 0, 'groups' => [], 'sample' => []],
+            'monitoring' => ['website_checks' => ['total' => 0], 'hosts' => [], 'containers' => []],
+            'health' => ['deltas' => [], 'worst_projects' => [['id' => 1, 'name' => 'Checkout API', 'health_score' => 42]]],
+            'activity' => ['total' => 0, 'by_project' => [], 'top_events' => []],
+        ];
+    }
+}
+
+class FakeLlmClient implements LlmClient
+{
+    public ?LlmPrompt $prompt = null;
+
+    public function __construct(
+        private readonly ?LlmResponse $response = null,
+        private readonly ?RuntimeException $exception = null,
+    ) {}
+
+    public function complete(LlmPrompt $prompt): LlmResponse
+    {
+        $this->prompt = $prompt;
+
+        if ($this->exception !== null) {
+            throw $this->exception;
+        }
+
+        return $this->response ?? new LlmResponse('{}');
+    }
+}

--- a/tests/Feature/DailyBriefings/GenerateDailyBriefingJobTest.php
+++ b/tests/Feature/DailyBriefings/GenerateDailyBriefingJobTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature\DailyBriefings;
+
+use App\Domain\AI\Contracts\LlmClient;
+use App\Domain\AI\DataTransferObjects\LlmPrompt;
+use App\Domain\AI\DataTransferObjects\LlmResponse;
+use App\Domain\DailyBriefings\Actions\GenerateDailyBriefingAction;
+use App\Domain\DailyBriefings\Jobs\GenerateDailyBriefingJob;
+use App\Domain\DailyBriefings\Queries\GetDailyBriefingInputQuery;
+use App\Enums\DailyBriefingStatus;
+use App\Models\DailyBriefing;
+use App\Models\DailyBriefingPreference;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GenerateDailyBriefingJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_is_unique_by_user_and_briefing_date(): void
+    {
+        $job = new GenerateDailyBriefingJob(123, '2026-07-20');
+
+        $this->assertSame('123:2026-07-20', $job->uniqueId());
+    }
+
+    public function test_builds_input_snapshot_and_generates_briefing_for_enabled_user(): void
+    {
+        config(['services.llm.enabled' => true]);
+        $user = User::factory()->create();
+        $project = Project::factory()->create([
+            'owner_user_id' => $user->id,
+            'name' => 'Checkout API',
+            'health_score' => 42,
+        ]);
+        DailyBriefingPreference::factory()->enabled()->create([
+            'user_id' => $user->id,
+            'timezone' => 'America/New_York',
+            'include_projects' => [$project->id],
+        ]);
+        $client = new GenerateJobFakeLlmClient;
+        $this->app->instance(LlmClient::class, $client);
+
+        (new GenerateDailyBriefingJob($user->id, '2026-07-20'))->handle(
+            app(GetDailyBriefingInputQuery::class),
+            app(GenerateDailyBriefingAction::class),
+        );
+
+        $briefing = DailyBriefing::query()->sole();
+        $this->assertSame(DailyBriefingStatus::Generated, $briefing->status);
+        $this->assertSame('2026-07-20', $briefing->briefing_date->toDateString());
+        $this->assertSame('America/New_York', $briefing->input_snapshot['window']['timezone']);
+        $this->assertSame($project->id, $briefing->input_snapshot['projects']['sample'][0]['id']);
+        $this->assertNotNull($client->prompt);
+    }
+
+    public function test_does_not_regenerate_existing_generated_briefing(): void
+    {
+        config(['services.llm.enabled' => true]);
+        $user = User::factory()->create();
+        DailyBriefingPreference::factory()->enabled()->create(['user_id' => $user->id]);
+        DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+        ]);
+        $client = new GenerateJobFakeLlmClient;
+        $this->app->instance(LlmClient::class, $client);
+
+        (new GenerateDailyBriefingJob($user->id, '2026-07-20'))->handle(
+            app(GetDailyBriefingInputQuery::class),
+            app(GenerateDailyBriefingAction::class),
+        );
+
+        $this->assertDatabaseCount('daily_briefings', 1);
+        $this->assertNull($client->prompt);
+    }
+
+    public function test_does_not_generate_when_user_is_not_opted_in_or_ai_is_disabled(): void
+    {
+        config(['services.llm.enabled' => false]);
+        $user = User::factory()->create();
+        DailyBriefingPreference::factory()->enabled()->create(['user_id' => $user->id]);
+
+        (new GenerateDailyBriefingJob($user->id, '2026-07-20'))->handle(
+            app(GetDailyBriefingInputQuery::class),
+            app(GenerateDailyBriefingAction::class),
+        );
+
+        $this->assertDatabaseCount('daily_briefings', 0);
+    }
+
+    public function test_does_not_generate_when_user_is_not_opted_in(): void
+    {
+        config(['services.llm.enabled' => true]);
+        $user = User::factory()->create();
+
+        (new GenerateDailyBriefingJob($user->id, '2026-07-20'))->handle(
+            app(GetDailyBriefingInputQuery::class),
+            app(GenerateDailyBriefingAction::class),
+        );
+
+        $this->assertDatabaseCount('daily_briefings', 0);
+    }
+}
+
+class GenerateJobFakeLlmClient implements LlmClient
+{
+    public ?LlmPrompt $prompt = null;
+
+    public function complete(LlmPrompt $prompt): LlmResponse
+    {
+        $this->prompt = $prompt;
+
+        return new LlmResponse(json_encode([
+            'summary' => 'Yesterday was stable with a few concrete items to review.',
+            'highlights' => [
+                'Checkout API was included in the briefing input.',
+                'Project health was available for prioritization.',
+                'No delivery channel was invoked in this generation slice.',
+            ],
+            'risks' => [],
+        ], JSON_THROW_ON_ERROR));
+    }
+}

--- a/tests/Feature/DailyBriefings/GenerateDailyBriefingJobTest.php
+++ b/tests/Feature/DailyBriefings/GenerateDailyBriefingJobTest.php
@@ -7,6 +7,7 @@ use App\Domain\AI\DataTransferObjects\LlmPrompt;
 use App\Domain\AI\DataTransferObjects\LlmResponse;
 use App\Domain\DailyBriefings\Actions\GenerateDailyBriefingAction;
 use App\Domain\DailyBriefings\Jobs\GenerateDailyBriefingJob;
+use App\Domain\DailyBriefings\Jobs\SendDailyBriefingJob;
 use App\Domain\DailyBriefings\Queries\GetDailyBriefingInputQuery;
 use App\Enums\DailyBriefingStatus;
 use App\Models\DailyBriefing;
@@ -14,6 +15,7 @@ use App\Models\DailyBriefingPreference;
 use App\Models\Project;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
 class GenerateDailyBriefingJobTest extends TestCase
@@ -29,6 +31,7 @@ class GenerateDailyBriefingJobTest extends TestCase
 
     public function test_builds_input_snapshot_and_generates_briefing_for_enabled_user(): void
     {
+        Queue::fake();
         config(['services.llm.enabled' => true]);
         $user = User::factory()->create();
         $project = Project::factory()->create([
@@ -55,10 +58,12 @@ class GenerateDailyBriefingJobTest extends TestCase
         $this->assertSame('America/New_York', $briefing->input_snapshot['window']['timezone']);
         $this->assertSame($project->id, $briefing->input_snapshot['projects']['sample'][0]['id']);
         $this->assertNotNull($client->prompt);
+        Queue::assertPushed(SendDailyBriefingJob::class, fn (SendDailyBriefingJob $job): bool => $job->briefingId === $briefing->id);
     }
 
     public function test_does_not_regenerate_existing_generated_briefing(): void
     {
+        Queue::fake();
         config(['services.llm.enabled' => true]);
         $user = User::factory()->create();
         DailyBriefingPreference::factory()->enabled()->create(['user_id' => $user->id]);
@@ -76,10 +81,12 @@ class GenerateDailyBriefingJobTest extends TestCase
 
         $this->assertDatabaseCount('daily_briefings', 1);
         $this->assertNull($client->prompt);
+        Queue::assertNotPushed(SendDailyBriefingJob::class);
     }
 
     public function test_does_not_generate_when_user_is_not_opted_in_or_ai_is_disabled(): void
     {
+        Queue::fake();
         config(['services.llm.enabled' => false]);
         $user = User::factory()->create();
         DailyBriefingPreference::factory()->enabled()->create(['user_id' => $user->id]);
@@ -90,10 +97,12 @@ class GenerateDailyBriefingJobTest extends TestCase
         );
 
         $this->assertDatabaseCount('daily_briefings', 0);
+        Queue::assertNotPushed(SendDailyBriefingJob::class);
     }
 
     public function test_does_not_generate_when_user_is_not_opted_in(): void
     {
+        Queue::fake();
         config(['services.llm.enabled' => true]);
         $user = User::factory()->create();
 
@@ -103,6 +112,7 @@ class GenerateDailyBriefingJobTest extends TestCase
         );
 
         $this->assertDatabaseCount('daily_briefings', 0);
+        Queue::assertNotPushed(SendDailyBriefingJob::class);
     }
 }
 

--- a/tests/Feature/DailyBriefings/GenerateDailyBriefingJobTest.php
+++ b/tests/Feature/DailyBriefings/GenerateDailyBriefingJobTest.php
@@ -61,13 +61,13 @@ class GenerateDailyBriefingJobTest extends TestCase
         Queue::assertPushed(SendDailyBriefingJob::class, fn (SendDailyBriefingJob $job): bool => $job->briefingId === $briefing->id);
     }
 
-    public function test_does_not_regenerate_existing_generated_briefing(): void
+    public function test_existing_generated_briefing_is_sent_without_llm_regeneration(): void
     {
         Queue::fake();
         config(['services.llm.enabled' => true]);
         $user = User::factory()->create();
         DailyBriefingPreference::factory()->enabled()->create(['user_id' => $user->id]);
-        DailyBriefing::factory()->generated()->create([
+        $briefing = DailyBriefing::factory()->generated()->create([
             'user_id' => $user->id,
             'briefing_date' => '2026-07-20',
         ]);
@@ -81,7 +81,75 @@ class GenerateDailyBriefingJobTest extends TestCase
 
         $this->assertDatabaseCount('daily_briefings', 1);
         $this->assertNull($client->prompt);
-        Queue::assertNotPushed(SendDailyBriefingJob::class);
+        Queue::assertPushed(SendDailyBriefingJob::class, fn (SendDailyBriefingJob $job): bool => $job->briefingId === $briefing->id);
+    }
+
+    public function test_failed_delivery_with_generated_content_is_resent_without_llm_regeneration(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => true]);
+        $user = User::factory()->create();
+        DailyBriefingPreference::factory()->enabled()->create(['user_id' => $user->id]);
+        $briefing = DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+            'status' => DailyBriefingStatus::Failed->value,
+            'error_message' => 'Slack timed out',
+        ]);
+        $client = new GenerateJobFakeLlmClient;
+        $this->app->instance(LlmClient::class, $client);
+
+        (new GenerateDailyBriefingJob($user->id, '2026-07-20'))->handle(
+            app(GetDailyBriefingInputQuery::class),
+            app(GenerateDailyBriefingAction::class),
+        );
+
+        $this->assertNull($client->prompt);
+        $this->assertSame(DailyBriefingStatus::Failed, $briefing->refresh()->status);
+        Queue::assertPushed(SendDailyBriefingJob::class, fn (SendDailyBriefingJob $job): bool => $job->briefingId === $briefing->id);
+    }
+
+    public function test_pending_briefing_does_not_permanently_suppress_generation(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => true]);
+        $user = User::factory()->create();
+        DailyBriefingPreference::factory()->enabled()->create(['user_id' => $user->id]);
+        $pending = DailyBriefing::factory()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+            'status' => DailyBriefingStatus::Pending->value,
+        ]);
+        $client = new GenerateJobFakeLlmClient;
+        $this->app->instance(LlmClient::class, $client);
+
+        (new GenerateDailyBriefingJob($user->id, '2026-07-20'))->handle(
+            app(GetDailyBriefingInputQuery::class),
+            app(GenerateDailyBriefingAction::class),
+        );
+
+        $this->assertSame($pending->id, DailyBriefing::query()->sole()->id);
+        $this->assertSame(DailyBriefingStatus::Generated, $pending->refresh()->status);
+        $this->assertNotNull($client->prompt);
+        Queue::assertPushed(SendDailyBriefingJob::class, fn (SendDailyBriefingJob $job): bool => $job->briefingId === $pending->id);
+    }
+
+    public function test_failed_handler_marks_pending_briefing_failed_after_retries_are_exhausted(): void
+    {
+        $user = User::factory()->create();
+        $briefing = DailyBriefing::factory()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+            'status' => DailyBriefingStatus::Pending->value,
+        ]);
+        $job = new GenerateDailyBriefingJob($user->id, '2026-07-20');
+
+        $this->assertSame(2, $job->tries);
+
+        $job->failed(new \RuntimeException('Snapshot failed'));
+
+        $this->assertSame(DailyBriefingStatus::Failed, $briefing->refresh()->status);
+        $this->assertSame('Snapshot failed', $briefing->error_message);
     }
 
     public function test_does_not_generate_when_user_is_not_opted_in_or_ai_is_disabled(): void

--- a/tests/Feature/DailyBriefings/GetDailyBriefingInputQueryTest.php
+++ b/tests/Feature/DailyBriefings/GetDailyBriefingInputQueryTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Feature\DailyBriefings;
+
+use App\Domain\DailyBriefings\Queries\GetDailyBriefingInputQuery;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
+use App\Enums\GithubIssueState;
+use App\Enums\GithubPullRequestState;
+use App\Enums\WorkflowRunConclusion;
+use App\Enums\WorkflowRunStatus;
+use App\Models\ActivityEvent;
+use App\Models\Alert;
+use App\Models\GithubIssue;
+use App\Models\GithubPullRequest;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\WorkflowRun;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GetDailyBriefingInputQueryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_scopes_snapshot_to_user_projects_and_requested_project_filter(): void
+    {
+        $user = User::factory()->create();
+        $includedProject = Project::factory()->create(['owner_user_id' => $user->id, 'name' => 'Included']);
+        $excludedOwnedProject = Project::factory()->create(['owner_user_id' => $user->id, 'name' => 'Excluded owned']);
+        $otherProject = Project::factory()->create(['name' => 'Other user']);
+        $includedRepo = Repository::factory()->create(['project_id' => $includedProject->id]);
+        $excludedRepo = Repository::factory()->create(['project_id' => $excludedOwnedProject->id]);
+        $otherRepo = Repository::factory()->create(['project_id' => $otherProject->id]);
+
+        GithubIssue::factory()->create([
+            'repository_id' => $includedRepo->id,
+            'title' => 'Visible issue',
+            'created_at_github' => '2026-07-20 12:00:00',
+        ]);
+        GithubIssue::factory()->create([
+            'repository_id' => $excludedRepo->id,
+            'title' => 'Filtered issue',
+            'created_at_github' => '2026-07-20 12:00:00',
+        ]);
+        GithubIssue::factory()->create([
+            'repository_id' => $otherRepo->id,
+            'title' => 'Leaked issue',
+            'created_at_github' => '2026-07-20 12:00:00',
+        ]);
+
+        $snapshot = app(GetDailyBriefingInputQuery::class)->execute(
+            $user,
+            '2026-07-20',
+            'UTC',
+            [$includedProject->id, $otherProject->id],
+        );
+
+        $this->assertSame(1, $snapshot['projects']['total']);
+        $this->assertSame(1, $snapshot['github']['issues']['opened']);
+        $this->assertSame(['Visible issue'], array_column($snapshot['github']['work_items'], 'title'));
+    }
+
+    public function test_converts_local_timezone_day_to_utc_query_window(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repository = Repository::factory()->create(['project_id' => $project->id]);
+
+        GithubIssue::factory()->create([
+            'repository_id' => $repository->id,
+            'title' => 'Before local day',
+            'created_at_github' => '2026-07-20 03:59:59',
+        ]);
+        GithubIssue::factory()->create([
+            'repository_id' => $repository->id,
+            'title' => 'Inside local day',
+            'created_at_github' => '2026-07-20 04:00:00',
+        ]);
+        GithubIssue::factory()->create([
+            'repository_id' => $repository->id,
+            'title' => 'End boundary',
+            'created_at_github' => '2026-07-21 04:00:00',
+        ]);
+
+        $snapshot = app(GetDailyBriefingInputQuery::class)->execute($user, '2026-07-20', 'America/New_York');
+
+        $this->assertSame('2026-07-20T04:00:00+00:00', $snapshot['window']['starts_at_utc']);
+        $this->assertSame('2026-07-21T04:00:00+00:00', $snapshot['window']['ends_at_utc']);
+        $this->assertSame(1, $snapshot['github']['issues']['opened']);
+        $this->assertSame(['Inside local day'], array_column($snapshot['github']['work_items'], 'title'));
+    }
+
+    public function test_counts_snapshot_sections_and_caps_samples(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id, 'health_score' => 42]);
+        $repository = Repository::factory()->create(['project_id' => $project->id]);
+
+        GithubIssue::factory()->create([
+            'repository_id' => $repository->id,
+            'state' => GithubIssueState::Closed->value,
+            'created_at_github' => '2026-07-20 09:00:00',
+            'closed_at_github' => '2026-07-20 10:00:00',
+        ]);
+        GithubPullRequest::factory()->create([
+            'repository_id' => $repository->id,
+            'state' => GithubPullRequestState::Merged->value,
+            'merged' => true,
+            'created_at_github' => '2026-07-20 09:30:00',
+            'closed_at_github' => '2026-07-20 11:00:00',
+            'merged_at' => '2026-07-20 11:00:00',
+        ]);
+        WorkflowRun::factory()->create([
+            'repository_id' => $repository->id,
+            'status' => WorkflowRunStatus::Completed->value,
+            'conclusion' => WorkflowRunConclusion::Success->value,
+            'run_completed_at' => '2026-07-20 12:00:00',
+        ]);
+        WorkflowRun::factory()->create([
+            'repository_id' => $repository->id,
+            'status' => WorkflowRunStatus::Completed->value,
+            'conclusion' => WorkflowRunConclusion::Failure->value,
+            'run_completed_at' => '2026-07-20 13:00:00',
+        ]);
+
+        Alert::factory()->count(GetDailyBriefingInputQuery::ALERTS_LIMIT + 2)->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Deployment->value,
+            'severity' => AlertSeverity::Warning->value,
+            'status' => AlertStatus::Open->value,
+            'triggered_at' => '2026-07-20 14:00:00',
+            'last_seen_at' => '2026-07-20 14:00:00',
+        ]);
+        ActivityEvent::factory()->count(GetDailyBriefingInputQuery::ACTIVITY_EVENTS_LIMIT + 2)->create([
+            'repository_id' => $repository->id,
+            'occurred_at' => '2026-07-20 15:00:00',
+        ]);
+
+        $snapshot = app(GetDailyBriefingInputQuery::class)->execute($user, '2026-07-20', 'UTC');
+
+        $this->assertSame(1, $snapshot['github']['issues']['opened']);
+        $this->assertSame(1, $snapshot['github']['issues']['closed']);
+        $this->assertSame(1, $snapshot['github']['pull_requests']['merged']);
+        $this->assertSame(1, $snapshot['deployments']['successful']);
+        $this->assertSame(1, $snapshot['deployments']['failed']);
+        $this->assertSame(GetDailyBriefingInputQuery::ALERTS_LIMIT + 2, $snapshot['alerts']['triggered']);
+        $this->assertCount(GetDailyBriefingInputQuery::ALERTS_LIMIT, $snapshot['alerts']['sample']);
+        $this->assertSame(GetDailyBriefingInputQuery::ACTIVITY_EVENTS_LIMIT + 2, $snapshot['activity']['total']);
+        $this->assertCount(GetDailyBriefingInputQuery::ACTIVITY_EVENTS_LIMIT, $snapshot['activity']['top_events']);
+        $this->assertSame($project->id, $snapshot['health']['worst_projects'][0]['id']);
+    }
+}

--- a/tests/Feature/DailyBriefings/GetDailyBriefingInputQueryTest.php
+++ b/tests/Feature/DailyBriefings/GetDailyBriefingInputQueryTest.php
@@ -37,18 +37,24 @@ class GetDailyBriefingInputQueryTest extends TestCase
 
         GithubIssue::factory()->create([
             'repository_id' => $includedRepo->id,
+            'state' => GithubIssueState::Open->value,
             'title' => 'Visible issue',
             'created_at_github' => '2026-07-20 12:00:00',
+            'closed_at_github' => null,
         ]);
         GithubIssue::factory()->create([
             'repository_id' => $excludedRepo->id,
+            'state' => GithubIssueState::Open->value,
             'title' => 'Filtered issue',
             'created_at_github' => '2026-07-20 12:00:00',
+            'closed_at_github' => null,
         ]);
         GithubIssue::factory()->create([
             'repository_id' => $otherRepo->id,
+            'state' => GithubIssueState::Open->value,
             'title' => 'Leaked issue',
             'created_at_github' => '2026-07-20 12:00:00',
+            'closed_at_github' => null,
         ]);
 
         $snapshot = app(GetDailyBriefingInputQuery::class)->execute(
@@ -71,18 +77,24 @@ class GetDailyBriefingInputQueryTest extends TestCase
 
         GithubIssue::factory()->create([
             'repository_id' => $repository->id,
+            'state' => GithubIssueState::Open->value,
             'title' => 'Before local day',
             'created_at_github' => '2026-07-20 03:59:59',
+            'closed_at_github' => null,
         ]);
         GithubIssue::factory()->create([
             'repository_id' => $repository->id,
+            'state' => GithubIssueState::Open->value,
             'title' => 'Inside local day',
             'created_at_github' => '2026-07-20 04:00:00',
+            'closed_at_github' => null,
         ]);
         GithubIssue::factory()->create([
             'repository_id' => $repository->id,
+            'state' => GithubIssueState::Open->value,
             'title' => 'End boundary',
             'created_at_github' => '2026-07-21 04:00:00',
+            'closed_at_github' => null,
         ]);
 
         $snapshot = app(GetDailyBriefingInputQuery::class)->execute($user, '2026-07-20', 'America/New_York');

--- a/tests/Feature/DailyBriefings/SendDailyBriefingJobTest.php
+++ b/tests/Feature/DailyBriefings/SendDailyBriefingJobTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature\DailyBriefings;
+
+use App\Domain\DailyBriefings\Jobs\SendDailyBriefingJob;
+use App\Enums\DailyBriefingStatus;
+use App\Mail\DailyBriefingMail;
+use App\Models\AlertNotificationChannel;
+use App\Models\DailyBriefing;
+use App\Models\DailyBriefingPreference;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Mail;
+use RuntimeException;
+use Tests\TestCase;
+
+class SendDailyBriefingJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_sends_generated_briefing_through_verified_selected_channel(): void
+    {
+        Http::fake([
+            'hooks.slack.com/*' => Http::response('ok', 200),
+        ]);
+        Mail::fake();
+
+        $user = User::factory()->create();
+        AlertNotificationChannel::factory()->email('ops@example.com')->for($user)->create();
+        $slack = AlertNotificationChannel::factory()
+            ->slack('https://hooks.slack.com/services/T00/B00/XXX')
+            ->for($user)
+            ->create();
+        DailyBriefingPreference::factory()->enabled()->create([
+            'user_id' => $user->id,
+            'channel_id' => $slack->id,
+        ]);
+        $briefing = DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+        ]);
+
+        (new SendDailyBriefingJob($briefing->id))->handle();
+
+        Http::assertSent(fn ($request): bool => str_contains($request->url(), 'hooks.slack.com')
+            && $request['text'] === 'Daily briefing for 2026-07-20');
+        Mail::assertNothingSent();
+        $this->assertDatabaseHas('daily_briefings', [
+            'id' => $briefing->id,
+            'status' => DailyBriefingStatus::Delivered->value,
+            'error_message' => null,
+        ]);
+        $this->assertNotNull($briefing->refresh()->delivered_at);
+        $this->assertSame('2026-07-20', $briefing->user->dailyBriefingPreference->refresh()->last_sent_for_date->toDateString());
+    }
+
+    public function test_falls_back_to_first_verified_email_channel_when_no_channel_is_selected(): void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create();
+        AlertNotificationChannel::factory()->email('unverified@example.com')->unverified()->for($user)->create();
+        AlertNotificationChannel::factory()->email('ops@example.com')->for($user)->create();
+        DailyBriefingPreference::factory()->enabled()->create([
+            'user_id' => $user->id,
+            'channel_id' => null,
+        ]);
+        $briefing = DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+        ]);
+
+        (new SendDailyBriefingJob($briefing->id))->handle();
+
+        Mail::assertSent(DailyBriefingMail::class, fn (DailyBriefingMail $mail): bool => $mail->payload->briefingId === $briefing->id);
+        $this->assertSame(DailyBriefingStatus::Delivered, $briefing->refresh()->status);
+        $this->assertSame('2026-07-20', $briefing->user->dailyBriefingPreference->refresh()->last_sent_for_date->toDateString());
+    }
+
+    public function test_marks_failed_and_does_not_update_last_sent_when_no_verified_channel_exists(): void
+    {
+        $user = User::factory()->create();
+        DailyBriefingPreference::factory()->enabled()->create(['user_id' => $user->id]);
+        $briefing = DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+        ]);
+
+        (new SendDailyBriefingJob($briefing->id))->handle();
+
+        $this->assertSame(DailyBriefingStatus::Failed, $briefing->refresh()->status);
+        $this->assertSame('No verified daily briefing delivery channel is available.', $briefing->error_message);
+        $this->assertNull($briefing->user->dailyBriefingPreference->refresh()->last_sent_for_date);
+    }
+
+    public function test_driver_failure_marks_failed_without_updating_last_sent(): void
+    {
+        Http::fake([
+            'ops.example.com/*' => Http::response('down', 503),
+        ]);
+
+        $user = User::factory()->create();
+        $channel = AlertNotificationChannel::factory()
+            ->webhook('https://ops.example.com/hook')
+            ->for($user)
+            ->create();
+        DailyBriefingPreference::factory()->enabled()->create([
+            'user_id' => $user->id,
+            'channel_id' => $channel->id,
+        ]);
+        $briefing = DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+        ]);
+
+        try {
+            (new SendDailyBriefingJob($briefing->id))->handle();
+            $this->fail('Expected RuntimeException.');
+        } catch (RuntimeException $exception) {
+            $this->assertStringContainsString('503', $exception->getMessage());
+        }
+
+        $this->assertSame(DailyBriefingStatus::Failed, $briefing->refresh()->status);
+        $this->assertStringContainsString('503', $briefing->error_message);
+        $this->assertNull($briefing->user->dailyBriefingPreference->refresh()->last_sent_for_date);
+    }
+
+    public function test_failed_generated_briefing_can_be_retried_successfully(): void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create();
+        AlertNotificationChannel::factory()->email('ops@example.com')->for($user)->create();
+        DailyBriefingPreference::factory()->enabled()->create(['user_id' => $user->id]);
+        $briefing = DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+            'status' => DailyBriefingStatus::Failed->value,
+            'error_message' => 'Previous delivery failure',
+        ]);
+
+        (new SendDailyBriefingJob($briefing->id))->handle();
+
+        Mail::assertSent(DailyBriefingMail::class);
+        $this->assertSame(DailyBriefingStatus::Delivered, $briefing->refresh()->status);
+        $this->assertNull($briefing->error_message);
+        $this->assertSame('2026-07-20', $briefing->user->dailyBriefingPreference->refresh()->last_sent_for_date->toDateString());
+    }
+}

--- a/tests/Feature/DailyBriefings/SendDailyBriefingJobTest.php
+++ b/tests/Feature/DailyBriefings/SendDailyBriefingJobTest.php
@@ -44,7 +44,8 @@ class SendDailyBriefingJobTest extends TestCase
         (new SendDailyBriefingJob($briefing->id))->handle();
 
         Http::assertSent(fn ($request): bool => str_contains($request->url(), 'hooks.slack.com')
-            && $request['text'] === 'Daily briefing for 2026-07-20');
+            && $request['text'] === 'Daily briefing for 2026-07-20'
+            && $request['blocks'][4]['elements'][0]['url'] === route('daily-briefings.index'));
         Mail::assertNothingSent();
         $this->assertDatabaseHas('daily_briefings', [
             'id' => $briefing->id,
@@ -146,5 +147,25 @@ class SendDailyBriefingJobTest extends TestCase
         $this->assertSame(DailyBriefingStatus::Delivered, $briefing->refresh()->status);
         $this->assertNull($briefing->error_message);
         $this->assertSame('2026-07-20', $briefing->user->dailyBriefingPreference->refresh()->last_sent_for_date->toDateString());
+    }
+
+    public function test_test_delivery_does_not_update_last_sent_date(): void
+    {
+        Mail::fake();
+
+        $user = User::factory()->create();
+        AlertNotificationChannel::factory()->email('ops@example.com')->for($user)->create();
+        DailyBriefingPreference::factory()->enabled()->create(['user_id' => $user->id]);
+        $briefing = DailyBriefing::factory()->generated()->create([
+            'user_id' => $user->id,
+            'briefing_date' => '2026-07-20',
+            'is_test' => true,
+        ]);
+
+        (new SendDailyBriefingJob($briefing->id, updateLastSentForDate: false))->handle();
+
+        Mail::assertSent(DailyBriefingMail::class);
+        $this->assertSame(DailyBriefingStatus::Delivered, $briefing->refresh()->status);
+        $this->assertNull($briefing->user->dailyBriefingPreference->refresh()->last_sent_for_date);
     }
 }

--- a/tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php
+++ b/tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php
@@ -22,6 +22,13 @@ class GetOverviewDashboardQueryTest extends TestCase
 
     private ?User $defaultUser = null;
 
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
     /**
      * Spec 035 — `handle()` accepts a User for the riskyProjects
      * scope. Tests that don't care about the user-scoped slice can
@@ -667,6 +674,8 @@ class GetOverviewDashboardQueryTest extends TestCase
 
     public function test_activity_heatmap_buckets_event_by_day_and_hour(): void
     {
+        Carbon::setTestNow(Carbon::parse('2026-05-15 12:00:00', 'UTC'));
+
         $repository = $this->setUpRepository();
 
         // Wednesday at 14:30 → day=3, hour=14, bucket=3 (12:00–16:00).
@@ -684,6 +693,8 @@ class GetOverviewDashboardQueryTest extends TestCase
 
     public function test_activity_heatmap_accumulates_multiple_events_in_same_bucket(): void
     {
+        Carbon::setTestNow(Carbon::parse('2026-05-15 12:00:00', 'UTC'));
+
         $repository = $this->setUpRepository();
 
         // Three events all on Monday at 09:00–10:30 → day=1, bucket=2 (08:00–12:00).
@@ -750,6 +761,8 @@ class GetOverviewDashboardQueryTest extends TestCase
      */
     public function test_activity_heatmap_bucket_boundary_contract(): void
     {
+        Carbon::setTestNow(Carbon::parse('2026-05-15 12:00:00', 'UTC'));
+
         $repository = $this->setUpRepository();
 
         // 2026-04-26 was a Sunday → day-of-week index 0. Seed one event


### PR DESCRIPTION
Closes #131

Spec: specs/phase-10-innovation/044-ai-daily-briefing.md

## Summary
- Adds the Spec 044 AI daily briefing backend: preferences, generated briefing persistence, bounded input snapshots, LLM generation, scheduler jobs, delivery via existing notification channels, and retry-safe delivery behavior.
- Adds daily briefing settings and history UI, command palette entries, and operator/env documentation for AI/LLM configuration.
- Keeps AI inert unless `AI_FEATURES_ENABLED=true`, LLM config exists, and the user opts in.

## Test plan
- [x] `php artisan test tests/Feature/DailyBriefings` — 47 passed, 233 assertions
- [x] `php artisan test` — 916 passed, 3400 assertions
- [x] `npm run build` — passed
- [x] `vendor/bin/pint --dirty` — passed
- [x] `git diff --cached --check` — passed

## Self-review notes
- Ran fresh 4-lens review focused on risk, reliability, resilience, and readability because this is a large AI/notification/scheduler change.
- Fixed review findings in `e1275fd`: test-send isolation, pending recovery, existing notification link, Anthropic retry semantics, and delivery retry LLM reuse.
- Ran scoped fix validation after corrections; all five reviewed findings passed with focused daily briefing tests.
- Known limitation: health-score deltas are empty until Nexus has a historical health-score source; the briefing snapshot still includes current worst projects.
