### PR TITLE
Spec 045 — AI PR risk score + project health explanation

### DIFF
--- a/app/Console/Commands/BackfillPullRequestRiskAssessmentsCommand.php
+++ b/app/Console/Commands/BackfillPullRequestRiskAssessmentsCommand.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\AiInsights\Jobs\GeneratePullRequestRiskAssessmentJob;
+use App\Enums\GithubPullRequestState;
+use App\Models\GithubPullRequest;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+
+class BackfillPullRequestRiskAssessmentsCommand extends Command
+{
+    protected $signature = 'ai-insights:backfill-pr-risk
+        {--user= : User id or email to scope the backfill}
+        {--project= : Project id or slug to scope the backfill}
+        {--repository= : Repository id or full name to scope the backfill}';
+
+    protected $description = 'Queue AI PR risk assessment generation for scoped open pull requests.';
+
+    public function handle(): int
+    {
+        if (! $this->option('user') && ! $this->option('project') && ! $this->option('repository')) {
+            $this->error('Provide at least one scope option: --user, --project, or --repository.');
+
+            return self::FAILURE;
+        }
+
+        if (! config('services.llm.enabled', false)) {
+            $this->info('AI features are disabled; no PR risk backfill jobs were queued.');
+
+            return self::SUCCESS;
+        }
+
+        $user = $this->resolveUser();
+        if ($user === false) {
+            return self::FAILURE;
+        }
+
+        $project = $this->resolveProject($user);
+        if ($project === false) {
+            return self::FAILURE;
+        }
+
+        $repository = $this->resolveRepository($user, $project);
+        if ($repository === false) {
+            return self::FAILURE;
+        }
+
+        $queued = 0;
+
+        $this->pullRequestQuery($user, $project, $repository)
+            ->chunkById(100, function ($pullRequests) use (&$queued): void {
+                foreach ($pullRequests as $pullRequest) {
+                    GeneratePullRequestRiskAssessmentJob::dispatch($pullRequest->id);
+                    $queued++;
+                }
+            }, 'github_pull_requests.id', 'id');
+
+        $this->info("Queued {$queued} PR risk assessment backfill job(s).");
+
+        return self::SUCCESS;
+    }
+
+    private function resolveUser(): User|false|null
+    {
+        $value = $this->option('user');
+        if (! $value) {
+            return null;
+        }
+
+        $user = User::query()
+            ->where('id', $value)
+            ->orWhere('email', $value)
+            ->first();
+
+        if (! $user) {
+            $this->error('User scope not found.');
+
+            return false;
+        }
+
+        return $user;
+    }
+
+    private function resolveProject(?User $user): Project|false|null
+    {
+        $value = $this->option('project');
+        if (! $value) {
+            return null;
+        }
+
+        $project = Project::query()
+            ->when($user, fn (Builder $query) => $query->where('owner_user_id', $user->id))
+            ->where(function (Builder $query) use ($value): void {
+                $query->where('id', $value)
+                    ->orWhere('slug', $value);
+            })
+            ->first();
+
+        if (! $project) {
+            $this->error('Project scope not found.');
+
+            return false;
+        }
+
+        return $project;
+    }
+
+    private function resolveRepository(?User $user, ?Project $project): Repository|false|null
+    {
+        $value = $this->option('repository');
+        if (! $value) {
+            return null;
+        }
+
+        $repository = Repository::query()
+            ->where(function (Builder $query) use ($value): void {
+                $query->where('id', $value)
+                    ->orWhere('full_name', $value);
+            })
+            ->when($project, fn (Builder $query) => $query->where('project_id', $project->id))
+            ->when($user, fn (Builder $query) => $query->whereHas('project', fn (Builder $projectQuery) => $projectQuery->where('owner_user_id', $user->id)))
+            ->first();
+
+        if (! $repository) {
+            $this->error('Repository scope not found.');
+
+            return false;
+        }
+
+        return $repository;
+    }
+
+    /** @return Builder<GithubPullRequest> */
+    private function pullRequestQuery(?User $user, ?Project $project, ?Repository $repository): Builder
+    {
+        return GithubPullRequest::query()
+            ->select('github_pull_requests.*')
+            ->where('state', GithubPullRequestState::Open->value)
+            ->whereNull('closed_at_github')
+            ->whereNull('merged_at')
+            ->whereHas('repository.project', function (Builder $query) use ($user): void {
+                if ($user) {
+                    $query->where('owner_user_id', $user->id);
+                }
+            })
+            ->when($project, fn (Builder $query) => $query->whereHas('repository', fn (Builder $repositoryQuery) => $repositoryQuery->where('project_id', $project->id)))
+            ->when($repository, fn (Builder $query) => $query->where('repository_id', $repository->id))
+            ->orderBy('github_pull_requests.id');
+    }
+}

--- a/app/Domain/AiInsights/Actions/GenerateProjectHealthExplanationAction.php
+++ b/app/Domain/AiInsights/Actions/GenerateProjectHealthExplanationAction.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace App\Domain\AiInsights\Actions;
+
+use App\Domain\AI\Contracts\LlmClient;
+use App\Domain\AI\DataTransferObjects\LlmPrompt;
+use App\Enums\HealthScoreBand;
+use App\Enums\ProjectHealthExplanationStatus;
+use App\Models\Project;
+use App\Models\ProjectHealthExplanation;
+use Illuminate\Support\Str;
+use Throwable;
+
+class GenerateProjectHealthExplanationAction
+{
+    public const PROMPT_VERSION = 'project-health-explanation-v1';
+
+    public function __construct(private readonly LlmClient $llm) {}
+
+    /** @param array<string, mixed> $inputSnapshot */
+    public function execute(Project $project, array $inputSnapshot): ProjectHealthExplanation
+    {
+        if (! config('services.llm.enabled', false)) {
+            return $this->markFailed($project, $inputSnapshot, 'AI features are disabled.');
+        }
+
+        try {
+            $response = $this->llm->complete($this->prompt($inputSnapshot));
+            $output = $this->validatedOutput($response->text);
+
+            return $this->writeExplanation($project, [
+                'status' => ProjectHealthExplanationStatus::Explained,
+                'health_score' => $this->healthScore($project, $inputSnapshot),
+                'health_band' => $this->healthBand($project, $inputSnapshot),
+                'summary' => $output['summary'],
+                'drivers' => $output['drivers'],
+                'recommended_actions' => $output['recommended_actions'],
+                'input_snapshot' => $inputSnapshot,
+                'prompt_version' => self::PROMPT_VERSION,
+                'model' => $response->model,
+                'explained_at' => now(),
+                'failed_at' => null,
+                'error_message' => null,
+            ]);
+        } catch (Throwable $exception) {
+            return $this->markFailed($project, $inputSnapshot, $exception->getMessage());
+        }
+    }
+
+    /** @param array<string, mixed> $inputSnapshot */
+    private function prompt(array $inputSnapshot): LlmPrompt
+    {
+        return new LlmPrompt(
+            version: self::PROMPT_VERSION,
+            system: 'You explain an existing Nexus project health score from structured monitoring data. Return only valid JSON matching the requested schema. Do not invent a different score. Do not include secrets, raw logs, tokens, webhook URLs, or unsupported claims.',
+            user: json_encode([
+                'prompt_version' => self::PROMPT_VERSION,
+                'task' => 'Explain why this existing project health score has its current value.',
+                'schema' => [
+                    'summary' => 'string, concise operator-facing explanation',
+                    'drivers' => 'array of 1-6 short strings tied to concrete input_snapshot drivers',
+                    'recommended_actions' => 'array of 0-4 short strings',
+                ],
+                'input_snapshot' => $inputSnapshot,
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+        );
+    }
+
+    /**
+     * @return array{summary: string, drivers: array<int, string>, recommended_actions: array<int, string>}
+     */
+    private function validatedOutput(string $text): array
+    {
+        $payload = json_decode($this->stripCodeFence($text), true);
+
+        if (! is_array($payload)) {
+            throw new \UnexpectedValueException('LLM response was not valid JSON.');
+        }
+
+        $summary = $this->sanitizeString($payload['summary'] ?? null, 1_000);
+        $drivers = $this->sanitizeList($payload['drivers'] ?? null, 6);
+        $recommendedActions = $this->sanitizeList($payload['recommended_actions'] ?? [], 4);
+
+        if ($summary === '') {
+            throw new \UnexpectedValueException('LLM response summary is required.');
+        }
+
+        if (count($drivers) < 1 || count($drivers) > 6) {
+            throw new \UnexpectedValueException('LLM response must include 1 to 6 drivers.');
+        }
+
+        return [
+            'summary' => $summary,
+            'drivers' => $drivers,
+            'recommended_actions' => $recommendedActions,
+        ];
+    }
+
+    /** @param mixed $value */
+    private function sanitizeString($value, int $limit): string
+    {
+        if (! is_string($value)) {
+            return '';
+        }
+
+        $value = trim(strip_tags(preg_replace('/[[:cntrl:]]+/', ' ', $value) ?? ''));
+
+        return Str::limit($value, $limit, '');
+    }
+
+    /**
+     * @param  mixed  $value
+     * @return array<int, string>
+     */
+    private function sanitizeList($value, int $limit): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return collect($value)
+            ->map(fn ($item): string => $this->sanitizeString($item, 500))
+            ->filter(fn (string $item): bool => $item !== '')
+            ->take($limit)
+            ->values()
+            ->all();
+    }
+
+    private function stripCodeFence(string $text): string
+    {
+        $text = trim($text);
+
+        if (str_starts_with($text, '```')) {
+            $text = preg_replace('/^```(?:json)?\s*/', '', $text) ?? $text;
+            $text = preg_replace('/\s*```$/', '', $text) ?? $text;
+        }
+
+        return trim($text);
+    }
+
+    /** @param array<string, mixed> $inputSnapshot */
+    private function markFailed(Project $project, array $inputSnapshot, string $error): ProjectHealthExplanation
+    {
+        return $this->writeExplanation($project, [
+            'status' => ProjectHealthExplanationStatus::Failed,
+            'health_score' => $this->healthScore($project, $inputSnapshot),
+            'health_band' => $this->healthBand($project, $inputSnapshot),
+            'summary' => null,
+            'drivers' => [],
+            'recommended_actions' => [],
+            'input_snapshot' => $inputSnapshot,
+            'prompt_version' => self::PROMPT_VERSION,
+            'model' => null,
+            'explained_at' => null,
+            'failed_at' => now(),
+            'error_message' => Str::limit($error, 2_000, ''),
+        ]);
+    }
+
+    /** @param array<string, mixed> $inputSnapshot */
+    private function healthScore(Project $project, array $inputSnapshot): int
+    {
+        $score = $inputSnapshot['project']['health_score'] ?? $project->health_score ?? 0;
+
+        return max(0, min(100, (int) $score));
+    }
+
+    /** @param array<string, mixed> $inputSnapshot */
+    private function healthBand(Project $project, array $inputSnapshot): HealthScoreBand
+    {
+        $band = $inputSnapshot['project']['health_band'] ?? null;
+
+        if (is_string($band) && ($healthBand = HealthScoreBand::tryFrom($band)) !== null) {
+            return $healthBand;
+        }
+
+        return HealthScoreBand::fromScore($this->healthScore($project, $inputSnapshot));
+    }
+
+    /** @param array<string, mixed> $attributes */
+    private function writeExplanation(Project $project, array $attributes): ProjectHealthExplanation
+    {
+        $explanation = ProjectHealthExplanation::query()
+            ->where('project_id', $project->id)
+            ->first() ?? new ProjectHealthExplanation(['project_id' => $project->id]);
+
+        $explanation->fill($attributes);
+        $explanation->save();
+
+        return $explanation;
+    }
+}

--- a/app/Domain/AiInsights/Actions/GeneratePullRequestRiskAssessmentAction.php
+++ b/app/Domain/AiInsights/Actions/GeneratePullRequestRiskAssessmentAction.php
@@ -9,7 +9,6 @@ use App\Enums\AlertSeverity;
 use App\Enums\AlertSource;
 use App\Enums\PullRequestRiskAssessmentStatus;
 use App\Enums\PullRequestRiskLevel;
-use App\Models\Alert;
 use App\Models\GithubPullRequest;
 use App\Models\PullRequestRiskAssessment;
 use Illuminate\Support\Facades\Log;
@@ -191,14 +190,6 @@ class GeneratePullRequestRiskAssessmentAction
         }
 
         $type = $this->notificationAlertType($riskLevel);
-
-        if (Alert::query()
-            ->where('source', AlertSource::Github->value)
-            ->where('source_id', $pullRequest->id)
-            ->where('type', $type)
-            ->exists()) {
-            return;
-        }
 
         try {
             $pullRequest->loadMissing('repository.project');

--- a/app/Domain/AiInsights/Actions/GeneratePullRequestRiskAssessmentAction.php
+++ b/app/Domain/AiInsights/Actions/GeneratePullRequestRiskAssessmentAction.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace App\Domain\AiInsights\Actions;
+
+use App\Domain\AI\Contracts\LlmClient;
+use App\Domain\AI\DataTransferObjects\LlmPrompt;
+use App\Enums\PullRequestRiskAssessmentStatus;
+use App\Enums\PullRequestRiskLevel;
+use App\Models\GithubPullRequest;
+use App\Models\PullRequestRiskAssessment;
+use Illuminate\Support\Str;
+use Throwable;
+
+class GeneratePullRequestRiskAssessmentAction
+{
+    public const PROMPT_VERSION = 'pr-risk-v1';
+
+    public function __construct(private readonly LlmClient $llm) {}
+
+    /** @param array<string, mixed> $inputSnapshot */
+    public function execute(GithubPullRequest $pullRequest, array $inputSnapshot): PullRequestRiskAssessment
+    {
+        if (! config('services.llm.enabled', false)) {
+            return $this->markFailed($pullRequest, $inputSnapshot, 'AI features are disabled.');
+        }
+
+        try {
+            $response = $this->llm->complete($this->prompt($inputSnapshot));
+            $output = $this->validatedOutput($response->text);
+
+            return $this->writeAssessment($pullRequest, [
+                'status' => PullRequestRiskAssessmentStatus::Scored,
+                'risk_level' => $output['risk_level'],
+                'risk_score' => $output['risk_score'],
+                'summary' => $output['summary'],
+                'reasons' => $output['reasons'],
+                'recommended_actions' => $output['recommended_actions'],
+                'input_snapshot' => $inputSnapshot,
+                'prompt_version' => self::PROMPT_VERSION,
+                'model' => $response->model,
+                'assessed_at' => now(),
+                'failed_at' => null,
+                'error_message' => null,
+            ]);
+        } catch (Throwable $exception) {
+            return $this->markFailed($pullRequest, $inputSnapshot, $exception->getMessage());
+        }
+    }
+
+    /** @param array<string, mixed> $inputSnapshot */
+    private function prompt(array $inputSnapshot): LlmPrompt
+    {
+        return new LlmPrompt(
+            version: self::PROMPT_VERSION,
+            system: 'You assess pull request review risk from structured Nexus metadata. Return only valid JSON matching the requested schema. Do not invent facts. Do not include secrets, raw logs, tokens, webhook URLs, raw diffs, or unsupported claims.',
+            user: json_encode([
+                'prompt_version' => self::PROMPT_VERSION,
+                'task' => 'Assess this pull request risk for an operator deciding review priority.',
+                'schema' => [
+                    'risk_level' => 'one of: low, medium, high, critical',
+                    'risk_score' => 'integer 0-100',
+                    'summary' => 'string, 1-2 short sentences',
+                    'reasons' => 'array of 1-5 short strings tied to concrete input_snapshot fields',
+                    'recommended_actions' => 'array of 0-4 short strings',
+                ],
+                'input_snapshot' => $inputSnapshot,
+            ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES),
+        );
+    }
+
+    /**
+     * @return array{risk_level: PullRequestRiskLevel, risk_score: int, summary: string, reasons: array<int, string>, recommended_actions: array<int, string>}
+     */
+    private function validatedOutput(string $text): array
+    {
+        $payload = json_decode($this->stripCodeFence($text), true);
+
+        if (! is_array($payload)) {
+            throw new \UnexpectedValueException('LLM response was not valid JSON.');
+        }
+
+        $riskLevel = PullRequestRiskLevel::tryFrom((string) ($payload['risk_level'] ?? ''));
+        $riskScore = $payload['risk_score'] ?? null;
+        $summary = $this->sanitizeString($payload['summary'] ?? null, 1_000);
+        $reasons = $this->sanitizeList($payload['reasons'] ?? null, 5);
+        $recommendedActions = $this->sanitizeList($payload['recommended_actions'] ?? [], 4);
+
+        if ($riskLevel === null) {
+            throw new \UnexpectedValueException('LLM response risk_level is invalid.');
+        }
+
+        if (! is_int($riskScore) || $riskScore < 0 || $riskScore > 100) {
+            throw new \UnexpectedValueException('LLM response risk_score must be an integer from 0 to 100.');
+        }
+
+        if ($summary === '') {
+            throw new \UnexpectedValueException('LLM response summary is required.');
+        }
+
+        if (count($reasons) < 1 || count($reasons) > 5) {
+            throw new \UnexpectedValueException('LLM response must include 1 to 5 reasons.');
+        }
+
+        return [
+            'risk_level' => $riskLevel,
+            'risk_score' => $riskScore,
+            'summary' => $summary,
+            'reasons' => $reasons,
+            'recommended_actions' => $recommendedActions,
+        ];
+    }
+
+    /** @param mixed $value */
+    private function sanitizeString($value, int $limit): string
+    {
+        if (! is_string($value)) {
+            return '';
+        }
+
+        $value = trim(strip_tags(preg_replace('/[[:cntrl:]]+/', ' ', $value) ?? ''));
+
+        return Str::limit($value, $limit, '');
+    }
+
+    /**
+     * @param  mixed  $value
+     * @return array<int, string>
+     */
+    private function sanitizeList($value, int $limit): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return collect($value)
+            ->map(fn ($item): string => $this->sanitizeString($item, 500))
+            ->filter(fn (string $item): bool => $item !== '')
+            ->take($limit)
+            ->values()
+            ->all();
+    }
+
+    private function stripCodeFence(string $text): string
+    {
+        $text = trim($text);
+
+        if (str_starts_with($text, '```')) {
+            $text = preg_replace('/^```(?:json)?\s*/', '', $text) ?? $text;
+            $text = preg_replace('/\s*```$/', '', $text) ?? $text;
+        }
+
+        return trim($text);
+    }
+
+    /** @param array<string, mixed> $inputSnapshot */
+    private function markFailed(GithubPullRequest $pullRequest, array $inputSnapshot, string $error): PullRequestRiskAssessment
+    {
+        return $this->writeAssessment($pullRequest, [
+            'status' => PullRequestRiskAssessmentStatus::Failed,
+            'risk_level' => null,
+            'risk_score' => null,
+            'summary' => null,
+            'reasons' => [],
+            'recommended_actions' => [],
+            'input_snapshot' => $inputSnapshot,
+            'prompt_version' => self::PROMPT_VERSION,
+            'model' => null,
+            'assessed_at' => null,
+            'failed_at' => now(),
+            'error_message' => Str::limit($error, 2_000, ''),
+        ]);
+    }
+
+    /** @param array<string, mixed> $attributes */
+    private function writeAssessment(GithubPullRequest $pullRequest, array $attributes): PullRequestRiskAssessment
+    {
+        $assessment = PullRequestRiskAssessment::query()
+            ->where('github_pull_request_id', $pullRequest->id)
+            ->first() ?? new PullRequestRiskAssessment(['github_pull_request_id' => $pullRequest->id]);
+
+        $assessment->fill($attributes);
+        $assessment->save();
+
+        return $assessment;
+    }
+}

--- a/app/Domain/AiInsights/Actions/GeneratePullRequestRiskAssessmentAction.php
+++ b/app/Domain/AiInsights/Actions/GeneratePullRequestRiskAssessmentAction.php
@@ -4,10 +4,15 @@ namespace App\Domain\AiInsights\Actions;
 
 use App\Domain\AI\Contracts\LlmClient;
 use App\Domain\AI\DataTransferObjects\LlmPrompt;
+use App\Domain\Alerts\Actions\TriggerAlertAction;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
 use App\Enums\PullRequestRiskAssessmentStatus;
 use App\Enums\PullRequestRiskLevel;
+use App\Models\Alert;
 use App\Models\GithubPullRequest;
 use App\Models\PullRequestRiskAssessment;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Throwable;
 
@@ -15,7 +20,10 @@ class GeneratePullRequestRiskAssessmentAction
 {
     public const PROMPT_VERSION = 'pr-risk-v1';
 
-    public function __construct(private readonly LlmClient $llm) {}
+    public function __construct(
+        private readonly LlmClient $llm,
+        private readonly TriggerAlertAction $triggerAlert,
+    ) {}
 
     /** @param array<string, mixed> $inputSnapshot */
     public function execute(GithubPullRequest $pullRequest, array $inputSnapshot): PullRequestRiskAssessment
@@ -28,7 +36,9 @@ class GeneratePullRequestRiskAssessmentAction
             $response = $this->llm->complete($this->prompt($inputSnapshot));
             $output = $this->validatedOutput($response->text);
 
-            return $this->writeAssessment($pullRequest, [
+            $previousRiskLevel = $this->currentRiskLevel($pullRequest);
+
+            $assessment = $this->writeAssessment($pullRequest, [
                 'status' => PullRequestRiskAssessmentStatus::Scored,
                 'risk_level' => $output['risk_level'],
                 'risk_score' => $output['risk_score'],
@@ -42,6 +52,10 @@ class GeneratePullRequestRiskAssessmentAction
                 'failed_at' => null,
                 'error_message' => null,
             ]);
+
+            $this->notifyForMaterialRiskIncrease($pullRequest, $previousRiskLevel, $assessment);
+
+            return $assessment;
         } catch (Throwable $exception) {
             return $this->markFailed($pullRequest, $inputSnapshot, $exception->getMessage());
         }
@@ -150,6 +164,90 @@ class GeneratePullRequestRiskAssessmentAction
         }
 
         return trim($text);
+    }
+
+    private function currentRiskLevel(GithubPullRequest $pullRequest): ?PullRequestRiskLevel
+    {
+        $riskLevel = PullRequestRiskAssessment::query()
+            ->where('github_pull_request_id', $pullRequest->id)
+            ->value('risk_level');
+
+        return is_string($riskLevel) ? PullRequestRiskLevel::tryFrom($riskLevel) : null;
+    }
+
+    private function notifyForMaterialRiskIncrease(
+        GithubPullRequest $pullRequest,
+        ?PullRequestRiskLevel $previousRiskLevel,
+        PullRequestRiskAssessment $assessment,
+    ): void {
+        $riskLevel = $assessment->risk_level;
+
+        if ($riskLevel === null || ! in_array($riskLevel, [PullRequestRiskLevel::High, PullRequestRiskLevel::Critical], true)) {
+            return;
+        }
+
+        if ($previousRiskLevel !== null && $this->riskRank($riskLevel) <= $this->riskRank($previousRiskLevel)) {
+            return;
+        }
+
+        $type = $this->notificationAlertType($riskLevel);
+
+        if (Alert::query()
+            ->where('source', AlertSource::Github->value)
+            ->where('source_id', $pullRequest->id)
+            ->where('type', $type)
+            ->exists()) {
+            return;
+        }
+
+        try {
+            $pullRequest->loadMissing('repository.project');
+            $repository = $pullRequest->repository;
+            $project = $repository?->project;
+
+            if ($project === null) {
+                return;
+            }
+
+            $this->triggerAlert->execute([
+                'project_id' => $project->id,
+                'source' => AlertSource::Github,
+                'source_id' => $pullRequest->id,
+                'type' => $type,
+                'severity' => $riskLevel === PullRequestRiskLevel::Critical ? AlertSeverity::Critical : AlertSeverity::Warning,
+                'title' => sprintf('PR #%d risk is %s', $pullRequest->number, $riskLevel->value),
+                'description' => $assessment->summary,
+                'metadata' => [
+                    'repository' => $repository?->full_name,
+                    'pull_request_id' => $pullRequest->id,
+                    'pull_request_number' => $pullRequest->number,
+                    'risk_level' => $riskLevel->value,
+                    'risk_score' => $assessment->risk_score,
+                    'assessment_id' => $assessment->id,
+                ],
+            ]);
+        } catch (Throwable $exception) {
+            Log::warning('PR risk notification dispatch failed', [
+                'pull_request_id' => $pullRequest->id,
+                'assessment_id' => $assessment->id,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    private function riskRank(PullRequestRiskLevel $riskLevel): int
+    {
+        return match ($riskLevel) {
+            PullRequestRiskLevel::Low => 1,
+            PullRequestRiskLevel::Medium => 2,
+            PullRequestRiskLevel::High => 3,
+            PullRequestRiskLevel::Critical => 4,
+        };
+    }
+
+    private function notificationAlertType(PullRequestRiskLevel $riskLevel): string
+    {
+        return 'pull_request.risk.'.$riskLevel->value;
     }
 
     /** @param array<string, mixed> $inputSnapshot */

--- a/app/Domain/AiInsights/Jobs/GenerateProjectHealthExplanationJob.php
+++ b/app/Domain/AiInsights/Jobs/GenerateProjectHealthExplanationJob.php
@@ -25,7 +25,7 @@ class GenerateProjectHealthExplanationJob implements ShouldBeUnique, ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public int $tries = 2;
+    public int $tries = 1;
 
     public int $uniqueFor = 900;
 
@@ -39,6 +39,8 @@ class GenerateProjectHealthExplanationJob implements ShouldBeUnique, ShouldQueue
     public function handle(GetProjectHealthExplanationInputQuery $inputQuery, GenerateProjectHealthExplanationAction $generate): void
     {
         if (! config('services.llm.enabled', false)) {
+            $this->markSkippedByProjectId('AI features are disabled.');
+
             return;
         }
 
@@ -97,8 +99,13 @@ class GenerateProjectHealthExplanationJob implements ShouldBeUnique, ShouldQueue
 
     private function markSkipped(Project $project, string $reason): void
     {
+        $this->markSkippedByProjectId($reason, $project->id);
+    }
+
+    private function markSkippedByProjectId(string $reason, ?int $projectId = null): void
+    {
         ProjectHealthExplanation::query()
-            ->where('project_id', $project->id)
+            ->where('project_id', $projectId ?? $this->projectId)
             ->where('status', ProjectHealthExplanationStatus::Pending->value)
             ->update([
                 'status' => ProjectHealthExplanationStatus::Skipped,

--- a/app/Domain/AiInsights/Jobs/GenerateProjectHealthExplanationJob.php
+++ b/app/Domain/AiInsights/Jobs/GenerateProjectHealthExplanationJob.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Domain\AiInsights\Jobs;
+
+use App\Domain\AiInsights\Actions\GenerateProjectHealthExplanationAction;
+use App\Domain\AiInsights\Queries\GetProjectHealthExplanationInputQuery;
+use App\Enums\HealthScoreBand;
+use App\Enums\ProjectHealthExplanationStatus;
+use App\Models\Project;
+use App\Models\ProjectHealthExplanation;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Str;
+use Throwable;
+
+class GenerateProjectHealthExplanationJob implements ShouldBeUnique, ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 2;
+
+    public int $uniqueFor = 900;
+
+    public function __construct(public readonly int $projectId) {}
+
+    public function uniqueId(): string
+    {
+        return (string) $this->projectId;
+    }
+
+    public function handle(GetProjectHealthExplanationInputQuery $inputQuery, GenerateProjectHealthExplanationAction $generate): void
+    {
+        if (! config('services.llm.enabled', false)) {
+            return;
+        }
+
+        $project = Project::query()->find($this->projectId);
+        $owner = $project?->owner_user_id === null ? null : User::query()->find($project->owner_user_id);
+
+        if ($project === null || $owner === null) {
+            return;
+        }
+
+        $this->markPending($project);
+
+        $snapshot = $inputQuery->execute($owner, $project);
+
+        if ($snapshot === null) {
+            $this->markSkipped($project, 'Project is no longer available in the scoped AI input query.');
+
+            return;
+        }
+
+        $generate->execute($project, $snapshot);
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        $explanation = ProjectHealthExplanation::query()
+            ->where('project_id', $this->projectId)
+            ->where('status', ProjectHealthExplanationStatus::Pending->value)
+            ->first();
+
+        if ($explanation === null) {
+            return;
+        }
+
+        $explanation->forceFill([
+            'status' => ProjectHealthExplanationStatus::Failed,
+            'failed_at' => now(),
+            'error_message' => Str::limit($exception->getMessage(), 2_000, ''),
+        ])->save();
+    }
+
+    private function markPending(Project $project): void
+    {
+        $explanation = ProjectHealthExplanation::query()
+            ->where('project_id', $project->id)
+            ->first() ?? new ProjectHealthExplanation(['project_id' => $project->id]);
+
+        $explanation->forceFill([
+            'status' => ProjectHealthExplanationStatus::Pending,
+            'health_score' => $project->health_score ?? 0,
+            'health_band' => HealthScoreBand::fromScore($project->health_score ?? 0),
+            'failed_at' => null,
+            'error_message' => null,
+        ])->save();
+    }
+
+    private function markSkipped(Project $project, string $reason): void
+    {
+        ProjectHealthExplanation::query()
+            ->where('project_id', $project->id)
+            ->where('status', ProjectHealthExplanationStatus::Pending->value)
+            ->update([
+                'status' => ProjectHealthExplanationStatus::Skipped,
+                'failed_at' => null,
+                'error_message' => Str::limit($reason, 2_000, ''),
+            ]);
+    }
+}

--- a/app/Domain/AiInsights/Jobs/GeneratePullRequestRiskAssessmentJob.php
+++ b/app/Domain/AiInsights/Jobs/GeneratePullRequestRiskAssessmentJob.php
@@ -24,7 +24,7 @@ class GeneratePullRequestRiskAssessmentJob implements ShouldBeUnique, ShouldQueu
     use Queueable;
     use SerializesModels;
 
-    public int $tries = 2;
+    public int $tries = 1;
 
     public int $uniqueFor = 900;
 
@@ -38,6 +38,8 @@ class GeneratePullRequestRiskAssessmentJob implements ShouldBeUnique, ShouldQueu
     public function handle(GetPullRequestRiskInputQuery $inputQuery, GeneratePullRequestRiskAssessmentAction $generate): void
     {
         if (! config('services.llm.enabled', false)) {
+            $this->markSkippedByPullRequestId('AI features are disabled.');
+
             return;
         }
 
@@ -98,8 +100,13 @@ class GeneratePullRequestRiskAssessmentJob implements ShouldBeUnique, ShouldQueu
 
     private function markSkipped(GithubPullRequest $pullRequest, string $reason): void
     {
+        $this->markSkippedByPullRequestId($reason, $pullRequest->id);
+    }
+
+    private function markSkippedByPullRequestId(string $reason, ?int $pullRequestId = null): void
+    {
         PullRequestRiskAssessment::query()
-            ->where('github_pull_request_id', $pullRequest->id)
+            ->where('github_pull_request_id', $pullRequestId ?? $this->pullRequestId)
             ->where('status', PullRequestRiskAssessmentStatus::Pending->value)
             ->update([
                 'status' => PullRequestRiskAssessmentStatus::Skipped,

--- a/app/Domain/AiInsights/Jobs/GeneratePullRequestRiskAssessmentJob.php
+++ b/app/Domain/AiInsights/Jobs/GeneratePullRequestRiskAssessmentJob.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Domain\AiInsights\Jobs;
+
+use App\Domain\AiInsights\Actions\GeneratePullRequestRiskAssessmentAction;
+use App\Domain\AiInsights\Queries\GetPullRequestRiskInputQuery;
+use App\Enums\PullRequestRiskAssessmentStatus;
+use App\Models\GithubPullRequest;
+use App\Models\PullRequestRiskAssessment;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Str;
+use Throwable;
+
+class GeneratePullRequestRiskAssessmentJob implements ShouldBeUnique, ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 2;
+
+    public int $uniqueFor = 900;
+
+    public function __construct(public readonly int $pullRequestId) {}
+
+    public function uniqueId(): string
+    {
+        return (string) $this->pullRequestId;
+    }
+
+    public function handle(GetPullRequestRiskInputQuery $inputQuery, GeneratePullRequestRiskAssessmentAction $generate): void
+    {
+        if (! config('services.llm.enabled', false)) {
+            return;
+        }
+
+        $pullRequest = GithubPullRequest::query()
+            ->with('repository.project')
+            ->find($this->pullRequestId);
+
+        $ownerId = $pullRequest?->repository?->project?->owner_user_id;
+        $owner = $ownerId === null ? null : User::query()->find($ownerId);
+
+        if ($pullRequest === null || $owner === null) {
+            return;
+        }
+
+        $this->markPending($pullRequest);
+
+        $snapshot = $inputQuery->execute($owner, $pullRequest);
+
+        if ($snapshot === null) {
+            $this->markSkipped($pullRequest, 'Pull request is no longer available in the scoped AI input query.');
+
+            return;
+        }
+
+        $generate->execute($pullRequest, $snapshot);
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        $assessment = PullRequestRiskAssessment::query()
+            ->where('github_pull_request_id', $this->pullRequestId)
+            ->where('status', PullRequestRiskAssessmentStatus::Pending->value)
+            ->first();
+
+        if ($assessment === null) {
+            return;
+        }
+
+        $assessment->forceFill([
+            'status' => PullRequestRiskAssessmentStatus::Failed,
+            'failed_at' => now(),
+            'error_message' => Str::limit($exception->getMessage(), 2_000, ''),
+        ])->save();
+    }
+
+    private function markPending(GithubPullRequest $pullRequest): void
+    {
+        $assessment = PullRequestRiskAssessment::query()
+            ->where('github_pull_request_id', $pullRequest->id)
+            ->first() ?? new PullRequestRiskAssessment(['github_pull_request_id' => $pullRequest->id]);
+
+        $assessment->forceFill([
+            'status' => PullRequestRiskAssessmentStatus::Pending,
+            'failed_at' => null,
+            'error_message' => null,
+        ])->save();
+    }
+
+    private function markSkipped(GithubPullRequest $pullRequest, string $reason): void
+    {
+        PullRequestRiskAssessment::query()
+            ->where('github_pull_request_id', $pullRequest->id)
+            ->where('status', PullRequestRiskAssessmentStatus::Pending->value)
+            ->update([
+                'status' => PullRequestRiskAssessmentStatus::Skipped,
+                'failed_at' => null,
+                'error_message' => Str::limit($reason, 2_000, ''),
+            ]);
+    }
+}

--- a/app/Domain/AiInsights/Queries/GetProjectHealthExplanationInputQuery.php
+++ b/app/Domain/AiInsights/Queries/GetProjectHealthExplanationInputQuery.php
@@ -1,0 +1,302 @@
+<?php
+
+namespace App\Domain\AiInsights\Queries;
+
+use App\Enums\AlertSeverity;
+use App\Enums\AlertStatus;
+use App\Enums\HealthScoreBand;
+use App\Enums\HostStatus;
+use App\Enums\WebsiteStatus;
+use App\Enums\WorkflowRunConclusion;
+use App\Models\Alert;
+use App\Models\Container;
+use App\Models\Host;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\Website;
+use App\Models\WorkflowRun;
+use Carbon\CarbonImmutable;
+
+class GetProjectHealthExplanationInputQuery
+{
+    public const SAMPLE_LIMIT = 5;
+
+    /** @return array<string, mixed>|null */
+    public function execute(User $user, Project $project): ?array
+    {
+        $project = Project::query()
+            ->whereKey($project->id)
+            ->where('owner_user_id', $user->id)
+            ->first();
+
+        if (! $project) {
+            return null;
+        }
+
+        return [
+            'snapshot_version' => 'project-health-explanation-input-v1',
+            'generated_at' => CarbonImmutable::now('UTC')->toIso8601String(),
+            'project' => [
+                'id' => $project->id,
+                'name' => $project->name,
+                'slug' => $project->slug,
+                'status' => $project->status?->value,
+                'priority' => $project->priority?->value,
+                'environment' => $project->environment,
+                'health_score' => $project->health_score,
+                'health_band' => $project->health_score === null
+                    ? null
+                    : HealthScoreBand::fromScore($project->health_score)->value,
+                'last_activity_at' => $project->last_activity_at?->toIso8601String(),
+            ],
+            'drivers' => [
+                'alerts' => $this->alerts($project->id),
+                'deployments' => $this->deployments($project->id),
+                'websites' => $this->websites($project->id),
+                'hosts' => $this->hosts($project->id),
+                'containers' => $this->containers($project->id),
+                'github_sync' => $this->githubSync($project->id),
+            ],
+            'health_delta' => null,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function alerts(int $projectId): array
+    {
+        $activeStatuses = [AlertStatus::Open->value, AlertStatus::Acknowledged->value];
+        $base = Alert::query()
+            ->where('project_id', $projectId)
+            ->whereIn('status', $activeStatuses);
+
+        return [
+            'active_total' => (clone $base)->count(),
+            'active_by_severity' => (clone $base)
+                ->selectRaw('severity, COUNT(id) as total')
+                ->groupBy('severity')
+                ->pluck('total', 'severity')
+                ->map(fn ($total): int => (int) $total)
+                ->all(),
+            'active_by_source' => (clone $base)
+                ->selectRaw('source, COUNT(id) as total')
+                ->groupBy('source')
+                ->pluck('total', 'source')
+                ->map(fn ($total): int => (int) $total)
+                ->all(),
+            'sample' => (clone $base)
+                ->whereIn('severity', [AlertSeverity::Critical->value, AlertSeverity::Warning->value])
+                ->orderByRaw("CASE severity WHEN 'critical' THEN 0 WHEN 'warning' THEN 1 ELSE 2 END")
+                ->orderByDesc('last_seen_at')
+                ->orderByDesc('id')
+                ->limit(self::SAMPLE_LIMIT)
+                ->get(['id', 'source', 'type', 'severity', 'status', 'title', 'triggered_at', 'last_seen_at'])
+                ->map(fn (Alert $alert): array => [
+                    'id' => $alert->id,
+                    'source' => $alert->source?->value,
+                    'type' => $alert->type,
+                    'severity' => $alert->severity?->value,
+                    'status' => $alert->status?->value,
+                    'title' => $this->sanitizeText($alert->title),
+                    'triggered_at' => $alert->triggered_at?->toIso8601String(),
+                    'last_seen_at' => $alert->last_seen_at?->toIso8601String(),
+                ])
+                ->all(),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function deployments(int $projectId): array
+    {
+        $since = CarbonImmutable::now('UTC')->subDay();
+
+        $failed = WorkflowRun::query()
+            ->join('repositories', 'workflow_runs.repository_id', '=', 'repositories.id')
+            ->where('repositories.project_id', $projectId)
+            ->whereColumn('workflow_runs.head_branch', 'repositories.default_branch')
+            ->where('workflow_runs.conclusion', WorkflowRunConclusion::Failure->value)
+            ->where('workflow_runs.run_completed_at', '>', $since);
+
+        return [
+            'failed_default_branch_last_24h' => (clone $failed)->count('workflow_runs.id'),
+            'failed_workflows_sample' => (clone $failed)
+                ->orderByDesc('workflow_runs.run_completed_at')
+                ->orderByDesc('workflow_runs.id')
+                ->limit(self::SAMPLE_LIMIT)
+                ->get([
+                    'workflow_runs.id',
+                    'workflow_runs.run_number',
+                    'workflow_runs.name',
+                    'workflow_runs.conclusion',
+                    'workflow_runs.head_branch',
+                    'workflow_runs.run_completed_at',
+                    'repositories.full_name as repository_full_name',
+                ])
+                ->map(fn (WorkflowRun $run): array => [
+                    'id' => $run->id,
+                    'run_number' => $run->run_number,
+                    'name' => $run->name,
+                    'conclusion' => $run->conclusion?->value,
+                    'head_branch' => $run->head_branch,
+                    'completed_at' => $run->run_completed_at?->toIso8601String(),
+                    'repository_full_name' => $run->repository_full_name,
+                ])
+                ->all(),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function websites(int $projectId): array
+    {
+        return [
+            'by_status' => Website::query()
+                ->where('project_id', $projectId)
+                ->selectRaw('status, COUNT(id) as total')
+                ->groupBy('status')
+                ->pluck('total', 'status')
+                ->map(fn ($total): int => (int) $total)
+                ->all(),
+            'problem_sample' => Website::query()
+                ->where('project_id', $projectId)
+                ->whereIn('status', [WebsiteStatus::Down->value, WebsiteStatus::Error->value, WebsiteStatus::Slow->value])
+                ->orderByDesc('last_failure_at')
+                ->orderByDesc('id')
+                ->limit(self::SAMPLE_LIMIT)
+                ->get(['id', 'name', 'status', 'last_checked_at', 'last_failure_at'])
+                ->map(fn (Website $website): array => [
+                    'id' => $website->id,
+                    'name' => $this->sanitizeText($website->name),
+                    'status' => $website->status?->value,
+                    'last_checked_at' => $website->last_checked_at?->toIso8601String(),
+                    'last_failure_at' => $website->last_failure_at?->toIso8601String(),
+                ])
+                ->all(),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function hosts(int $projectId): array
+    {
+        return [
+            'by_status' => Host::query()
+                ->where('project_id', $projectId)
+                ->whereNull('archived_at')
+                ->selectRaw('status, COUNT(id) as total')
+                ->groupBy('status')
+                ->pluck('total', 'status')
+                ->map(fn ($total): int => (int) $total)
+                ->all(),
+            'offline_count' => Host::query()
+                ->where('project_id', $projectId)
+                ->whereNull('archived_at')
+                ->where('status', HostStatus::Offline->value)
+                ->count(),
+            'problem_sample' => Host::query()
+                ->where('project_id', $projectId)
+                ->whereNull('archived_at')
+                ->whereIn('status', [HostStatus::Offline->value, HostStatus::Degraded->value])
+                ->orderByDesc('last_seen_at')
+                ->orderByDesc('id')
+                ->limit(self::SAMPLE_LIMIT)
+                ->get(['id', 'name', 'status', 'last_seen_at'])
+                ->map(fn (Host $host): array => [
+                    'id' => $host->id,
+                    'name' => $this->sanitizeText($host->name),
+                    'status' => $host->status?->value,
+                    'last_seen_at' => $host->last_seen_at?->toIso8601String(),
+                ])
+                ->all(),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function containers(int $projectId): array
+    {
+        return [
+            'by_health_status' => Container::query()
+                ->where('project_id', $projectId)
+                ->selectRaw('COALESCE(health_status, status) as health_key, COUNT(id) as total')
+                ->groupBy('health_key')
+                ->pluck('total', 'health_key')
+                ->map(fn ($total): int => (int) $total)
+                ->all(),
+            'unhealthy_count' => Container::query()
+                ->where('project_id', $projectId)
+                ->where('health_status', 'unhealthy')
+                ->count(),
+            'problem_sample' => Container::query()
+                ->where('project_id', $projectId)
+                ->where(function ($query): void {
+                    $query->where('health_status', 'unhealthy')
+                        ->orWhereIn('status', ['exited', 'dead', 'restarting']);
+                })
+                ->orderByDesc('last_seen_at')
+                ->orderByDesc('id')
+                ->limit(self::SAMPLE_LIMIT)
+                ->get(['id', 'name', 'status', 'health_status', 'last_seen_at'])
+                ->map(fn (Container $container): array => [
+                    'id' => $container->id,
+                    'name' => $this->sanitizeText($container->name),
+                    'status' => $container->status,
+                    'health_status' => $container->health_status,
+                    'last_seen_at' => $container->last_seen_at?->toIso8601String(),
+                ])
+                ->all(),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function githubSync(int $projectId): array
+    {
+        $repositories = Repository::query()
+            ->where('project_id', $projectId);
+
+        return [
+            'repositories_total' => (clone $repositories)->count(),
+            'failed_repositories_sample' => (clone $repositories)
+                ->where(function ($query): void {
+                    $query->whereNotNull('sync_failed_at')
+                        ->orWhereNotNull('issues_sync_failed_at')
+                        ->orWhereNotNull('prs_sync_failed_at')
+                        ->orWhereNotNull('workflow_runs_sync_failed_at');
+                })
+                ->orderByDesc('sync_failed_at')
+                ->orderByDesc('id')
+                ->limit(self::SAMPLE_LIMIT)
+                ->get([
+                    'id',
+                    'full_name',
+                    'sync_status',
+                    'issues_sync_status',
+                    'prs_sync_status',
+                    'workflow_runs_sync_status',
+                    'sync_failed_at',
+                    'issues_sync_failed_at',
+                    'prs_sync_failed_at',
+                    'workflow_runs_sync_failed_at',
+                ])
+                ->map(fn ($repository): array => [
+                    'id' => $repository->id,
+                    'full_name' => $repository->full_name,
+                    'sync_status' => $repository->sync_status?->value,
+                    'issues_sync_status' => $repository->issues_sync_status?->value,
+                    'prs_sync_status' => $repository->prs_sync_status?->value,
+                    'workflow_runs_sync_status' => $repository->workflow_runs_sync_status?->value,
+                    'sync_failed_at' => $repository->sync_failed_at?->toIso8601String(),
+                    'issues_sync_failed_at' => $repository->issues_sync_failed_at?->toIso8601String(),
+                    'prs_sync_failed_at' => $repository->prs_sync_failed_at?->toIso8601String(),
+                    'workflow_runs_sync_failed_at' => $repository->workflow_runs_sync_failed_at?->toIso8601String(),
+                ])
+                ->all(),
+        ];
+    }
+
+    private function sanitizeText(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return preg_replace('/\b[A-Z0-9_]*(TOKEN|SECRET|PASSWORD|KEY)[A-Z0-9_]*\s*[:=]\s*[^\s,;]+/i', '[redacted]', $value);
+    }
+}

--- a/app/Domain/AiInsights/Queries/GetPullRequestRiskInputQuery.php
+++ b/app/Domain/AiInsights/Queries/GetPullRequestRiskInputQuery.php
@@ -13,12 +13,9 @@ use App\Models\Repository;
 use App\Models\User;
 use App\Models\WorkflowRun;
 use Carbon\CarbonImmutable;
-use Illuminate\Support\Str;
 
 class GetPullRequestRiskInputQuery
 {
-    public const BODY_PREVIEW_LIMIT = 500;
-
     public const FAILED_WORKFLOWS_LIMIT = 5;
 
     public const ALERTS_LIMIT = 5;
@@ -77,7 +74,6 @@ class GetPullRequestRiskInputQuery
             'id' => $pullRequest->id,
             'number' => $pullRequest->number,
             'title' => $this->sanitizeText($pullRequest->title),
-            'body_preview' => Str::limit($this->sanitizeText($pullRequest->body_preview), self::BODY_PREVIEW_LIMIT, ''),
             'state' => $pullRequest->state?->value,
             'author_login' => $pullRequest->author_login,
             'base_branch' => $pullRequest->base_branch,

--- a/app/Domain/AiInsights/Queries/GetPullRequestRiskInputQuery.php
+++ b/app/Domain/AiInsights/Queries/GetPullRequestRiskInputQuery.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Domain\AiInsights\Queries;
+
+use App\Enums\AlertSeverity;
+use App\Enums\AlertStatus;
+use App\Enums\HealthScoreBand;
+use App\Enums\WorkflowRunConclusion;
+use App\Enums\WorkflowRunStatus;
+use App\Models\Alert;
+use App\Models\GithubPullRequest;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\WorkflowRun;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Str;
+
+class GetPullRequestRiskInputQuery
+{
+    public const BODY_PREVIEW_LIMIT = 500;
+
+    public const FAILED_WORKFLOWS_LIMIT = 5;
+
+    public const ALERTS_LIMIT = 5;
+
+    /** @return array<string, mixed>|null */
+    public function execute(User $user, GithubPullRequest $pullRequest): ?array
+    {
+        $pullRequest = GithubPullRequest::query()
+            ->with('repository.project')
+            ->whereKey($pullRequest->id)
+            ->whereHas('repository.project', fn ($query) => $query->where('owner_user_id', $user->id))
+            ->first();
+
+        if (! $pullRequest?->repository?->project) {
+            return null;
+        }
+
+        $repository = $pullRequest->repository;
+        $project = $repository->project;
+
+        return [
+            'snapshot_version' => 'pr-risk-input-v1',
+            'generated_at' => CarbonImmutable::now('UTC')->toIso8601String(),
+            'project' => [
+                'id' => $project->id,
+                'name' => $project->name,
+                'slug' => $project->slug,
+                'priority' => $project->priority?->value,
+                'health_score' => $project->health_score,
+                'health_band' => $project->health_score === null
+                    ? null
+                    : HealthScoreBand::fromScore($project->health_score)->value,
+            ],
+            'repository' => [
+                'id' => $repository->id,
+                'full_name' => $repository->full_name,
+                'default_branch' => $repository->default_branch,
+                'visibility' => $repository->visibility,
+                'language' => $repository->language,
+                'sync_status' => $repository->sync_status?->value,
+                'prs_sync_status' => $repository->prs_sync_status?->value,
+                'workflow_runs_sync_status' => $repository->workflow_runs_sync_status?->value,
+            ],
+            'pull_request' => $this->pullRequestFacts($pullRequest, $repository),
+            'recent_failed_workflows' => $this->recentFailedWorkflows($repository, $pullRequest->head_branch),
+            'active_alerts' => $this->activeAlerts($project->id),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function pullRequestFacts(GithubPullRequest $pullRequest, Repository $repository): array
+    {
+        $createdAt = $pullRequest->created_at_github;
+
+        return [
+            'id' => $pullRequest->id,
+            'number' => $pullRequest->number,
+            'title' => $this->sanitizeText($pullRequest->title),
+            'body_preview' => Str::limit($this->sanitizeText($pullRequest->body_preview), self::BODY_PREVIEW_LIMIT, ''),
+            'state' => $pullRequest->state?->value,
+            'author_login' => $pullRequest->author_login,
+            'base_branch' => $pullRequest->base_branch,
+            'head_branch' => $pullRequest->head_branch,
+            'draft' => $pullRequest->draft,
+            'merged' => $pullRequest->merged,
+            'additions' => $pullRequest->additions,
+            'deletions' => $pullRequest->deletions,
+            'changed_files' => $pullRequest->changed_files,
+            'comments_count' => $pullRequest->comments_count,
+            'review_comments_count' => $pullRequest->review_comments_count,
+            'age_days' => $createdAt === null ? null : (int) $createdAt->diffInDays(CarbonImmutable::now('UTC')),
+            'stale' => $pullRequest->updated_at_github !== null
+                && $pullRequest->updated_at_github->lt(CarbonImmutable::now('UTC')->subDays(7)),
+            'created_at' => $pullRequest->created_at_github?->toIso8601String(),
+            'updated_at' => $pullRequest->updated_at_github?->toIso8601String(),
+            'html_url' => "https://github.com/{$repository->full_name}/pull/{$pullRequest->number}",
+        ];
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function recentFailedWorkflows(Repository $repository, ?string $branch): array
+    {
+        $failedConclusions = [
+            WorkflowRunConclusion::Failure->value,
+            WorkflowRunConclusion::TimedOut->value,
+            WorkflowRunConclusion::ActionRequired->value,
+        ];
+
+        return WorkflowRun::query()
+            ->where('repository_id', $repository->id)
+            ->where('status', WorkflowRunStatus::Completed->value)
+            ->whereIn('conclusion', $failedConclusions)
+            ->when($branch !== null && $branch !== '', fn ($query) => $query->where('head_branch', $branch))
+            ->orderByDesc('run_completed_at')
+            ->orderByDesc('id')
+            ->limit(self::FAILED_WORKFLOWS_LIMIT)
+            ->get(['id', 'run_number', 'name', 'event', 'conclusion', 'head_branch', 'run_completed_at'])
+            ->map(fn (WorkflowRun $run): array => [
+                'id' => $run->id,
+                'run_number' => $run->run_number,
+                'name' => $run->name,
+                'event' => $run->event,
+                'conclusion' => $run->conclusion?->value,
+                'head_branch' => $run->head_branch,
+                'completed_at' => $run->run_completed_at?->toIso8601String(),
+            ])
+            ->all();
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function activeAlerts(int $projectId): array
+    {
+        return Alert::query()
+            ->where('project_id', $projectId)
+            ->whereIn('status', [AlertStatus::Open->value, AlertStatus::Acknowledged->value])
+            ->whereIn('severity', [AlertSeverity::Critical->value, AlertSeverity::Warning->value])
+            ->orderByRaw("CASE severity WHEN 'critical' THEN 0 WHEN 'warning' THEN 1 ELSE 2 END")
+            ->orderByDesc('last_seen_at')
+            ->orderByDesc('id')
+            ->limit(self::ALERTS_LIMIT)
+            ->get(['id', 'source', 'type', 'severity', 'status', 'title', 'triggered_at', 'last_seen_at'])
+            ->map(fn (Alert $alert): array => [
+                'id' => $alert->id,
+                'source' => $alert->source?->value,
+                'type' => $alert->type,
+                'severity' => $alert->severity?->value,
+                'status' => $alert->status?->value,
+                'title' => $this->sanitizeText($alert->title),
+                'triggered_at' => $alert->triggered_at?->toIso8601String(),
+                'last_seen_at' => $alert->last_seen_at?->toIso8601String(),
+            ])
+            ->all();
+    }
+
+    private function sanitizeText(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return preg_replace('/\b[A-Z0-9_]*(TOKEN|SECRET|PASSWORD|KEY)[A-Z0-9_]*\s*[:=]\s*[^\s,;]+/i', '[redacted]', $value);
+    }
+}

--- a/app/Domain/Analytics/Actions/RefreshProjectHealthScoreAction.php
+++ b/app/Domain/Analytics/Actions/RefreshProjectHealthScoreAction.php
@@ -2,9 +2,11 @@
 
 namespace App\Domain\Analytics\Actions;
 
+use App\Domain\AiInsights\Jobs\GenerateProjectHealthExplanationJob;
 use App\Enums\HealthScoreBand;
 use App\Events\HealthScoreUpdated;
 use App\Models\Project;
+use App\Models\ProjectHealthExplanation;
 use App\Models\User;
 
 /**
@@ -22,6 +24,12 @@ use App\Models\User;
  */
 class RefreshProjectHealthScoreAction
 {
+    private const MATERIAL_SCORE_DELTA = 5;
+
+    private const EXPLANATION_STALE_AFTER_DAYS = 7;
+
+    private const EXPLANATION_RATE_LIMIT_MINUTES = 30;
+
     public function __construct(
         private readonly ComputeProjectHealthScoreAction $compute,
     ) {}
@@ -39,21 +47,77 @@ class RefreshProjectHealthScoreAction
             ? $this->compute->executeForUser($project, $owner)
             : $this->compute->execute($project);
 
-        if ($project->health_score === $newScore) {
+        $oldScore = $project->health_score;
+        $oldBand = $oldScore === null ? null : HealthScoreBand::fromScore($oldScore);
+        $newBand = HealthScoreBand::fromScore($newScore);
+
+        $shouldDispatchHealthExplanation = $this->shouldDispatchHealthExplanation($project, $oldScore, $newScore, $oldBand, $newBand);
+
+        if ($oldScore === $newScore) {
+            if ($shouldDispatchHealthExplanation) {
+                GenerateProjectHealthExplanationJob::dispatch($project->id);
+            }
+
             return $newScore;
         }
 
         $project->forceFill(['health_score' => $newScore])->save();
 
-        $band = HealthScoreBand::fromScore($newScore);
+        if ($shouldDispatchHealthExplanation) {
+            GenerateProjectHealthExplanationJob::dispatch($project->id);
+        }
 
         HealthScoreUpdated::dispatch(
             $project->id,
             $project->owner_user_id,
             $newScore,
-            $band->value,
+            $newBand->value,
         );
 
         return $newScore;
+    }
+
+    private function shouldDispatchHealthExplanation(
+        Project $project,
+        ?int $oldScore,
+        int $newScore,
+        ?HealthScoreBand $oldBand,
+        HealthScoreBand $newBand,
+    ): bool {
+        if (! config('services.llm.enabled', false)) {
+            return false;
+        }
+
+        $explanation = ProjectHealthExplanation::query()
+            ->where('project_id', $project->id)
+            ->first();
+
+        if ($this->rateLimited($explanation)) {
+            return false;
+        }
+
+        if ($explanation === null || $explanation->explained_at === null) {
+            return true;
+        }
+
+        if ($oldBand !== null && $oldBand !== $newBand) {
+            return true;
+        }
+
+        if ($oldScore !== null && abs($oldScore - $newScore) >= self::MATERIAL_SCORE_DELTA) {
+            return true;
+        }
+
+        return $explanation->explained_at->lte(now()->subDays(self::EXPLANATION_STALE_AFTER_DAYS));
+    }
+
+    private function rateLimited(?ProjectHealthExplanation $explanation): bool
+    {
+        if ($explanation === null) {
+            return false;
+        }
+
+        return $explanation->updated_at !== null
+            && $explanation->updated_at->gt(now()->subMinutes(self::EXPLANATION_RATE_LIMIT_MINUTES));
     }
 }

--- a/app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php
+++ b/app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php
@@ -7,6 +7,7 @@ use App\Enums\AlertSeverity;
 use App\Enums\AlertStatus;
 use App\Enums\HealthScoreBand;
 use App\Enums\HostStatus;
+use App\Enums\ProjectHealthExplanationStatus;
 use App\Models\ActivityEvent;
 use App\Models\Alert;
 use App\Models\Host;
@@ -292,6 +293,7 @@ class GetOverviewDashboardQuery
     private function riskyProjects(User $user): array
     {
         return Project::query()
+            ->with('healthExplanation')
             ->where('owner_user_id', $user->id)
             ->orderByRaw('health_score IS NULL')
             ->orderBy('health_score', 'asc')
@@ -307,18 +309,33 @@ class GetOverviewDashboardQuery
                 'health_score',
                 'last_activity_at',
             ])
-            ->map(fn (Project $p): array => [
-                'id' => $p->id,
-                'slug' => $p->slug,
-                'name' => $p->name,
-                'color' => $p->color,
-                'icon' => $p->icon,
-                'health_score' => $p->health_score,
-                'health_band' => $p->health_score === null
-                    ? null
-                    : HealthScoreBand::fromScore($p->health_score)->value,
-                'last_activity_at' => $p->last_activity_at?->diffForHumans(),
-            ])
+            ->map(function (Project $p): array {
+                $explanation = $p->healthExplanation;
+
+                return [
+                    'id' => $p->id,
+                    'slug' => $p->slug,
+                    'name' => $p->name,
+                    'color' => $p->color,
+                    'icon' => $p->icon,
+                    'health_score' => $p->health_score,
+                    'health_band' => $p->health_score === null
+                        ? null
+                        : HealthScoreBand::fromScore($p->health_score)->value,
+                    'health_explanation' => $explanation === null ? null : [
+                        'status' => $explanation->status->value,
+                        'summary' => $explanation->summary,
+                        'drivers' => $explanation->drivers ?? [],
+                        'recommended_actions' => $explanation->recommended_actions ?? [],
+                        'explained_at' => $explanation->explained_at?->diffForHumans(),
+                        'failed_at' => $explanation->failed_at?->diffForHumans(),
+                        'error_message' => $explanation->status === ProjectHealthExplanationStatus::Failed
+                            ? $explanation->error_message
+                            : null,
+                    ],
+                    'last_activity_at' => $p->last_activity_at?->diffForHumans(),
+                ];
+            })
             ->all();
     }
 

--- a/app/Domain/GitHub/Queries/WorkItemsForUserQuery.php
+++ b/app/Domain/GitHub/Queries/WorkItemsForUserQuery.php
@@ -4,6 +4,7 @@ namespace App\Domain\GitHub\Queries;
 
 use App\Models\GithubIssue;
 use App\Models\GithubPullRequest;
+use App\Models\PullRequestRiskAssessment;
 use App\Models\Repository;
 use App\Models\User;
 use Illuminate\Support\Collection;
@@ -138,7 +139,10 @@ class WorkItemsForUserQuery
     private function fetchPullRequests(Collection $repositoryIds, string $state, ?string $search): Collection
     {
         $query = GithubPullRequest::query()
-            ->with('repository:id,full_name,name')
+            ->with([
+                'repository:id,full_name,name',
+                'riskAssessment',
+            ])
             ->whereIn('repository_id', $repositoryIds);
 
         if ($state !== 'all') {
@@ -175,7 +179,30 @@ class WorkItemsForUserQuery
                     'full_name' => $pr->repository->full_name,
                     'name' => $pr->repository->name,
                 ] : null,
+                'risk_assessment' => $this->riskAssessmentPayload($pr->riskAssessment),
             ]);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function riskAssessmentPayload(?PullRequestRiskAssessment $assessment): ?array
+    {
+        if ($assessment === null) {
+            return null;
+        }
+
+        return [
+            'status' => $assessment->status?->value,
+            'risk_level' => $assessment->risk_level?->value,
+            'risk_score' => $assessment->risk_score,
+            'summary' => $assessment->summary,
+            'reasons' => $assessment->reasons ?? [],
+            'recommended_actions' => $assessment->recommended_actions ?? [],
+            'assessed_at' => $assessment->assessed_at?->diffForHumans(),
+            'failed_at' => $assessment->failed_at?->diffForHumans(),
+            'error_message' => $assessment->error_message,
+        ];
     }
 
     /**

--- a/app/Domain/GitHub/WebhookHandlers/PullRequestWebhookHandler.php
+++ b/app/Domain/GitHub/WebhookHandlers/PullRequestWebhookHandler.php
@@ -3,6 +3,7 @@
 namespace App\Domain\GitHub\WebhookHandlers;
 
 use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Domain\AiInsights\Jobs\GeneratePullRequestRiskAssessmentJob;
 use App\Domain\GitHub\Actions\NormalizeGitHubPullRequestAction;
 use App\Enums\ActivitySeverity;
 use App\Enums\WebhookDeliveryStatus;
@@ -77,7 +78,7 @@ class PullRequestWebhookHandler
             return WebhookDeliveryStatus::Skipped;
         }
 
-        GithubPullRequest::query()->updateOrCreate(
+        $pullRequest = GithubPullRequest::query()->updateOrCreate(
             [
                 'repository_id' => $repository->id,
                 'github_id' => $normalized['github_id'],
@@ -87,6 +88,10 @@ class PullRequestWebhookHandler
                 'synced_at' => now(),
             ],
         );
+
+        if (config('services.llm.enabled', false) && $this->shouldDispatchRiskAssessment($action)) {
+            GeneratePullRequestRiskAssessmentJob::dispatch($pullRequest->id);
+        }
 
         $sender = $payload['sender']['login'] ?? null;
 
@@ -118,10 +123,25 @@ class PullRequestWebhookHandler
         return match ($action) {
             'opened' => ['type' => 'pull_request.opened', 'severity' => ActivitySeverity::Info],
             'reopened' => ['type' => 'pull_request.reopened', 'severity' => ActivitySeverity::Info],
+            'synchronize' => ['type' => 'pull_request.synchronize', 'severity' => ActivitySeverity::Info],
+            'ready_for_review' => ['type' => 'pull_request.ready_for_review', 'severity' => ActivitySeverity::Info],
+            'edited' => ['type' => 'pull_request.edited', 'severity' => ActivitySeverity::Info],
             'review_requested' => ['type' => 'pull_request.review_requested', 'severity' => ActivitySeverity::Info],
             'closed' => $this->resolveClosedRule($prPayload),
             default => null,
         };
+    }
+
+    private function shouldDispatchRiskAssessment(string $action): bool
+    {
+        return in_array($action, [
+            'opened',
+            'reopened',
+            'synchronize',
+            'ready_for_review',
+            'edited',
+            'review_requested',
+        ], true);
     }
 
     /**

--- a/app/Enums/AlertSource.php
+++ b/app/Enums/AlertSource.php
@@ -6,7 +6,7 @@ namespace App\Enums;
  * Origin domain of an Alert (spec 030). Matches roadmap §8.12.
  *
  * Spec 030 only emits `website` / `docker` / `deployment`; `github` is
- * reserved for future repo-scoped alerts (stale PR, merge conflict);
+ * reserved for repo/PR-scoped alerts (stale PR, PR risk, merge conflict);
  * `manual` is the user-pressed-the-button path; `system` is for Nexus's
  * own self-checks.
  *
@@ -14,7 +14,7 @@ namespace App\Enums;
  *   website     → websites.id
  *   docker      → hosts.id
  *   deployment  → workflow_runs.id
- *   github      → repositories.id
+ *   github      → repositories.id or github_pull_requests.id, depending on type
  *   manual      → null
  *   system      → null
  */

--- a/app/Enums/ProjectHealthExplanationStatus.php
+++ b/app/Enums/ProjectHealthExplanationStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum ProjectHealthExplanationStatus: string
+{
+    case Pending = 'pending';
+    case Explained = 'explained';
+    case Failed = 'failed';
+    case Skipped = 'skipped';
+}

--- a/app/Enums/PullRequestRiskAssessmentStatus.php
+++ b/app/Enums/PullRequestRiskAssessmentStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum PullRequestRiskAssessmentStatus: string
+{
+    case Pending = 'pending';
+    case Scored = 'scored';
+    case Failed = 'failed';
+    case Skipped = 'skipped';
+}

--- a/app/Enums/PullRequestRiskLevel.php
+++ b/app/Enums/PullRequestRiskLevel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum PullRequestRiskLevel: string
+{
+    case Low = 'low';
+    case Medium = 'medium';
+    case High = 'high';
+    case Critical = 'critical';
+}

--- a/app/Http/Controllers/OverviewController.php
+++ b/app/Http/Controllers/OverviewController.php
@@ -49,6 +49,7 @@ class OverviewController extends Controller
 
         return Inertia::render('Overview', array_merge($payload, [
             'topWorkItems' => $topWorkItems,
+            'canRegenerateProjectHealthExplanation' => config('services.llm.enabled', false),
         ]));
     }
 }

--- a/app/Http/Controllers/ProjectHealthExplanationRegenerationController.php
+++ b/app/Http/Controllers/ProjectHealthExplanationRegenerationController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\AiInsights\Jobs\GenerateProjectHealthExplanationJob;
+use App\Enums\HealthScoreBand;
+use App\Enums\ProjectHealthExplanationStatus;
+use App\Models\Project;
+use App\Models\ProjectHealthExplanation;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class ProjectHealthExplanationRegenerationController extends Controller
+{
+    public function __invoke(Request $request, Project $project): RedirectResponse
+    {
+        abort_unless($request->user()?->can('update', $project), 403);
+
+        if (! config('services.llm.enabled', false)) {
+            return back()->withErrors([
+                'health_explanation' => 'AI insights are disabled for this environment.',
+            ]);
+        }
+
+        ProjectHealthExplanation::query()->updateOrCreate(
+            ['project_id' => $project->id],
+            [
+                'status' => ProjectHealthExplanationStatus::Pending->value,
+                'health_score' => $project->health_score ?? 0,
+                'health_band' => HealthScoreBand::fromScore($project->health_score ?? 0)->value,
+                'failed_at' => null,
+                'error_message' => null,
+            ],
+        );
+
+        GenerateProjectHealthExplanationJob::dispatch($project->id);
+
+        return back()->with('status', 'Project health explanation queued.');
+    }
+}

--- a/app/Http/Controllers/PullRequestRiskRegenerationController.php
+++ b/app/Http/Controllers/PullRequestRiskRegenerationController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\AiInsights\Jobs\GeneratePullRequestRiskAssessmentJob;
+use App\Enums\PullRequestRiskAssessmentStatus;
+use App\Models\GithubPullRequest;
+use App\Models\PullRequestRiskAssessment;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class PullRequestRiskRegenerationController extends Controller
+{
+    public function __invoke(Request $request, GithubPullRequest $pullRequest): RedirectResponse
+    {
+        $pullRequest->loadMissing('repository.project');
+
+        $project = $pullRequest->repository?->project;
+
+        abort_unless(
+            $project !== null && $request->user()?->can('update', $project),
+            403,
+        );
+
+        if (! config('services.llm.enabled', false)) {
+            return back()->withErrors([
+                'risk' => 'AI insights are disabled for this environment.',
+            ]);
+        }
+
+        PullRequestRiskAssessment::query()->updateOrCreate(
+            ['github_pull_request_id' => $pullRequest->id],
+            [
+                'status' => PullRequestRiskAssessmentStatus::Pending->value,
+                'failed_at' => null,
+                'error_message' => null,
+            ],
+        );
+
+        GeneratePullRequestRiskAssessmentJob::dispatch($pullRequest->id);
+
+        return back()->with('status', 'PR risk assessment queued.');
+    }
+}

--- a/app/Http/Controllers/WorkItemController.php
+++ b/app/Http/Controllers/WorkItemController.php
@@ -60,6 +60,7 @@ class WorkItemController extends Controller
             'items' => $items,
             'repositories' => $repositories,
             'filters' => $filters,
+            'canRegeneratePrRisk' => config('services.llm.enabled', false),
         ]);
     }
 }

--- a/app/Models/GithubPullRequest.php
+++ b/app/Models/GithubPullRequest.php
@@ -7,6 +7,7 @@ use Database\Factories\GithubPullRequestFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class GithubPullRequest extends Model
 {
@@ -61,5 +62,10 @@ class GithubPullRequest extends Model
     public function repository(): BelongsTo
     {
         return $this->belongsTo(Repository::class);
+    }
+
+    public function riskAssessment(): HasOne
+    {
+        return $this->hasOne(PullRequestRiskAssessment::class);
     }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Str;
 
 class Project extends Model
@@ -88,5 +89,10 @@ class Project extends Model
     public function repositories(): HasMany
     {
         return $this->hasMany(Repository::class);
+    }
+
+    public function healthExplanation(): HasOne
+    {
+        return $this->hasOne(ProjectHealthExplanation::class);
     }
 }

--- a/app/Models/ProjectHealthExplanation.php
+++ b/app/Models/ProjectHealthExplanation.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\HealthScoreBand;
+use App\Enums\ProjectHealthExplanationStatus;
+use Database\Factories\ProjectHealthExplanationFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ProjectHealthExplanation extends Model
+{
+    /** @use HasFactory<ProjectHealthExplanationFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'project_id',
+        'status',
+        'health_score',
+        'health_band',
+        'summary',
+        'drivers',
+        'recommended_actions',
+        'input_snapshot',
+        'prompt_version',
+        'model',
+        'explained_at',
+        'failed_at',
+        'error_message',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => ProjectHealthExplanationStatus::class,
+            'health_score' => 'integer',
+            'health_band' => HealthScoreBand::class,
+            'drivers' => 'array',
+            'recommended_actions' => 'array',
+            'input_snapshot' => 'array',
+            'explained_at' => 'immutable_datetime',
+            'failed_at' => 'immutable_datetime',
+        ];
+    }
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+}

--- a/app/Models/PullRequestRiskAssessment.php
+++ b/app/Models/PullRequestRiskAssessment.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\PullRequestRiskAssessmentStatus;
+use App\Enums\PullRequestRiskLevel;
+use Database\Factories\PullRequestRiskAssessmentFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PullRequestRiskAssessment extends Model
+{
+    /** @use HasFactory<PullRequestRiskAssessmentFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'github_pull_request_id',
+        'status',
+        'risk_level',
+        'risk_score',
+        'summary',
+        'reasons',
+        'recommended_actions',
+        'input_snapshot',
+        'prompt_version',
+        'model',
+        'assessed_at',
+        'failed_at',
+        'error_message',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'status' => PullRequestRiskAssessmentStatus::class,
+            'risk_level' => PullRequestRiskLevel::class,
+            'risk_score' => 'integer',
+            'reasons' => 'array',
+            'recommended_actions' => 'array',
+            'input_snapshot' => 'array',
+            'assessed_at' => 'immutable_datetime',
+            'failed_at' => 'immutable_datetime',
+        ];
+    }
+
+    public function pullRequest(): BelongsTo
+    {
+        return $this->belongsTo(GithubPullRequest::class, 'github_pull_request_id');
+    }
+}

--- a/database/factories/ProjectHealthExplanationFactory.php
+++ b/database/factories/ProjectHealthExplanationFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\HealthScoreBand;
+use App\Enums\ProjectHealthExplanationStatus;
+use App\Models\Project;
+use App\Models\ProjectHealthExplanation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<ProjectHealthExplanation> */
+class ProjectHealthExplanationFactory extends Factory
+{
+    protected $model = ProjectHealthExplanation::class;
+
+    public function definition(): array
+    {
+        return [
+            'project_id' => Project::factory(),
+            'status' => ProjectHealthExplanationStatus::Pending->value,
+            'health_score' => 75,
+            'health_band' => HealthScoreBand::Good->value,
+            'summary' => null,
+            'drivers' => [],
+            'recommended_actions' => [],
+            'input_snapshot' => null,
+            'prompt_version' => 'project-health-explanation-v1',
+            'model' => null,
+            'explained_at' => null,
+            'failed_at' => null,
+            'error_message' => null,
+        ];
+    }
+
+    public function explained(): static
+    {
+        return $this->state(fn () => [
+            'status' => ProjectHealthExplanationStatus::Explained->value,
+            'health_score' => 42,
+            'health_band' => HealthScoreBand::Warning->value,
+            'summary' => 'Health dropped because alerts and failed checks increased.',
+            'drivers' => ['2 critical alerts', '1 failing website check'],
+            'recommended_actions' => ['Investigate the critical alerts first'],
+            'input_snapshot' => ['project' => ['health_score' => 42]],
+            'model' => 'claude-3-5-haiku-latest',
+            'explained_at' => now(),
+        ]);
+    }
+}

--- a/database/factories/PullRequestRiskAssessmentFactory.php
+++ b/database/factories/PullRequestRiskAssessmentFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\PullRequestRiskAssessmentStatus;
+use App\Enums\PullRequestRiskLevel;
+use App\Models\GithubPullRequest;
+use App\Models\PullRequestRiskAssessment;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/** @extends Factory<PullRequestRiskAssessment> */
+class PullRequestRiskAssessmentFactory extends Factory
+{
+    protected $model = PullRequestRiskAssessment::class;
+
+    public function definition(): array
+    {
+        return [
+            'github_pull_request_id' => GithubPullRequest::factory(),
+            'status' => PullRequestRiskAssessmentStatus::Pending->value,
+            'risk_level' => null,
+            'risk_score' => null,
+            'summary' => null,
+            'reasons' => [],
+            'recommended_actions' => [],
+            'input_snapshot' => null,
+            'prompt_version' => 'pr-risk-v1',
+            'model' => null,
+            'assessed_at' => null,
+            'failed_at' => null,
+            'error_message' => null,
+        ];
+    }
+
+    public function scored(): static
+    {
+        return $this->state(fn () => [
+            'status' => PullRequestRiskAssessmentStatus::Scored->value,
+            'risk_level' => PullRequestRiskLevel::High->value,
+            'risk_score' => 82,
+            'summary' => 'Large PR with failing checks needs careful review.',
+            'reasons' => ['Large change size', 'Recent workflow failure'],
+            'recommended_actions' => ['Review failing workflow before merge'],
+            'input_snapshot' => ['pull_request' => ['number' => 42, 'changed_files' => 18]],
+            'model' => 'claude-3-5-haiku-latest',
+            'assessed_at' => now(),
+        ]);
+    }
+}

--- a/database/migrations/2026_05_27_080000_create_alerts_table.php
+++ b/database/migrations/2026_05_27_080000_create_alerts_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
 
             // website | docker | deployment | github | manual | system
             // (per AlertSource enum, subset of roadmap §8.12). `github` is
-            // reserved for future repo-scoped alerts; spec 030 only
+            // reserved for repo/PR-scoped alerts; spec 030 only
             // emits website / docker / deployment.
             $table->string('source', 16);
 

--- a/database/migrations/2026_07_21_150000_create_pull_request_risk_assessments_table.php
+++ b/database/migrations/2026_07_21_150000_create_pull_request_risk_assessments_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pull_request_risk_assessments', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('github_pull_request_id')
+                ->constrained('github_pull_requests')
+                ->cascadeOnDelete();
+
+            $table->string('status', 16)->default('pending')->index();
+            $table->string('risk_level', 16)->nullable()->index();
+            $table->unsignedTinyInteger('risk_score')->nullable();
+            $table->text('summary')->nullable();
+            $table->json('reasons')->nullable();
+            $table->json('recommended_actions')->nullable();
+            $table->json('input_snapshot')->nullable();
+            $table->string('prompt_version')->default('pr-risk-v1');
+            $table->string('model')->nullable();
+            $table->timestamp('assessed_at')->nullable();
+            $table->timestamp('failed_at')->nullable();
+            $table->text('error_message')->nullable();
+
+            $table->timestamps();
+
+            $table->unique('github_pull_request_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pull_request_risk_assessments');
+    }
+};

--- a/database/migrations/2026_07_21_150001_create_project_health_explanations_table.php
+++ b/database/migrations/2026_07_21_150001_create_project_health_explanations_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('project_health_explanations', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('project_id')
+                ->constrained('projects')
+                ->cascadeOnDelete();
+
+            $table->string('status', 16)->default('pending')->index();
+            $table->unsignedTinyInteger('health_score');
+            $table->string('health_band', 16)->nullable()->index();
+            $table->text('summary')->nullable();
+            $table->json('drivers')->nullable();
+            $table->json('recommended_actions')->nullable();
+            $table->json('input_snapshot')->nullable();
+            $table->string('prompt_version')->default('project-health-explanation-v1');
+            $table->string('model')->nullable();
+            $table->timestamp('explained_at')->nullable();
+            $table->timestamp('failed_at')->nullable();
+            $table->text('error_message')->nullable();
+
+            $table->timestamps();
+
+            $table->unique('project_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('project_health_explanations');
+    }
+};

--- a/docs/security/operator-checklist.md
+++ b/docs/security/operator-checklist.md
@@ -94,6 +94,8 @@ Per-user limits via Laravel's `throttle:N,1` middleware:
 | `POST /settings/notifications/deliveries/{delivery}/retry` | 30/min (spec 042) |
 | `PATCH /settings/daily-briefing` | 20/min (spec 044) |
 | `POST /settings/daily-briefing/test` | 5/min (spec 044) |
+| `POST /work-items/pull-requests/{pullRequest}/risk/regenerate` | 10/min (spec 045) |
+| `POST /overview/projects/{project}/health-explanation/regenerate` | 10/min (spec 045) |
 | `PATCH /settings/rules/weights` | 20/min (spec 046) |
 | `DELETE /settings/rules/weights` | 20/min (spec 046) |
 | `POST /settings/rules` | 10/min (spec 046) |
@@ -158,6 +160,32 @@ Operators should verify:
   entity metadata, timestamps, labels, and short snippets, not secrets,
   tokens, webhook URLs, raw logs, or full issue/PR bodies.
 
+### AI PR risk + health explanations (spec 045)
+
+PR-risk scoring and project-health explanations reuse the shared LLM gate
+from spec 044. Keep the operator posture conservative:
+
+- **Feature gate.** Leave `AI_FEATURES_ENABLED=false` until an LLM provider,
+  model, timeout, and budget posture are approved for production.
+- **Prompt safety.** PR risk and health explanation input snapshots are
+  bounded Nexus metadata only. They must not include raw diffs, raw logs,
+  access tokens, webhook URLs, provider headers, environment values, or full
+  PR bodies.
+- **Webhook trigger.** Only PR webhook actions that can materially change
+  review risk enqueue PR-risk generation: opened, reopened, synchronize,
+  ready-for-review, edited, and review-requested.
+- **Notifications.** High/critical PR risk uses verified spec 042 channels
+  through the normal alert-notification routing. A PR creates at most one
+  notification per material increase to `high` or `critical`; unchanged
+  `low`/`medium` scores stay quiet.
+- **Regenerate controls.** Work Items PR-risk regenerate and Overview
+  health-explanation regenerate are owner-only, AI-gated, and throttled at
+  10/min per route.
+- **Health-explanation rate limit.** Automatic health explanation refreshes
+  only enqueue after material score/band changes or stale explanations, and
+  are rate-limited per project so noisy alerts do not produce repeated LLM
+  calls.
+
 ## 7. Deferred to follow-ups
 
 Documented for visibility; not blockers for spec 039 sign-off:
@@ -187,4 +215,7 @@ Documented for visibility; not blockers for spec 039 sign-off:
       rest; outbound webhook HMAC available on demand.
 - [ ] §6 (spec 044): AI daily briefing gate, throttles, scheduler, and
       sanitized LLM input reviewed before enabling `AI_FEATURES_ENABLED`.
+- [ ] §6 (spec 045): AI PR-risk/health prompt safety, webhook trigger,
+      notification, regenerate, and rate-limit posture reviewed before
+      enabling `AI_FEATURES_ENABLED`.
 - [ ] Run the suite: `php artisan test --filter=Security` passes.

--- a/resources/js/Components/Dashboard/RiskyProjects.vue
+++ b/resources/js/Components/Dashboard/RiskyProjects.vue
@@ -2,8 +2,8 @@
 import HealthScoreBadge from '@/Components/Project/HealthScoreBadge.vue';
 import { projectIcon } from '@/lib/projectIcons';
 import type { RiskyProjectRow } from '@/types';
-import { Link } from '@inertiajs/vue3';
-import { FolderKanban, ShieldCheck } from 'lucide-vue-next';
+import { Link, router } from '@inertiajs/vue3';
+import { FolderKanban, RefreshCw, ShieldCheck } from 'lucide-vue-next';
 import { computed } from 'vue';
 
 /**
@@ -25,6 +25,7 @@ import { computed } from 'vue';
  */
 const props = defineProps<{
     projects: RiskyProjectRow[];
+    canRegenerate: boolean;
 }>();
 
 const HIDING_BANDS = new Set(['healthy', 'good']);
@@ -57,6 +58,22 @@ const iconAccentClass = (color: string | null): string => {
             return 'text-text-secondary';
     }
 };
+
+const fallbackSummary = (project: RiskyProjectRow): string => {
+    if (project.health_score === null) {
+        return 'Nexus has not computed a health score for this project yet.';
+    }
+
+    return `Nexus is showing a ${project.health_band ?? 'unknown'} health band at ${project.health_score}/100. Regenerate an AI explanation to summarize the current drivers.`;
+};
+
+const regenerateExplanation = (project: RiskyProjectRow): void => {
+    router.post(
+        route('overview.projects.health-explanation.regenerate', project.slug),
+        {},
+        { preserveScroll: true },
+    );
+};
 </script>
 
 <template>
@@ -87,40 +104,123 @@ const iconAccentClass = (color: string | null): string => {
                 v-for="project in props.projects.filter((p) => p.health_band !== null && !HIDING_BANDS.has(p.health_band))"
                 :key="project.id"
             >
-                <Link
-                    :href="route('projects.show', project.slug)"
-                    class="group flex items-center justify-between gap-3 rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 transition hover:border-accent-cyan/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                <article
+                    class="rounded-lg border border-border-subtle bg-background-panel-hover px-3 py-2 transition hover:border-accent-cyan/40"
                 >
-                    <div class="flex min-w-0 items-center gap-3">
-                        <span
-                            class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border-subtle bg-background-panel"
+                    <div class="flex items-center justify-between gap-3">
+                        <Link
+                            :href="route('projects.show', project.slug)"
+                            class="group flex min-w-0 items-center gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
                         >
-                            <component
-                                :is="projectIcon(project.icon) ?? FolderKanban"
-                                class="h-4 w-4"
-                                :class="iconAccentClass(project.color)"
-                                aria-hidden="true"
-                            />
-                        </span>
-                        <div class="flex min-w-0 flex-col">
                             <span
-                                class="truncate text-sm font-semibold text-text-primary group-hover:text-accent-cyan"
+                                class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-border-subtle bg-background-panel"
                             >
-                                {{ project.name }}
+                                <component
+                                    :is="projectIcon(project.icon) ?? FolderKanban"
+                                    class="h-4 w-4"
+                                    :class="iconAccentClass(project.color)"
+                                    aria-hidden="true"
+                                />
                             </span>
-                            <span
-                                v-if="project.last_activity_at"
-                                class="truncate text-[11px] text-text-muted"
-                            >
-                                {{ project.last_activity_at }}
-                            </span>
-                        </div>
+                            <div class="flex min-w-0 flex-col">
+                                <span
+                                    class="truncate text-sm font-semibold text-text-primary group-hover:text-accent-cyan"
+                                >
+                                    {{ project.name }}
+                                </span>
+                                <span
+                                    v-if="project.last_activity_at"
+                                    class="truncate text-[11px] text-text-muted"
+                                >
+                                    {{ project.last_activity_at }}
+                                </span>
+                            </div>
+                        </Link>
+                        <HealthScoreBadge
+                            :score="project.health_score"
+                            :band="project.health_band"
+                        />
                     </div>
-                    <HealthScoreBadge
-                        :score="project.health_score"
-                        :band="project.health_band"
-                    />
-                </Link>
+
+                    <details class="group/explanation mt-2 rounded-md border border-border-subtle bg-background-panel/70 px-3 py-2">
+                        <summary class="cursor-pointer list-none text-[11px] font-semibold uppercase tracking-[0.2em] text-accent-cyan transition hover:text-accent-cyan/80">
+                            Why?
+                        </summary>
+
+                        <div class="mt-3 space-y-3 text-xs text-text-secondary">
+                            <p v-if="project.health_explanation?.status === 'pending'">
+                                AI explanation is being generated. Refresh will update this card when the job finishes.
+                            </p>
+                            <p v-else-if="project.health_explanation?.status === 'failed'">
+                                Explanation failed{{ project.health_explanation.failed_at ? ` ${project.health_explanation.failed_at}` : '' }}.
+                                <span v-if="project.health_explanation.error_message">
+                                    {{ project.health_explanation.error_message }}
+                                </span>
+                            </p>
+                            <p v-else-if="project.health_explanation?.status === 'explained' && project.health_explanation.summary">
+                                {{ project.health_explanation.summary }}
+                            </p>
+                            <p v-else>
+                                {{ fallbackSummary(project) }}
+                            </p>
+
+                            <div v-if="project.health_explanation?.drivers.length" class="space-y-1">
+                                <p class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted">
+                                    Drivers
+                                </p>
+                                <ul class="space-y-1">
+                                    <li
+                                        v-for="driver in project.health_explanation.drivers"
+                                        :key="driver"
+                                    >
+                                        {{ driver }}
+                                    </li>
+                                </ul>
+                            </div>
+
+                            <div v-if="project.health_explanation?.recommended_actions.length" class="space-y-1">
+                                <p class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted">
+                                    Recommended actions
+                                </p>
+                                <ul class="space-y-1">
+                                    <li
+                                        v-for="action in project.health_explanation.recommended_actions"
+                                        :key="action"
+                                    >
+                                        {{ action }}
+                                    </li>
+                                </ul>
+                            </div>
+
+                            <div class="flex flex-col gap-2 border-t border-border-subtle pt-3 sm:flex-row sm:items-center sm:justify-between">
+                                <span class="font-mono text-[10px] text-text-muted">
+                                    <template v-if="project.health_explanation?.explained_at">
+                                        Explained {{ project.health_explanation.explained_at }}
+                                    </template>
+                                    <template v-else-if="project.health_explanation?.status === 'pending'">
+                                        Pending generation
+                                    </template>
+                                    <template v-else-if="project.health_explanation?.status === 'failed'">
+                                        Failed generation
+                                    </template>
+                                    <template v-else>
+                                        No AI explanation yet
+                                    </template>
+                                </span>
+
+                                <button
+                                    v-if="props.canRegenerate"
+                                    type="button"
+                                    class="inline-flex items-center justify-center gap-1.5 rounded-md border border-accent-cyan/30 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.16em] text-accent-cyan transition hover:border-accent-cyan/60 hover:bg-accent-cyan/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                    @click="regenerateExplanation(project)"
+                                >
+                                    <RefreshCw class="h-3 w-3" aria-hidden="true" />
+                                    Regenerate
+                                </button>
+                            </div>
+                        </div>
+                    </details>
+                </article>
             </li>
         </ul>
 

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -41,6 +41,7 @@ defineProps<{
     dashboard: DashboardPayload;
     activityHeatmap: ActivityHeatmapPayload;
     topWorkItems: TopWorkItem[];
+    canRegenerateProjectHealthExplanation: boolean;
 }>();
 
 // ─── Reverb subscription (spec 033) ──────────────────────────────────
@@ -567,7 +568,10 @@ const visualizationStubs = [
                      `users.{id}.dashboard` subscription wired in
                      spec 033. -->
                 <div class="lg:col-span-12">
-                    <RiskyProjects :projects="dashboard.riskyProjects" />
+                    <RiskyProjects
+                        :projects="dashboard.riskyProjects"
+                        :can-regenerate="canRegenerateProjectHealthExplanation"
+                    />
                 </div>
 
                 <!-- Activity Heatmap — 7 days × 6 four-hour buckets per §8.11 -->

--- a/resources/js/Pages/WorkItems/Index.vue
+++ b/resources/js/Pages/WorkItems/Index.vue
@@ -9,6 +9,7 @@ import {
     Inbox,
     MessageSquare,
     Search,
+    Sparkles,
 } from 'lucide-vue-next';
 import { reactive, watch } from 'vue';
 
@@ -30,6 +31,19 @@ interface WorkItem {
     updated_at_github: string | null;
     html_url: string | null;
     repository: RepositoryRef | null;
+    risk_assessment?: PullRequestRiskAssessment | null;
+}
+
+interface PullRequestRiskAssessment {
+    status: 'pending' | 'scored' | 'failed' | 'skipped' | string | null;
+    risk_level: 'low' | 'medium' | 'high' | 'critical' | string | null;
+    risk_score: number | null;
+    summary: string | null;
+    reasons: string[];
+    recommended_actions: string[];
+    assessed_at: string | null;
+    failed_at: string | null;
+    error_message: string | null;
 }
 
 interface Filters {
@@ -43,6 +57,7 @@ const props = defineProps<{
     items: WorkItem[];
     repositories: { id: number; full_name: string }[];
     filters: Filters;
+    canRegeneratePrRisk: boolean;
 }>();
 
 const local = reactive<Filters>({
@@ -65,6 +80,43 @@ const itemStateTone = (item: WorkItem) => {
         );
     }
     return item.state === 'open' ? 'info' : 'muted';
+};
+
+const riskTone = (assessment: PullRequestRiskAssessment | null | undefined) => {
+    if (!assessment || assessment.status === 'pending') return 'muted';
+    if (assessment.status === 'failed') return 'danger';
+
+    return (
+        (
+            ({
+                low: 'success',
+                medium: 'warning',
+                high: 'danger',
+                critical: 'danger',
+            }) as const
+        )[assessment.risk_level ?? ''] ?? 'muted'
+    );
+};
+
+const riskLabel = (assessment: PullRequestRiskAssessment | null | undefined) => {
+    if (!assessment) return 'Risk not assessed';
+    if (assessment.status === 'pending') return 'Risk pending';
+    if (assessment.status === 'failed') return 'Risk failed';
+    if (assessment.risk_level && assessment.risk_score !== null) {
+        return `${assessment.risk_level} ${assessment.risk_score}`;
+    }
+
+    return assessment.status ?? 'Risk unknown';
+};
+
+const regenerateRisk = (item: WorkItem) => {
+    if (item.kind !== 'pull_request' || !props.canRegeneratePrRisk) return;
+
+    router.post(
+        route('work-items.pull-requests.risk.regenerate', item.id.replace('pull-', '')),
+        {},
+        { preserveScroll: true },
+    );
 };
 
 // Push filter changes to the server. `preserveState: false` re-renders
@@ -237,93 +289,180 @@ watch(
                     <li
                         v-for="item in items"
                         :key="item.id"
-                        class="flex flex-col gap-2 px-6 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
+                        class="flex flex-col gap-3 px-6 py-4"
                     >
-                        <div class="flex min-w-0 items-start gap-3">
-                            <CircleDot
-                                v-if="item.kind === 'issue'"
-                                class="mt-1 h-4 w-4 shrink-0"
-                                :class="
-                                    item.state === 'open'
-                                        ? 'text-accent-cyan'
-                                        : 'text-text-muted'
-                                "
-                                aria-hidden="true"
-                            />
-                            <GitPullRequest
-                                v-else
-                                class="mt-1 h-4 w-4 shrink-0"
-                                :class="{
-                                    'text-accent-cyan': item.state === 'open',
-                                    'text-status-success':
-                                        item.state === 'merged',
-                                    'text-text-muted':
-                                        item.state === 'closed' || !item.state,
-                                }"
-                                aria-hidden="true"
-                            />
-                            <div class="flex min-w-0 flex-col gap-1">
+                        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+                            <div class="flex min-w-0 items-start gap-3">
+                                <CircleDot
+                                    v-if="item.kind === 'issue'"
+                                    class="mt-1 h-4 w-4 shrink-0"
+                                    :class="
+                                        item.state === 'open'
+                                            ? 'text-accent-cyan'
+                                            : 'text-text-muted'
+                                    "
+                                    aria-hidden="true"
+                                />
+                                <GitPullRequest
+                                    v-else
+                                    class="mt-1 h-4 w-4 shrink-0"
+                                    :class="{
+                                        'text-accent-cyan': item.state === 'open',
+                                        'text-status-success':
+                                            item.state === 'merged',
+                                        'text-text-muted':
+                                            item.state === 'closed' || !item.state,
+                                    }"
+                                    aria-hidden="true"
+                                />
+                                <div class="flex min-w-0 flex-col gap-1">
+                                    <a
+                                        v-if="item.html_url"
+                                        :href="item.html_url"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        class="truncate text-sm font-semibold text-text-primary transition hover:text-accent-cyan"
+                                    >
+                                        <span class="font-mono text-text-muted">#{{ item.number }}</span>
+                                        {{ item.title }}
+                                    </a>
+                                    <span
+                                        v-else
+                                        class="truncate text-sm font-semibold text-text-primary"
+                                    >
+                                        <span class="font-mono text-text-muted">#{{ item.number }}</span>
+                                        {{ item.title }}
+                                    </span>
+                                    <p class="text-xs text-text-muted">
+                                        <span
+                                            v-if="item.repository"
+                                            class="font-mono text-text-secondary"
+                                        >
+                                            {{ item.repository.full_name }}
+                                        </span>
+                                        <template v-if="item.author_login">
+                                            ·
+                                            <span class="font-mono text-text-secondary">@{{ item.author_login }}</span>
+                                        </template>
+                                        · Updated {{ item.updated_at_github ?? '—' }}
+                                    </p>
+                                </div>
+                            </div>
+                            <div
+                                class="flex flex-shrink-0 items-center gap-3 text-xs text-text-muted"
+                            >
+                                <StatusBadge
+                                    v-if="item.kind === 'pull_request' && item.draft"
+                                    tone="muted"
+                                >
+                                    draft
+                                </StatusBadge>
+                                <StatusBadge
+                                    v-if="item.kind === 'pull_request'"
+                                    :tone="riskTone(item.risk_assessment)"
+                                    :title="item.risk_assessment?.summary ?? riskLabel(item.risk_assessment)"
+                                >
+                                    {{ riskLabel(item.risk_assessment) }}
+                                </StatusBadge>
+                                <StatusBadge :tone="itemStateTone(item)">
+                                    {{ item.state }}
+                                </StatusBadge>
+                                <span class="inline-flex items-center gap-1">
+                                    <MessageSquare
+                                        class="h-3.5 w-3.5"
+                                        aria-hidden="true"
+                                    />
+                                    {{ item.comments_count }}
+                                </span>
                                 <a
                                     v-if="item.html_url"
                                     :href="item.html_url"
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    class="truncate text-sm font-semibold text-text-primary transition hover:text-accent-cyan"
+                                    class="text-text-muted transition hover:text-accent-cyan"
+                                    :aria-label="`Open ${item.kind === 'pull_request' ? 'pull request' : 'issue'} #${item.number} on GitHub`"
                                 >
-                                    <span class="font-mono text-text-muted">#{{ item.number }}</span>
-                                    {{ item.title }}
+                                    <ExternalLink class="h-4 w-4" aria-hidden="true" />
                                 </a>
-                                <span
-                                    v-else
-                                    class="truncate text-sm font-semibold text-text-primary"
-                                >
-                                    <span class="font-mono text-text-muted">#{{ item.number }}</span>
-                                    {{ item.title }}
-                                </span>
-                                <p class="text-xs text-text-muted">
-                                    <span
-                                        v-if="item.repository"
-                                        class="font-mono text-text-secondary"
-                                    >
-                                        {{ item.repository.full_name }}
-                                    </span>
-                                    <template v-if="item.author_login">
-                                        ·
-                                        <span class="font-mono text-text-secondary">@{{ item.author_login }}</span>
-                                    </template>
-                                    · Updated {{ item.updated_at_github ?? '—' }}
-                                </p>
                             </div>
                         </div>
                         <div
-                            class="flex flex-shrink-0 items-center gap-3 text-xs text-text-muted"
+                            v-if="item.kind === 'pull_request'"
+                            class="rounded-xl border border-border-subtle bg-background-panel-hover/45 p-4 text-xs text-text-secondary"
                         >
-                            <StatusBadge
-                                v-if="item.kind === 'pull_request' && item.draft"
-                                tone="muted"
+                            <div class="flex flex-wrap items-start justify-between gap-3">
+                                <div class="space-y-1">
+                                    <p class="font-mono text-[10px] uppercase tracking-[0.2em] text-text-muted">
+                                        AI risk panel
+                                    </p>
+                                    <p class="text-sm font-semibold text-text-primary">
+                                        {{ riskLabel(item.risk_assessment) }}
+                                    </p>
+                                    <p v-if="item.risk_assessment?.summary" class="max-w-3xl text-text-secondary">
+                                        {{ item.risk_assessment.summary }}
+                                    </p>
+                                    <p v-else-if="item.risk_assessment?.status === 'pending'" class="text-text-muted">
+                                        Assessment is queued or running.
+                                    </p>
+                                    <p v-else-if="item.risk_assessment?.status === 'failed'" class="text-status-danger">
+                                        {{ item.risk_assessment.error_message ?? 'Assessment failed.' }}
+                                    </p>
+                                    <p v-else class="text-text-muted">
+                                        No assessment has been stored for this pull request yet.
+                                    </p>
+                                </div>
+                                <button
+                                    v-if="canRegeneratePrRisk"
+                                    type="button"
+                                    class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/15 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-accent-cyan transition hover:border-accent-cyan/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                    @click="regenerateRisk(item)"
+                                >
+                                    <Sparkles class="h-3.5 w-3.5" aria-hidden="true" />
+                                    Regenerate
+                                </button>
+                            </div>
+                            <dl class="mt-3 grid gap-3 sm:grid-cols-3">
+                                <div>
+                                    <dt class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted">Score</dt>
+                                    <dd class="mt-1 text-text-primary">
+                                        {{ item.risk_assessment?.risk_score ?? '—' }}
+                                    </dd>
+                                </div>
+                                <div>
+                                    <dt class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted">Status</dt>
+                                    <dd class="mt-1 text-text-primary">
+                                        {{ item.risk_assessment?.status ?? 'not assessed' }}
+                                    </dd>
+                                </div>
+                                <div>
+                                    <dt class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted">Assessed</dt>
+                                    <dd class="mt-1 text-text-primary">
+                                        {{ item.risk_assessment?.assessed_at ?? item.risk_assessment?.failed_at ?? '—' }}
+                                    </dd>
+                                </div>
+                            </dl>
+                            <div
+                                v-if="item.risk_assessment?.reasons?.length"
+                                class="mt-3"
                             >
-                                draft
-                            </StatusBadge>
-                            <StatusBadge :tone="itemStateTone(item)">
-                                {{ item.state }}
-                            </StatusBadge>
-                            <span class="inline-flex items-center gap-1">
-                                <MessageSquare
-                                    class="h-3.5 w-3.5"
-                                    aria-hidden="true"
-                                />
-                                {{ item.comments_count }}
-                            </span>
-                            <a
-                                v-if="item.html_url"
-                                :href="item.html_url"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                class="text-text-muted transition hover:text-accent-cyan"
-                                :aria-label="`Open ${item.kind === 'pull_request' ? 'pull request' : 'issue'} #${item.number} on GitHub`"
+                                <p class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted">Reasons</p>
+                                <ul class="mt-1 list-disc space-y-1 pl-4">
+                                    <li v-for="reason in item.risk_assessment.reasons" :key="reason">
+                                        {{ reason }}
+                                    </li>
+                                </ul>
+                            </div>
+                            <div
+                                v-if="item.risk_assessment?.recommended_actions?.length"
+                                class="mt-3"
                             >
-                                <ExternalLink class="h-4 w-4" aria-hidden="true" />
-                            </a>
+                                <p class="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted">Recommended actions</p>
+                                <ul class="mt-1 list-disc space-y-1 pl-4">
+                                    <li v-for="action in item.risk_assessment.recommended_actions" :key="action">
+                                        {{ action }}
+                                    </li>
+                                </ul>
+                            </div>
                         </div>
                     </li>
                 </ul>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -177,6 +177,17 @@ export interface RiskyProjectRow {
         | null;
     /** Humanized via `diffForHumans()`. */
     last_activity_at: string | null;
+    health_explanation: ProjectHealthExplanationPayload | null;
+}
+
+export interface ProjectHealthExplanationPayload {
+    status: 'pending' | 'explained' | 'failed' | 'skipped';
+    summary: string | null;
+    drivers: string[];
+    recommended_actions: string[];
+    explained_at: string | null;
+    failed_at: string | null;
+    error_message: string | null;
 }
 
 /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\OverviewController;
 use App\Http\Controllers\PaletteSearchController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ProjectController;
+use App\Http\Controllers\ProjectHealthExplanationRegenerationController;
 use App\Http\Controllers\PublicStatus\ConfirmSubscriptionController;
 use App\Http\Controllers\PublicStatus\ShowController;
 use App\Http\Controllers\PublicStatus\SubscribeController;
@@ -216,6 +217,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/work-items/pull-requests/{pullRequest}/risk/regenerate', PullRequestRiskRegenerationController::class)
         ->middleware('throttle:10,1')
         ->name('work-items.pull-requests.risk.regenerate');
+    Route::post('/overview/projects/{project}/health-explanation/regenerate', ProjectHealthExplanationRegenerationController::class)
+        ->middleware('throttle:10,1')
+        ->name('overview.projects.health-explanation.regenerate');
 
     // Spec 018 — dedicated activity feed page. Right-rail shares the
     // same data via the activity.recent Inertia prop registered in

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ use App\Http\Controllers\PublicStatus\ConfirmSubscriptionController;
 use App\Http\Controllers\PublicStatus\ShowController;
 use App\Http\Controllers\PublicStatus\SubscribeController;
 use App\Http\Controllers\PublicStatus\UnsubscribeController;
+use App\Http\Controllers\PullRequestRiskRegenerationController;
 use App\Http\Controllers\RepositoryController;
 use App\Http\Controllers\RepositoryIssuesSyncController;
 use App\Http\Controllers\RepositoryPullRequestsSyncController;
@@ -212,6 +213,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     // Spec 016 — unified Work Items queue (issues + PRs).
     Route::get('/work-items', WorkItemController::class)->name('work-items.index');
+    Route::post('/work-items/pull-requests/{pullRequest}/risk/regenerate', PullRequestRiskRegenerationController::class)
+        ->middleware('throttle:10,1')
+        ->name('work-items.pull-requests.risk.regenerate');
 
     // Spec 018 — dedicated activity feed page. Right-rail shares the
     // same data via the activity.recent Inertia prop registered in

--- a/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
+++ b/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
@@ -285,6 +285,14 @@ List of created/modified files. Fill in as work progresses.
 - `app/Domain/AiInsights/Actions/GenerateProjectHealthExplanationAction.php` — builds `project-health-explanation-v1` prompts, validates/sanitizes LLM output, persists explained or failed health explanation rows, and reuses the current row on regeneration.
 - `tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentActionTest.php` — covers PR risk generation prompt, sanitization, failed client, disabled AI gate, invalid output, and regeneration row updates.
 - `tests/Feature/AiInsights/GenerateProjectHealthExplanationActionTest.php` — covers project health explanation prompt, sanitization, failed client, disabled AI gate, invalid output, and regeneration row updates.
+- `app/Domain/AiInsights/Jobs/GeneratePullRequestRiskAssessmentJob.php` — queues PR risk assessment generation with AI gating, uniqueness, pending state, and terminal failure recovery.
+- `app/Domain/AiInsights/Jobs/GenerateProjectHealthExplanationJob.php` — queues project health explanation generation with AI gating, uniqueness, pending state, and terminal failure recovery.
+- `app/Domain/GitHub/WebhookHandlers/PullRequestWebhookHandler.php` — dispatches PR risk assessment jobs after material `pull_request` webhook actions update the local PR row.
+- `app/Domain/Analytics/Actions/RefreshProjectHealthScoreAction.php` — dispatches health explanation jobs after material score/band changes or stale explanations, guarded by AI gate and rate limit.
+- `tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentJobTest.php` — covers PR risk job uniqueness, AI gate, snapshot/generation path, and failed-handler recovery.
+- `tests/Feature/AiInsights/GenerateProjectHealthExplanationJobTest.php` — covers health explanation job uniqueness, AI gate, snapshot/generation path, and failed-handler recovery.
+- `tests/Feature/GitHub/Webhooks/PullRequestWebhookHandlerTest.php` — covers material PR webhook risk dispatch and disabled-AI skip behavior.
+- `tests/Unit/Domain/Analytics/RefreshProjectHealthScoreActionTest.php` — covers health explanation dispatch on material changes, stale explanations, rate limiting, and disabled-AI skip behavior.
 
 ## Work log
 
@@ -315,6 +323,11 @@ List of created/modified files. Fill in as work progresses.
   `services.llm.enabled` gate, building versioned prompts from bounded snapshots,
   validating/sanitizing structured JSON output, persisting scored/explained rows,
   failing closed with error context, and updating the existing current row on regeneration.
+- Implemented the fourth reviewable backend slice: queued PR risk and project health
+  explanation jobs, PR webhook dispatch after material pull request actions update the
+  local row, and health-score refresh dispatch after material score/band changes or stale
+  explanations. The dispatch paths respect the shared AI gate, use uniqueness/rate-limit
+  guards, and mark pending rows failed on terminal job failure so rows do not stay stuck.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
+++ b/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
@@ -295,6 +295,12 @@ List of created/modified files. Fill in as work progresses.
 - `tests/Unit/Domain/Analytics/RefreshProjectHealthScoreActionTest.php` — covers health explanation dispatch on material changes, stale explanations, rate limiting, and disabled-AI skip behavior.
 - `app/Console/Commands/BackfillPullRequestRiskAssessmentsCommand.php` — queues scoped PR risk assessment jobs for currently open PRs when AI is enabled.
 - `tests/Feature/AiInsights/PullRequestRiskBackfillCommandTest.php` — covers open-only/user/project/repository scoping, other-user exclusion, AI gate, and explicit-scope guard for the backfill command.
+- `app/Domain/GitHub/Queries/WorkItemsForUserQuery.php` — includes current PR risk assessment payload only on pull request rows.
+- `app/Http/Controllers/WorkItemController.php` — exposes the AI regenerate gate to the Work Items page.
+- `app/Http/Controllers/PullRequestRiskRegenerationController.php` — queues manual PR risk regeneration for project owners when AI insights are enabled.
+- `routes/web.php` — adds the throttled Work Items PR-risk regenerate route.
+- `resources/js/Pages/WorkItems/Index.vue` — renders PR-only risk badge and inline risk panel with summary, reasons, actions, timestamp, pending/failed state, and gated regenerate action.
+- `tests/Feature/GitHub/WorkItemControllerTest.php` — covers Work Items PR-risk payload boundaries and regenerate authorization/AI gate behavior.
 
 ## Work log
 
@@ -336,6 +342,12 @@ List of created/modified files. Fill in as work progresses.
   the UI surface slice because the current route/controller patterns are tied to existing
   authenticated UI pages and there is not yet a PR detail or Overview explanation surface
   for those actions.
+- Implemented the sixth reviewable UI slice: Work Items now receives current PR risk
+  assessment data only for pull request rows, renders a PR-only risk badge and inline risk
+  panel with score, summary, reasons, recommended actions, assessed/failed timestamp, and
+  pending/failed states, and exposes a throttled manual regenerate action for project
+  owners only when AI insights are enabled. Kept issue rows unchanged and deferred the
+  Overview project-health overlay, notifications, and docs.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
+++ b/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
@@ -277,6 +277,10 @@ List of created/modified files. Fill in as work progresses.
 - `tests/Feature/AiInsights/AiInsightPersistenceTest.php` — focused persistence, casts, uniqueness, relationship, and cascade tests.
 - `app/Models/GithubPullRequest.php` — adds current risk assessment relationship.
 - `app/Models/Project.php` — adds current health explanation relationship.
+- `app/Domain/AiInsights/Queries/GetPullRequestRiskInputQuery.php` — builds scoped, bounded PR-risk input snapshots from existing Nexus metadata.
+- `app/Domain/AiInsights/Queries/GetProjectHealthExplanationInputQuery.php` — builds scoped, bounded project-health explanation snapshots from existing score drivers.
+- `tests/Feature/AiInsights/GetPullRequestRiskInputQueryTest.php` — covers PR ownership scoping, bounded samples, and sensitive-field exclusion.
+- `tests/Feature/AiInsights/GetProjectHealthExplanationInputQueryTest.php` — covers project ownership scoping, health-driver samples/caps, and sensitive-field exclusion.
 
 ## Work log
 
@@ -298,6 +302,10 @@ List of created/modified files. Fill in as work progresses.
   PR risk assessments and project health explanations. Added a health explanation
   lifecycle `status` column so later pending/failed UI and job slices do not infer
   state from nullable timestamps.
+- Implemented the second reviewable backend slice: `GetPullRequestRiskInputQuery`
+  and `GetProjectHealthExplanationInputQuery`, with ownership scoping, deterministic
+  bounded facts, sample caps, and focused tests proving snapshots exclude secrets,
+  webhook URLs, access tokens, raw logs, raw diffs, and full PR bodies.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
+++ b/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
@@ -167,7 +167,7 @@ health-score weights.
   - `GeneratePullRequestRiskAssessmentActionTest` — happy path, output
     validation, failed LLM call, disabled AI gate, row update on regenerated
     score.
-  - `GeneratePullRequestRiskAssessmentJobTest` — unique by PR, retry/failure
+  - `GeneratePullRequestRiskAssessmentJobTest` — unique by PR, fail-closed
     handling, no dispatch when AI is disabled.
   - `PullRequestWebhookRiskDispatchTest` — risk job dispatches after relevant
     webhook actions and skips irrelevant actions.
@@ -285,8 +285,8 @@ List of created/modified files. Fill in as work progresses.
 - `app/Domain/AiInsights/Actions/GenerateProjectHealthExplanationAction.php` — builds `project-health-explanation-v1` prompts, validates/sanitizes LLM output, persists explained or failed health explanation rows, and reuses the current row on regeneration.
 - `tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentActionTest.php` — covers PR risk generation prompt, sanitization, failed client, disabled AI gate, invalid output, and regeneration row updates.
 - `tests/Feature/AiInsights/GenerateProjectHealthExplanationActionTest.php` — covers project health explanation prompt, sanitization, failed client, disabled AI gate, invalid output, and regeneration row updates.
-- `app/Domain/AiInsights/Jobs/GeneratePullRequestRiskAssessmentJob.php` — queues PR risk assessment generation with AI gating, uniqueness, pending state, and terminal failure recovery.
-- `app/Domain/AiInsights/Jobs/GenerateProjectHealthExplanationJob.php` — queues project health explanation generation with AI gating, uniqueness, pending state, and terminal failure recovery.
+- `app/Domain/AiInsights/Jobs/GeneratePullRequestRiskAssessmentJob.php` — queues PR risk assessment generation with AI gating, uniqueness, pending state, pending-row skip when AI is disabled, and terminal failure recovery.
+- `app/Domain/AiInsights/Jobs/GenerateProjectHealthExplanationJob.php` — queues project health explanation generation with AI gating, uniqueness, pending state, pending-row skip when AI is disabled, and terminal failure recovery.
 - `app/Domain/GitHub/WebhookHandlers/PullRequestWebhookHandler.php` — dispatches PR risk assessment jobs after material `pull_request` webhook actions update the local PR row.
 - `app/Domain/Analytics/Actions/RefreshProjectHealthScoreAction.php` — dispatches health explanation jobs after material score/band changes or stale explanations, guarded by AI gate and rate limit.
 - `tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentJobTest.php` — covers PR risk job uniqueness, AI gate, snapshot/generation path, and failed-handler recovery.
@@ -313,7 +313,7 @@ List of created/modified files. Fill in as work progresses.
 - `app/Domain/AiInsights/Actions/GeneratePullRequestRiskAssessmentAction.php` — dispatches conservative spec 042 notifications for material increases to high/critical PR risk.
 - `app/Enums/AlertSource.php` — clarifies that GitHub alert `source_id` can point at repositories or pull requests depending on alert type.
 - `database/migrations/2026_05_27_080000_create_alerts_table.php` — clarifies the historical alerts-table comment for GitHub repo/PR-scoped alerts.
-- `tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentActionTest.php` — covers high/critical notification guardrails and quiet unchanged low/medium scores.
+- `tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentActionTest.php` — covers high/critical notification guardrails, quiet unchanged low/medium scores, and resolved historical alert boundaries.
 - `docs/security/operator-checklist.md` — documents Spec 045 prompt-safety, webhook-trigger, notification, regenerate, and rate-limit expectations.
 
 ## Work log
@@ -373,6 +373,11 @@ List of created/modified files. Fill in as work progresses.
   operator security checklist for prompt safety, webhook trigger, notification, regenerate,
   and rate-limit expectations. Env docs needed no new keys because Spec 045 reuses the
   shared Spec 044 LLM gate/config.
+- Fixed fresh review findings: removed PR `body_preview` from LLM input snapshots entirely,
+  aligned PR-risk and health-explanation jobs to the existing fail-closed/no queue-retry
+  contract, marked existing pending rows skipped when the AI gate is disabled at execution
+  time, and let spec 042 active-alert idempotency handle PR-risk notification duplicates so
+  resolved historical alerts do not suppress later material increases.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
+++ b/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
@@ -281,6 +281,10 @@ List of created/modified files. Fill in as work progresses.
 - `app/Domain/AiInsights/Queries/GetProjectHealthExplanationInputQuery.php` — builds scoped, bounded project-health explanation snapshots from existing score drivers.
 - `tests/Feature/AiInsights/GetPullRequestRiskInputQueryTest.php` — covers PR ownership scoping, bounded samples, and sensitive-field exclusion.
 - `tests/Feature/AiInsights/GetProjectHealthExplanationInputQueryTest.php` — covers project ownership scoping, health-driver samples/caps, and sensitive-field exclusion.
+- `app/Domain/AiInsights/Actions/GeneratePullRequestRiskAssessmentAction.php` — builds `pr-risk-v1` prompts, validates/sanitizes LLM output, persists scored or failed PR risk rows, and reuses the current row on regeneration.
+- `app/Domain/AiInsights/Actions/GenerateProjectHealthExplanationAction.php` — builds `project-health-explanation-v1` prompts, validates/sanitizes LLM output, persists explained or failed health explanation rows, and reuses the current row on regeneration.
+- `tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentActionTest.php` — covers PR risk generation prompt, sanitization, failed client, disabled AI gate, invalid output, and regeneration row updates.
+- `tests/Feature/AiInsights/GenerateProjectHealthExplanationActionTest.php` — covers project health explanation prompt, sanitization, failed client, disabled AI gate, invalid output, and regeneration row updates.
 
 ## Work log
 
@@ -306,6 +310,11 @@ List of created/modified files. Fill in as work progresses.
   and `GetProjectHealthExplanationInputQuery`, with ownership scoping, deterministic
   bounded facts, sample caps, and focused tests proving snapshots exclude secrets,
   webhook URLs, access tokens, raw logs, raw diffs, and full PR bodies.
+- Implemented the third reviewable backend slice: `GeneratePullRequestRiskAssessmentAction`
+  and `GenerateProjectHealthExplanationAction`, reusing the shared `LlmClient` and
+  `services.llm.enabled` gate, building versioned prompts from bounded snapshots,
+  validating/sanitizing structured JSON output, persisting scored/explained rows,
+  failing closed with error context, and updating the existing current row on regeneration.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
+++ b/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
@@ -243,7 +243,7 @@ health-score weights.
       rows.
 - [ ] PR detail/drawer UI shows score, summary, reasons, recommended actions,
       assessment timestamp, pending state, failed state, and gated regenerate.
-- [ ] Existing open PRs can be backfilled through a scoped command/job without
+- [x] Existing open PRs can be backfilled through a scoped command/job without
       scoring closed PRs or other users' data.
 - [ ] Project health explanations describe the existing Phase 8/spec 046 health
       score; they do not compute or display a competing score.
@@ -293,6 +293,8 @@ List of created/modified files. Fill in as work progresses.
 - `tests/Feature/AiInsights/GenerateProjectHealthExplanationJobTest.php` — covers health explanation job uniqueness, AI gate, snapshot/generation path, and failed-handler recovery.
 - `tests/Feature/GitHub/Webhooks/PullRequestWebhookHandlerTest.php` — covers material PR webhook risk dispatch and disabled-AI skip behavior.
 - `tests/Unit/Domain/Analytics/RefreshProjectHealthScoreActionTest.php` — covers health explanation dispatch on material changes, stale explanations, rate limiting, and disabled-AI skip behavior.
+- `app/Console/Commands/BackfillPullRequestRiskAssessmentsCommand.php` — queues scoped PR risk assessment jobs for currently open PRs when AI is enabled.
+- `tests/Feature/AiInsights/PullRequestRiskBackfillCommandTest.php` — covers open-only/user/project/repository scoping, other-user exclusion, AI gate, and explicit-scope guard for the backfill command.
 
 ## Work log
 
@@ -328,6 +330,12 @@ List of created/modified files. Fill in as work progresses.
   local row, and health-score refresh dispatch after material score/band changes or stale
   explanations. The dispatch paths respect the shared AI gate, use uniqueness/rate-limit
   guards, and mark pending rows failed on terminal job failure so rows do not stay stuck.
+- Implemented the fifth reviewable backend slice: `ai-insights:backfill-pr-risk` queues
+  PR risk assessment jobs for explicitly scoped user/project/repository backfills, only
+  when AI is enabled and only for open PRs. Deferred UI-triggered regenerate endpoints to
+  the UI surface slice because the current route/controller patterns are tied to existing
+  authenticated UI pages and there is not yet a PR detail or Overview explanation surface
+  for those actions.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
+++ b/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
@@ -301,6 +301,15 @@ List of created/modified files. Fill in as work progresses.
 - `routes/web.php` — adds the throttled Work Items PR-risk regenerate route.
 - `resources/js/Pages/WorkItems/Index.vue` — renders PR-only risk badge and inline risk panel with summary, reasons, actions, timestamp, pending/failed state, and gated regenerate action.
 - `tests/Feature/GitHub/WorkItemControllerTest.php` — covers Work Items PR-risk payload boundaries and regenerate authorization/AI gate behavior.
+- `app/Domain/Dashboard/Queries/GetOverviewDashboardQuery.php` — includes the latest project health explanation payload on risky-project rows.
+- `app/Http/Controllers/OverviewController.php` — exposes the gated Overview health-explanation regenerate affordance flag.
+- `app/Http/Controllers/ProjectHealthExplanationRegenerationController.php` — queues manual health-explanation regeneration for project owners when AI insights are enabled.
+- `routes/web.php` — adds the throttled Overview project-health explanation regenerate route.
+- `resources/js/Components/Dashboard/RiskyProjects.vue` — renders the “Why?” health explanation affordance with summary, drivers, recommended actions, timestamps, pending/failed/no-explanation states, and gated regenerate.
+- `resources/js/Pages/Overview.vue` — passes the health-explanation regenerate gate into the Risky Projects panel.
+- `resources/js/types/index.d.ts` — adds the project health explanation payload type on `RiskyProjectRow`.
+- `tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php` — covers Overview risky-project health explanation payload and cross-user isolation.
+- `tests/Feature/Dashboard/ProjectHealthExplanationUiTest.php` — covers Overview Inertia payload and health-explanation regenerate gate/authorization behavior.
 
 ## Work log
 
@@ -348,6 +357,11 @@ List of created/modified files. Fill in as work progresses.
   pending/failed states, and exposes a throttled manual regenerate action for project
   owners only when AI insights are enabled. Kept issue rows unchanged and deferred the
   Overview project-health overlay, notifications, and docs.
+- Implemented the seventh reviewable UI slice: Overview risky-project rows now carry the
+  latest project health explanation payload, render a natural-language “Why?” affordance
+  with summary, drivers, recommended actions, timestamp, pending/failed/no-explanation
+  states, and expose a throttled manual regenerate action for project owners when AI
+  insights are enabled. Kept PR risk notifications and docs deferred.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
+++ b/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
@@ -63,6 +63,7 @@ health-score weights.
 - **Migration: `project_health_explanations`.** Persist the latest AI
   explanation for each project health score. Columns:
   - `id`, `project_id` (FK -> `projects`, cascade delete)
+  - `status` (`pending` | `explained` | `failed` | `skipped`)
   - `health_score` (unsigned tiny integer captured at explanation time)
   - `health_band` (nullable string matching the existing backend band)
   - `summary` (text; concise explanation)
@@ -264,6 +265,18 @@ health-score weights.
 List of created/modified files. Fill in as work progresses.
 
 - `specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md` — created, draft spec.
+- `database/migrations/2026_07_21_150000_create_pull_request_risk_assessments_table.php` — adds one-current-row PR risk assessment persistence.
+- `database/migrations/2026_07_21_150001_create_project_health_explanations_table.php` — adds one-current-row project health explanation persistence.
+- `app/Models/PullRequestRiskAssessment.php` — PR risk assessment model, casts, and PR relationship.
+- `app/Models/ProjectHealthExplanation.php` — project health explanation model, casts, and project relationship.
+- `app/Enums/PullRequestRiskAssessmentStatus.php` — PR risk assessment lifecycle enum.
+- `app/Enums/PullRequestRiskLevel.php` — PR risk level enum.
+- `app/Enums/ProjectHealthExplanationStatus.php` — project health explanation lifecycle enum.
+- `database/factories/PullRequestRiskAssessmentFactory.php` — PR risk assessment factory states.
+- `database/factories/ProjectHealthExplanationFactory.php` — project health explanation factory states.
+- `tests/Feature/AiInsights/AiInsightPersistenceTest.php` — focused persistence, casts, uniqueness, relationship, and cascade tests.
+- `app/Models/GithubPullRequest.php` — adds current risk assessment relationship.
+- `app/Models/Project.php` — adds current health explanation relationship.
 
 ## Work log
 
@@ -280,6 +293,11 @@ List of created/modified files. Fill in as work progresses.
 - Started workflow on branch
   `spec/045-ai-pr-risk-score-and-project-health-explanation` with GitHub issue
   #134.
+- Implemented the first reviewable backend foundation slice: migrations, models,
+  enums, factories, current-row relationships, and focused persistence tests for
+  PR risk assessments and project health explanations. Added a health explanation
+  lifecycle `status` column so later pending/failed UI and job slices do not infer
+  state from nullable timestamps.
 
 ## Open questions / blockers
 

--- a/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
+++ b/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
@@ -233,29 +233,29 @@ health-score weights.
 
 ## Acceptance criteria
 
-- [ ] Feature stays inert unless `AI_FEATURES_ENABLED=true` and shared LLM
+- [x] Feature stays inert unless `AI_FEATURES_ENABLED=true` and shared LLM
       config is present.
-- [ ] Relevant incoming GitHub PR webhook actions enqueue at most one risk
+- [x] Relevant incoming GitHub PR webhook actions enqueue at most one risk
       assessment job per PR after the local PR row is updated.
-- [ ] Every assessed PR persists `risk_level`, `risk_score`, summary, reasons,
+- [x] Every assessed PR persists `risk_level`, `risk_score`, summary, reasons,
       input snapshot, prompt version, model, and assessment timestamp.
-- [ ] Work Items queue surfaces risk badges for PR rows without affecting issue
+- [x] Work Items queue surfaces risk badges for PR rows without affecting issue
       rows.
-- [ ] PR detail/drawer UI shows score, summary, reasons, recommended actions,
+- [x] PR detail/drawer UI shows score, summary, reasons, recommended actions,
       assessment timestamp, pending state, failed state, and gated regenerate.
 - [x] Existing open PRs can be backfilled through a scoped command/job without
       scoring closed PRs or other users' data.
-- [ ] Project health explanations describe the existing Phase 8/spec 046 health
+- [x] Project health explanations describe the existing Phase 8/spec 046 health
       score; they do not compute or display a competing score.
-- [ ] Overview/project health UI includes a natural-language "why" overlay with
+- [x] Overview/project health UI includes a natural-language "why" overlay with
       drivers, recommended actions, timestamp, pending state, and failed state.
-- [ ] High/critical PR risk creates at most one spec 042 notification per PR per
+- [x] High/critical PR risk creates at most one spec 042 notification per PR per
       material risk-level increase.
-- [ ] LLM input excludes secrets, webhook URLs, access tokens, raw diffs, raw
+- [x] LLM input excludes secrets, webhook URLs, access tokens, raw diffs, raw
       logs, and full PR bodies.
-- [ ] Failed LLM calls persist failed status/error context and do not fabricate
+- [x] Failed LLM calls persist failed status/error context and do not fabricate
       risk/explanation text.
-- [ ] Tests cover query scoping, generation validation/failure, webhook dispatch,
+- [x] Tests cover query scoping, generation validation/failure, webhook dispatch,
       backfill, UI payloads, notification guardrails, and health-score refresh
       triggers.
 - [ ] Pint clean, tests green, build clean, CI green on the eventual spec PR.
@@ -310,6 +310,11 @@ List of created/modified files. Fill in as work progresses.
 - `resources/js/types/index.d.ts` — adds the project health explanation payload type on `RiskyProjectRow`.
 - `tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php` — covers Overview risky-project health explanation payload and cross-user isolation.
 - `tests/Feature/Dashboard/ProjectHealthExplanationUiTest.php` — covers Overview Inertia payload and health-explanation regenerate gate/authorization behavior.
+- `app/Domain/AiInsights/Actions/GeneratePullRequestRiskAssessmentAction.php` — dispatches conservative spec 042 notifications for material increases to high/critical PR risk.
+- `app/Enums/AlertSource.php` — clarifies that GitHub alert `source_id` can point at repositories or pull requests depending on alert type.
+- `database/migrations/2026_05_27_080000_create_alerts_table.php` — clarifies the historical alerts-table comment for GitHub repo/PR-scoped alerts.
+- `tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentActionTest.php` — covers high/critical notification guardrails and quiet unchanged low/medium scores.
+- `docs/security/operator-checklist.md` — documents Spec 045 prompt-safety, webhook-trigger, notification, regenerate, and rate-limit expectations.
 
 ## Work log
 
@@ -362,11 +367,17 @@ List of created/modified files. Fill in as work progresses.
   with summary, drivers, recommended actions, timestamp, pending/failed/no-explanation
   states, and expose a throttled manual regenerate action for project owners when AI
   insights are enabled. Kept PR risk notifications and docs deferred.
+- Implemented the final planned small work unit: PR risk assessments now create conservative
+  spec 042 notifications only for material increases to `high` or `critical`, with one alert
+  per PR per risk level and no notifications for unchanged `low`/`medium`. Updated the
+  operator security checklist for prompt safety, webhook trigger, notification, regenerate,
+  and rate-limit expectations. Env docs needed no new keys because Spec 045 reuses the
+  shared Spec 044 LLM gate/config.
 
 ## Open questions / blockers
 
-- Should PR-risk notifications be opt-in via a dedicated setting, or is the
-  conservative high/critical-only spec 042 routing enough for v1?
+- Resolved for v1: PR-risk notifications reuse existing spec 042 routing preferences;
+  no dedicated opt-in setting was added beyond conservative high/critical-only dispatch.
 - Where should the PR detail risk panel live if the current Work Items UI has no
   drawer yet: inside the Work Items row expansion, repository PR list details,
   or a small dedicated PR show route?

--- a/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
+++ b/specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md
@@ -1,0 +1,294 @@
+---
+spec: ai-pr-risk-score-and-project-health-explanation
+phase: 10
+status: in-progress   # not-started | in-progress | blocked | done
+owner: Yoany
+created: 2026-07-21
+updated: 2026-07-21
+---
+
+# 045 — AI PR risk score + project health explanation
+
+## Goal
+
+Phase 10 adds an operator-facing AI layer over two existing decision
+surfaces: pull requests and project health. Every incoming PR should get a
+bounded LLM-derived risk tag that helps the operator decide what to review
+first, and each project health-score card should explain in plain language
+why the score moved.
+
+The roadmap only names this as "AI PR risk score" and "AI project health
+explanation." The Phase 10 README narrows the slice: score PRs on webhook
+arrival, surface the tag on the Work Items queue + PR drawer, and add a
+natural-language "why" overlay to Phase 8 health-score cards. This spec
+keeps that scope narrow: explain existing Nexus signals, do not build a
+general AI assistant.
+
+Roadmap refs: §Phase 10 Future Features ("AI PR risk score", "AI project
+health explanation"), §3.2 Signal Over Noise, §8.4 GitHub Issues & Pull
+Requests, §14.2 Health Score, Phase 10 README LLM dependencies, spec 042
+delivery layer, spec 044 shared LLM client/config, spec 046 user-tunable
+health-score weights.
+
+## Scope
+
+**In scope:**
+
+- **Environment gate + shared LLM config.** The feature is inert unless
+  `AI_FEATURES_ENABLED=true` and `services.llm.*` is configured. Reuse the
+  provider-swappable `LlmClient` contract from spec 044 when present rather
+  than creating a second AI client.
+
+- **Migration: `pull_request_risk_assessments`.** Persist one current
+  assessment per PR plus enough audit context to explain what happened.
+  Columns:
+  - `id`, `github_pull_request_id` (FK -> `github_pull_requests`, cascade
+    delete)
+  - `status` (`pending` | `scored` | `failed` | `skipped`)
+  - `risk_level` (`low` | `medium` | `high` | `critical`, nullable until
+    scored)
+  - `risk_score` (unsigned tiny integer 0-100, nullable until scored)
+  - `summary` (text, nullable; 1-2 operator-facing sentences)
+  - `reasons` (JSON array of short bullets tied to concrete PR signals)
+  - `recommended_actions` (JSON array, default empty)
+  - `input_snapshot` (JSON; bounded non-secret context sent to the LLM)
+  - `prompt_version` (string, e.g. `pr-risk-v1`)
+  - `model` (nullable string)
+  - `assessed_at`, `failed_at` (nullable timestamps)
+  - `error_message` (nullable text)
+  - Timestamps.
+  - Unique index on `github_pull_request_id` so webhook reprocessing updates
+    the current score rather than creating duplicate badges.
+
+- **Migration: `project_health_explanations`.** Persist the latest AI
+  explanation for each project health score. Columns:
+  - `id`, `project_id` (FK -> `projects`, cascade delete)
+  - `health_score` (unsigned tiny integer captured at explanation time)
+  - `health_band` (nullable string matching the existing backend band)
+  - `summary` (text; concise explanation)
+  - `drivers` (JSON array of scored factors such as alerts, deployments,
+    website checks, host/container state, GitHub sync state)
+  - `recommended_actions` (JSON array, default empty)
+  - `input_snapshot` (JSON; bounded source facts)
+  - `prompt_version` (string, e.g. `project-health-explanation-v1`)
+  - `model` (nullable string)
+  - `explained_at`, `failed_at` (nullable timestamps)
+  - `error_message` (nullable text)
+  - Timestamps.
+  - Unique index on `project_id` for a latest-explanation lookup.
+
+- **Models + enums.** Add `PullRequestRiskAssessment` and
+  `ProjectHealthExplanation` models with casts for JSON, enum-like status
+  fields, immutable timestamps, and relationships from `GithubPullRequest`
+  and `Project`.
+
+- **PR risk input query.** `GetPullRequestRiskInputQuery` builds a bounded
+  snapshot for one `GithubPullRequest`. Include existing deterministic facts
+  only:
+  - PR title/body preview, draft state, mergeability, review/check status,
+    additions, deletions, changed files, comments/review comments, age, stale
+    state, base/head branches, labels/author when available.
+  - Recent workflow/deployment failures for the repository/branch.
+  - Open critical/high project alerts and recent health-score band.
+  - Repository/project priority signals already stored in Nexus.
+  - Links/IDs needed for UI deep links, but no tokens, webhook secrets, raw
+    logs, or full patch content.
+
+- **PR risk generation action.** `GeneratePullRequestRiskAssessmentAction`
+  builds prompt `pr-risk-v1`, calls the shared `LlmClient`, validates output,
+  persists the row, and fails closed. Output contract:
+  - `risk_level`: one of `low`, `medium`, `high`, `critical`.
+  - `risk_score`: integer 0-100.
+  - `summary`: 1-2 short sentences.
+  - `reasons`: 1-5 bullets, each tied to a field in `input_snapshot`.
+  - `recommended_actions`: 0-4 bullets.
+
+- **Webhook scoring hook.** On GitHub `pull_request` webhook actions that can
+  materially change risk (`opened`, `reopened`, `synchronize`,
+  `ready_for_review`, `edited`, `review_requested`), dispatch
+  `GeneratePullRequestRiskAssessmentJob` after the local PR row is updated.
+  The job is unique by PR ID and may be retried on transient LLM errors.
+
+- **Manual backfill command.** Add an artisan command or queued job to score
+  currently open PRs for a user/project/repository when AI is enabled. This
+  prevents the feature from only applying to PRs that arrive after deploy.
+
+- **Work Items queue UI.** Surface the risk tag in `/work-items` for PR rows:
+  badge color by `risk_level`, tooltip/inline text for `summary`, and a
+  loading/failed state when assessment is pending or failed. Existing issue
+  rows remain unchanged.
+
+- **PR drawer/detail UI.** Add a compact risk panel to the PR detail drawer or
+  repository PR list details, depending on the current UI shape. Show score,
+  summary, reasons, recommended actions, `assessed_at`, and a "Regenerate"
+  action gated by the AI feature flag.
+
+- **Project health explanation query.** `GetProjectHealthExplanationInputQuery`
+  builds a bounded snapshot matching the current `ComputeProjectHealthScoreAction`
+  inputs after spec 046 weights are applied. Include score, band, active alert
+  counts by severity/source, failed deployments/workflows, website/host/container
+  health, GitHub sync failures, and recent score delta when available.
+
+- **Project health explanation action.** `GenerateProjectHealthExplanationAction`
+  builds prompt `project-health-explanation-v1`, validates output, persists
+  the latest explanation, and fails closed. It should explain the existing
+  score, not invent a competing score.
+
+- **Health-score integration.** After a project health score is refreshed,
+  enqueue explanation generation when the score/band changed materially or the
+  previous explanation is stale. Rate-limit by project so a noisy alert or
+  monitor cannot trigger repeated LLM calls.
+
+- **Overview health-score overlay.** Add a "Why?" affordance to the Phase 8
+  health-score card / risky-projects panel. The overlay shows the latest
+  summary, drivers, recommended actions, and timestamp. If no explanation
+  exists yet, show a deterministic fallback based on the current score inputs
+  and offer a gated regenerate action when AI is enabled.
+
+- **Notifications through spec 042.** When a PR scores `high` or `critical`,
+  optionally send a notification through the user's verified spec 042 channels.
+  Keep this conservative: one notification per PR per material risk-level
+  increase. No notification for unchanged `low`/`medium` scores.
+
+- **Prompt safety + privacy.** Send bounded snapshots, never raw diffs,
+  secrets, webhook URLs, access tokens, full PR bodies, full logs, or private
+  environment values. Store `input_snapshot` for auditability; do not store
+  provider request headers or secrets.
+
+- **Docs.** Update `docs/env.production.example` only if shared AI env keys
+  are missing. Extend `docs/security/operator-checklist.md` with PR-risk and
+  health-explanation prompt-safety, webhook-trigger, notification, regenerate,
+  and rate-limit expectations.
+
+- **Tests.**
+  - `GetPullRequestRiskInputQueryTest` — scopes the PR to the user's projects,
+    includes bounded facts, excludes other users' data and sensitive fields.
+  - `GeneratePullRequestRiskAssessmentActionTest` — happy path, output
+    validation, failed LLM call, disabled AI gate, row update on regenerated
+    score.
+  - `GeneratePullRequestRiskAssessmentJobTest` — unique by PR, retry/failure
+    handling, no dispatch when AI is disabled.
+  - `PullRequestWebhookRiskDispatchTest` — risk job dispatches after relevant
+    webhook actions and skips irrelevant actions.
+  - `PullRequestRiskBackfillCommandTest` — backfills only open scoped PRs and
+    respects the AI gate.
+  - `WorkItemsRiskBadgeTest` — Work Items payload exposes PR risk state and
+    renders only for PR rows.
+  - `GetProjectHealthExplanationInputQueryTest` — mirrors current health-score
+    drivers, scopes to owned projects, caps sampled entities.
+  - `GenerateProjectHealthExplanationActionTest` — persists explanation,
+    validates/sanitizes output, fails closed on client error.
+  - `ProjectHealthExplanationRefreshTest` — generation enqueues after material
+    health-score changes and respects stale/rate-limit guards.
+  - `ProjectHealthExplanationUiTest` — Overview payload exposes the latest
+    explanation and the overlay handles present, pending, and failed states.
+
+**Out of scope:**
+
+- **AI code review.** This spec does not read diffs or suggest line-level code
+  changes. It scores operational/review risk from metadata Nexus already owns.
+- **Merge blocking / automation.** Risk tags inform humans; they do not block
+  merges, approve PRs, request changes, or write GitHub comments.
+- **Training a custom risk model.** Prompted LLM analysis over bounded Nexus
+  signals is enough for v1.
+- **Embeddings or semantic repository indexing.** No vector database, codebase
+  search, or repository-content ingestion.
+- **Incident summaries.** Roadmap lists AI incident summary separately. Health
+  explanations may mention active incidents/alerts but do not generate
+  postmortems.
+- **A general AI assistant/chat UI.** No free-form prompt box or natural
+  language querying over Nexus data.
+- **Per-team/multi-tenant routing.** The current product shape remains
+  per-user/single-tenant.
+- **Discord/PagerDuty-specific AI notifications.** Spec 042 channels are reused;
+  new channel drivers are their own specs.
+
+## Plan
+
+1. **Confirm scope before workflow start.** Keep this spec `not-started` until
+   the user confirms the draft scope, then open the single spec issue/branch
+   per the Nexus workflow.
+2. **Migrations + models.** Create `pull_request_risk_assessments` and
+   `project_health_explanations`, model relationships, factories, and status
+   enums/value helpers.
+3. **Input queries.** Build PR-risk and health-explanation snapshot queries
+   with strict ownership scoping, deterministic fields, sample caps, and
+   sensitive-field exclusion.
+4. **Generation actions.** Add prompt builders, LLM calls, response validation,
+   sanitization, persistence, and fail-closed behavior for both AI outputs.
+5. **Jobs + triggers.** Wire PR webhook actions to PR-risk jobs; wire material
+   health-score refreshes to health-explanation jobs with rate-limit/staleness
+   guards.
+6. **Backfill + regenerate.** Add a scoped backfill path for existing open PRs
+   and a guarded regenerate action for PR risk/health explanation.
+7. **UI surfaces.** Add Work Items risk badges, PR detail risk panel, and
+   Overview/project-health "Why?" overlay using existing visual language.
+8. **Notifications.** Send spec 042 notifications only for new high/critical PR
+   risk or material risk-level increases.
+9. **Docs.** Update env/security operator docs for the AI gate, prompt-safety,
+   trigger, notification, and throttle posture.
+10. **Tests + verification.** Cover the tests listed above, run Pint,
+    `php artisan test`, `npm run build`, self-review, PR.
+
+## Acceptance criteria
+
+- [ ] Feature stays inert unless `AI_FEATURES_ENABLED=true` and shared LLM
+      config is present.
+- [ ] Relevant incoming GitHub PR webhook actions enqueue at most one risk
+      assessment job per PR after the local PR row is updated.
+- [ ] Every assessed PR persists `risk_level`, `risk_score`, summary, reasons,
+      input snapshot, prompt version, model, and assessment timestamp.
+- [ ] Work Items queue surfaces risk badges for PR rows without affecting issue
+      rows.
+- [ ] PR detail/drawer UI shows score, summary, reasons, recommended actions,
+      assessment timestamp, pending state, failed state, and gated regenerate.
+- [ ] Existing open PRs can be backfilled through a scoped command/job without
+      scoring closed PRs or other users' data.
+- [ ] Project health explanations describe the existing Phase 8/spec 046 health
+      score; they do not compute or display a competing score.
+- [ ] Overview/project health UI includes a natural-language "why" overlay with
+      drivers, recommended actions, timestamp, pending state, and failed state.
+- [ ] High/critical PR risk creates at most one spec 042 notification per PR per
+      material risk-level increase.
+- [ ] LLM input excludes secrets, webhook URLs, access tokens, raw diffs, raw
+      logs, and full PR bodies.
+- [ ] Failed LLM calls persist failed status/error context and do not fabricate
+      risk/explanation text.
+- [ ] Tests cover query scoping, generation validation/failure, webhook dispatch,
+      backfill, UI payloads, notification guardrails, and health-score refresh
+      triggers.
+- [ ] Pint clean, tests green, build clean, CI green on the eventual spec PR.
+
+## Files touched
+
+List of created/modified files. Fill in as work progresses.
+
+- `specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md` — created, draft spec.
+
+## Work log
+
+### 2026-07-21
+
+- Drafted from `_template.md`. Kept `status: not-started` because Nexus workflow
+  requires user scope confirmation before opening the GitHub issue/branch.
+- Assumed spec 044's shared `LlmClient`/`services.llm.*` config is available and
+  should be reused rather than duplicated.
+- Assumed PR risk scoring uses bounded Nexus metadata, not raw diffs or code
+  review, to keep prompt size and privacy risk controlled.
+- Assumed project health explanations explain the existing Phase 8/spec 046
+  score rather than creating a separate AI score.
+- Started workflow on branch
+  `spec/045-ai-pr-risk-score-and-project-health-explanation` with GitHub issue
+  #134.
+
+## Open questions / blockers
+
+- Should PR-risk notifications be opt-in via a dedicated setting, or is the
+  conservative high/critical-only spec 042 routing enough for v1?
+- Where should the PR detail risk panel live if the current Work Items UI has no
+  drawer yet: inside the Work Items row expansion, repository PR list details,
+  or a small dedicated PR show route?
+- What threshold counts as a "material" health-score change for regeneration:
+  score delta, band change, or either one?
+- Should regenerated PR risk assessments keep historical versions, or is the
+  current-assessment row plus `input_snapshot` enough for v1?

--- a/tests/Feature/AiInsights/AiInsightPersistenceTest.php
+++ b/tests/Feature/AiInsights/AiInsightPersistenceTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Feature\AiInsights;
+
+use App\Enums\HealthScoreBand;
+use App\Enums\ProjectHealthExplanationStatus;
+use App\Enums\PullRequestRiskAssessmentStatus;
+use App\Enums\PullRequestRiskLevel;
+use App\Models\GithubPullRequest;
+use App\Models\Project;
+use App\Models\ProjectHealthExplanation;
+use App\Models\PullRequestRiskAssessment;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AiInsightPersistenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_pull_request_risk_assessment_casts_payloads_and_relationships(): void
+    {
+        $pullRequest = GithubPullRequest::factory()->create();
+
+        $assessment = PullRequestRiskAssessment::factory()
+            ->scored()
+            ->for($pullRequest, 'pullRequest')
+            ->create(['assessed_at' => '2026-07-21 15:30:00']);
+
+        $this->assertSame(PullRequestRiskAssessmentStatus::Scored, $assessment->status);
+        $this->assertSame(PullRequestRiskLevel::High, $assessment->risk_level);
+        $this->assertSame(82, $assessment->risk_score);
+        $this->assertSame(['Large change size', 'Recent workflow failure'], $assessment->reasons);
+        $this->assertSame(['Review failing workflow before merge'], $assessment->recommended_actions);
+        $this->assertSame(['pull_request' => ['number' => 42, 'changed_files' => 18]], $assessment->input_snapshot);
+        $this->assertSame('2026-07-21 15:30:00', $assessment->assessed_at->format('Y-m-d H:i:s'));
+        $this->assertTrue($assessment->pullRequest->is($pullRequest));
+        $this->assertTrue($pullRequest->riskAssessment->is($assessment));
+    }
+
+    public function test_pull_request_has_one_current_risk_assessment_and_cascades_delete(): void
+    {
+        $pullRequest = GithubPullRequest::factory()->create();
+
+        PullRequestRiskAssessment::factory()->for($pullRequest, 'pullRequest')->create();
+
+        $this->expectException(UniqueConstraintViolationException::class);
+
+        PullRequestRiskAssessment::factory()->for($pullRequest, 'pullRequest')->create();
+    }
+
+    public function test_pull_request_risk_assessment_is_deleted_with_pull_request(): void
+    {
+        $pullRequest = GithubPullRequest::factory()->create();
+        $assessment = PullRequestRiskAssessment::factory()->for($pullRequest, 'pullRequest')->create();
+
+        $pullRequest->delete();
+
+        $this->assertDatabaseMissing('pull_request_risk_assessments', ['id' => $assessment->id]);
+    }
+
+    public function test_project_health_explanation_casts_payloads_and_relationships(): void
+    {
+        $project = Project::factory()->create(['health_score' => 42]);
+
+        $explanation = ProjectHealthExplanation::factory()
+            ->explained()
+            ->for($project)
+            ->create(['explained_at' => '2026-07-21 15:35:00']);
+
+        $this->assertSame(ProjectHealthExplanationStatus::Explained, $explanation->status);
+        $this->assertSame(42, $explanation->health_score);
+        $this->assertSame(HealthScoreBand::Warning, $explanation->health_band);
+        $this->assertSame(['2 critical alerts', '1 failing website check'], $explanation->drivers);
+        $this->assertSame(['Investigate the critical alerts first'], $explanation->recommended_actions);
+        $this->assertSame(['project' => ['health_score' => 42]], $explanation->input_snapshot);
+        $this->assertSame('2026-07-21 15:35:00', $explanation->explained_at->format('Y-m-d H:i:s'));
+        $this->assertTrue($explanation->project->is($project));
+        $this->assertTrue($project->healthExplanation->is($explanation));
+    }
+
+    public function test_project_has_one_current_health_explanation_and_cascades_delete(): void
+    {
+        $project = Project::factory()->create();
+
+        ProjectHealthExplanation::factory()->for($project)->create();
+
+        $this->expectException(UniqueConstraintViolationException::class);
+
+        ProjectHealthExplanation::factory()->for($project)->create();
+    }
+
+    public function test_project_health_explanation_is_deleted_with_project(): void
+    {
+        $project = Project::factory()->create();
+        $explanation = ProjectHealthExplanation::factory()->for($project)->create();
+
+        $project->delete();
+
+        $this->assertDatabaseMissing('project_health_explanations', ['id' => $explanation->id]);
+    }
+}

--- a/tests/Feature/AiInsights/GenerateProjectHealthExplanationActionTest.php
+++ b/tests/Feature/AiInsights/GenerateProjectHealthExplanationActionTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Tests\Feature\AiInsights;
+
+use App\Domain\AI\Contracts\LlmClient;
+use App\Domain\AI\DataTransferObjects\LlmPrompt;
+use App\Domain\AI\DataTransferObjects\LlmResponse;
+use App\Domain\AiInsights\Actions\GenerateProjectHealthExplanationAction;
+use App\Enums\HealthScoreBand;
+use App\Enums\ProjectHealthExplanationStatus;
+use App\Models\Project;
+use App\Models\ProjectHealthExplanation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use RuntimeException;
+use Tests\TestCase;
+
+class GenerateProjectHealthExplanationActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_builds_versioned_prompt_calls_llm_and_persists_explained_output(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $project = Project::factory()->create(['health_score' => 28]);
+        $client = new HealthExplanationFakeLlmClient(new LlmResponse(json_encode([
+            'summary' => 'Health is critical because active alerts and failed checks are concentrated on production.',
+            'drivers' => ['Seven critical alerts are active.', 'Default branch workflow failures increased.'],
+            'recommended_actions' => ['Investigate active critical alerts first.'],
+        ], JSON_THROW_ON_ERROR), 'claude-3-5-haiku-latest'));
+        $this->app->instance(LlmClient::class, $client);
+
+        $explanation = app(GenerateProjectHealthExplanationAction::class)->execute($project, $this->snapshot());
+
+        $this->assertSame(ProjectHealthExplanationStatus::Explained, $explanation->status);
+        $this->assertSame(28, $explanation->health_score);
+        $this->assertSame(HealthScoreBand::Critical, $explanation->health_band);
+        $this->assertSame('Health is critical because active alerts and failed checks are concentrated on production.', $explanation->summary);
+        $this->assertSame(['Seven critical alerts are active.', 'Default branch workflow failures increased.'], $explanation->drivers);
+        $this->assertSame(['Investigate active critical alerts first.'], $explanation->recommended_actions);
+        $this->assertSame($this->snapshot(), $explanation->input_snapshot);
+        $this->assertSame(GenerateProjectHealthExplanationAction::PROMPT_VERSION, $explanation->prompt_version);
+        $this->assertSame('claude-3-5-haiku-latest', $explanation->model);
+        $this->assertNotNull($explanation->explained_at);
+        $this->assertNull($explanation->failed_at);
+        $this->assertNull($explanation->error_message);
+
+        $this->assertNotNull($client->prompt);
+        $this->assertSame(GenerateProjectHealthExplanationAction::PROMPT_VERSION, $client->prompt->version);
+        $this->assertStringContainsString('Return only valid JSON', $client->prompt->system);
+        $this->assertStringContainsString('Do not invent a different score', $client->prompt->system);
+        $this->assertStringContainsString('"prompt_version":"project-health-explanation-v1"', $client->prompt->user);
+        $this->assertStringContainsString('"Checkout Platform"', $client->prompt->user);
+    }
+
+    public function test_sanitizes_structured_output_before_persisting(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $project = Project::factory()->create(['health_score' => 28]);
+        $this->app->instance(LlmClient::class, new HealthExplanationFakeLlmClient(new LlmResponse(json_encode([
+            'summary' => '<strong>Critical</strong> health needs attention.',
+            'drivers' => ["<b>Alerts</b>\nare active"],
+            'recommended_actions' => ['<script>bad()</script>Check production site.'],
+        ], JSON_THROW_ON_ERROR))));
+
+        $explanation = app(GenerateProjectHealthExplanationAction::class)->execute($project, $this->snapshot());
+
+        $this->assertSame('Critical health needs attention.', $explanation->summary);
+        $this->assertSame(['Alerts are active'], $explanation->drivers);
+        $this->assertSame(['bad()Check production site.'], $explanation->recommended_actions);
+    }
+
+    public function test_persists_failed_status_when_llm_client_errors(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $project = Project::factory()->create(['health_score' => 28]);
+        $this->app->instance(LlmClient::class, new HealthExplanationFakeLlmClient(exception: new RuntimeException('Provider timed out')));
+
+        $explanation = app(GenerateProjectHealthExplanationAction::class)->execute($project, $this->snapshot());
+
+        $this->assertSame(ProjectHealthExplanationStatus::Failed, $explanation->status);
+        $this->assertSame(28, $explanation->health_score);
+        $this->assertSame(HealthScoreBand::Critical, $explanation->health_band);
+        $this->assertNull($explanation->summary);
+        $this->assertSame([], $explanation->drivers);
+        $this->assertSame($this->snapshot(), $explanation->input_snapshot);
+        $this->assertNull($explanation->explained_at);
+        $this->assertNotNull($explanation->failed_at);
+        $this->assertSame('Provider timed out', $explanation->error_message);
+    }
+
+    public function test_fails_closed_without_calling_llm_when_ai_features_are_disabled(): void
+    {
+        config(['services.llm.enabled' => false]);
+
+        $project = Project::factory()->create(['health_score' => 28]);
+        $client = new HealthExplanationFakeLlmClient(new LlmResponse('{}'));
+        $this->app->instance(LlmClient::class, $client);
+
+        $explanation = app(GenerateProjectHealthExplanationAction::class)->execute($project, $this->snapshot());
+
+        $this->assertSame(ProjectHealthExplanationStatus::Failed, $explanation->status);
+        $this->assertSame('AI features are disabled.', $explanation->error_message);
+        $this->assertNull($client->prompt);
+    }
+
+    public function test_invalid_llm_output_is_stored_as_failed_explanation(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $project = Project::factory()->create(['health_score' => 28]);
+        $this->app->instance(LlmClient::class, new HealthExplanationFakeLlmClient(new LlmResponse(json_encode([
+            'summary' => 'Missing drivers.',
+            'drivers' => [],
+        ], JSON_THROW_ON_ERROR))));
+
+        $explanation = app(GenerateProjectHealthExplanationAction::class)->execute($project, $this->snapshot());
+
+        $this->assertSame(ProjectHealthExplanationStatus::Failed, $explanation->status);
+        $this->assertSame('LLM response must include 1 to 6 drivers.', $explanation->error_message);
+    }
+
+    public function test_reuses_existing_current_row_when_regenerating(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $project = Project::factory()->create(['health_score' => 28]);
+        $existing = ProjectHealthExplanation::factory()->for($project)->create([
+            'status' => ProjectHealthExplanationStatus::Failed->value,
+            'error_message' => 'Previous failure',
+        ]);
+        $this->app->instance(LlmClient::class, new HealthExplanationFakeLlmClient(new LlmResponse(json_encode([
+            'summary' => 'Health improved but active alerts remain.',
+            'drivers' => ['Current health score is 28.'],
+            'recommended_actions' => [],
+        ], JSON_THROW_ON_ERROR))));
+
+        $explanation = app(GenerateProjectHealthExplanationAction::class)->execute($project, $this->snapshot());
+
+        $this->assertSame($existing->id, $explanation->id);
+        $this->assertSame(ProjectHealthExplanationStatus::Explained, $explanation->status);
+        $this->assertDatabaseCount('project_health_explanations', 1);
+    }
+
+    /** @return array<string, mixed> */
+    private function snapshot(): array
+    {
+        return [
+            'snapshot_version' => 'project-health-explanation-input-v1',
+            'project' => [
+                'id' => 1,
+                'name' => 'Checkout Platform',
+                'health_score' => 28,
+                'health_band' => 'critical',
+            ],
+            'drivers' => [
+                'alerts' => ['active_total' => 7],
+                'deployments' => ['failed_default_branch_last_24h' => 2],
+            ],
+            'health_delta' => null,
+        ];
+    }
+}
+
+class HealthExplanationFakeLlmClient implements LlmClient
+{
+    public ?LlmPrompt $prompt = null;
+
+    public function __construct(
+        private readonly ?LlmResponse $response = null,
+        private readonly ?RuntimeException $exception = null,
+    ) {}
+
+    public function complete(LlmPrompt $prompt): LlmResponse
+    {
+        $this->prompt = $prompt;
+
+        if ($this->exception !== null) {
+            throw $this->exception;
+        }
+
+        return $this->response ?? new LlmResponse('{}');
+    }
+}

--- a/tests/Feature/AiInsights/GenerateProjectHealthExplanationJobTest.php
+++ b/tests/Feature/AiInsights/GenerateProjectHealthExplanationJobTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Feature\AiInsights;
+
+use App\Domain\AI\Contracts\LlmClient;
+use App\Domain\AI\DataTransferObjects\LlmPrompt;
+use App\Domain\AI\DataTransferObjects\LlmResponse;
+use App\Domain\AiInsights\Actions\GenerateProjectHealthExplanationAction;
+use App\Domain\AiInsights\Jobs\GenerateProjectHealthExplanationJob;
+use App\Domain\AiInsights\Queries\GetProjectHealthExplanationInputQuery;
+use App\Enums\ProjectHealthExplanationStatus;
+use App\Models\Project;
+use App\Models\ProjectHealthExplanation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class GenerateProjectHealthExplanationJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_is_unique_by_project(): void
+    {
+        $job = new GenerateProjectHealthExplanationJob(123);
+
+        $this->assertSame('123', $job->uniqueId());
+        $this->assertSame(2, $job->tries);
+    }
+
+    public function test_builds_input_snapshot_and_generates_health_explanation(): void
+    {
+        config(['services.llm.enabled' => true]);
+        $project = $this->project();
+        $client = new HealthJobFakeLlmClient;
+        $this->app->instance(LlmClient::class, $client);
+
+        (new GenerateProjectHealthExplanationJob($project->id))->handle(
+            app(GetProjectHealthExplanationInputQuery::class),
+            app(GenerateProjectHealthExplanationAction::class),
+        );
+
+        $explanation = ProjectHealthExplanation::query()->sole();
+        $this->assertSame(ProjectHealthExplanationStatus::Explained, $explanation->status);
+        $this->assertSame($project->id, $explanation->input_snapshot['project']['id']);
+        $this->assertNotNull($client->prompt);
+    }
+
+    public function test_does_not_generate_when_ai_is_disabled(): void
+    {
+        config(['services.llm.enabled' => false]);
+        $project = $this->project();
+        $client = new HealthJobFakeLlmClient;
+        $this->app->instance(LlmClient::class, $client);
+
+        (new GenerateProjectHealthExplanationJob($project->id))->handle(
+            app(GetProjectHealthExplanationInputQuery::class),
+            app(GenerateProjectHealthExplanationAction::class),
+        );
+
+        $this->assertDatabaseCount('project_health_explanations', 0);
+        $this->assertNull($client->prompt);
+    }
+
+    public function test_failed_handler_marks_pending_explanation_failed_after_retries_are_exhausted(): void
+    {
+        $project = $this->project();
+        $explanation = ProjectHealthExplanation::factory()->for($project)->create([
+            'status' => ProjectHealthExplanationStatus::Pending->value,
+        ]);
+
+        (new GenerateProjectHealthExplanationJob($project->id))->failed(new \RuntimeException('Snapshot failed'));
+
+        $this->assertSame(ProjectHealthExplanationStatus::Failed, $explanation->refresh()->status);
+        $this->assertSame('Snapshot failed', $explanation->error_message);
+        $this->assertNotNull($explanation->failed_at);
+    }
+
+    public function test_null_scoped_snapshot_marks_pending_explanation_skipped(): void
+    {
+        config(['services.llm.enabled' => true]);
+        Queue::fake();
+        $project = $this->project();
+        $client = new HealthJobFakeLlmClient;
+        $this->app->instance(LlmClient::class, $client);
+
+        (new GenerateProjectHealthExplanationJob($project->id))->handle(
+            new NullProjectHealthExplanationInputQuery,
+            app(GenerateProjectHealthExplanationAction::class),
+        );
+
+        $explanation = ProjectHealthExplanation::query()->sole();
+        $this->assertSame(ProjectHealthExplanationStatus::Skipped, $explanation->status);
+        $this->assertStringContainsString('scoped AI input query', $explanation->error_message);
+        $this->assertNull($client->prompt);
+    }
+
+    private function project(): Project
+    {
+        $user = User::factory()->create();
+
+        return Project::factory()->create([
+            'owner_user_id' => $user->id,
+            'health_score' => 42,
+        ]);
+    }
+}
+
+class NullProjectHealthExplanationInputQuery extends GetProjectHealthExplanationInputQuery
+{
+    public function execute(User $user, Project $project): ?array
+    {
+        return null;
+    }
+}
+
+class HealthJobFakeLlmClient implements LlmClient
+{
+    public ?LlmPrompt $prompt = null;
+
+    public function complete(LlmPrompt $prompt): LlmResponse
+    {
+        $this->prompt = $prompt;
+
+        return new LlmResponse(json_encode([
+            'summary' => 'Health is reduced by active alerts and failed checks.',
+            'drivers' => ['Critical alerts are active', 'Website checks are failing'],
+            'recommended_actions' => ['Investigate the critical alerts first'],
+        ], JSON_THROW_ON_ERROR));
+    }
+}

--- a/tests/Feature/AiInsights/GenerateProjectHealthExplanationJobTest.php
+++ b/tests/Feature/AiInsights/GenerateProjectHealthExplanationJobTest.php
@@ -25,7 +25,7 @@ class GenerateProjectHealthExplanationJobTest extends TestCase
         $job = new GenerateProjectHealthExplanationJob(123);
 
         $this->assertSame('123', $job->uniqueId());
-        $this->assertSame(2, $job->tries);
+        $this->assertSame(1, $job->tries);
     }
 
     public function test_builds_input_snapshot_and_generates_health_explanation(): void
@@ -59,6 +59,26 @@ class GenerateProjectHealthExplanationJobTest extends TestCase
         );
 
         $this->assertDatabaseCount('project_health_explanations', 0);
+        $this->assertNull($client->prompt);
+    }
+
+    public function test_marks_existing_pending_explanation_skipped_when_ai_is_disabled(): void
+    {
+        config(['services.llm.enabled' => false]);
+        $project = $this->project();
+        $explanation = ProjectHealthExplanation::factory()->for($project)->create([
+            'status' => ProjectHealthExplanationStatus::Pending->value,
+        ]);
+        $client = new HealthJobFakeLlmClient;
+        $this->app->instance(LlmClient::class, $client);
+
+        (new GenerateProjectHealthExplanationJob($project->id))->handle(
+            app(GetProjectHealthExplanationInputQuery::class),
+            app(GenerateProjectHealthExplanationAction::class),
+        );
+
+        $this->assertSame(ProjectHealthExplanationStatus::Skipped, $explanation->refresh()->status);
+        $this->assertSame('AI features are disabled.', $explanation->error_message);
         $this->assertNull($client->prompt);
     }
 

--- a/tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentActionTest.php
+++ b/tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentActionTest.php
@@ -302,6 +302,46 @@ class GeneratePullRequestRiskAssessmentActionTest extends TestCase
         Bus::assertDispatchedTimes(DispatchAlertNotificationJob::class, 1);
     }
 
+    public function test_resolved_historical_risk_alert_does_not_suppress_later_material_increase(): void
+    {
+        config(['services.llm.enabled' => true]);
+        Bus::fake();
+
+        $pullRequest = $this->ownedPullRequest();
+        $channel = AlertNotificationChannel::factory()->slack()->for($pullRequest->repository->project->owner)->create();
+        AlertNotificationPreference::factory()
+            ->for($pullRequest->repository->project->owner)
+            ->for($channel, 'channel')
+            ->create(['min_severity' => AlertSeverity::Warning->value]);
+        PullRequestRiskAssessment::factory()->for($pullRequest, 'pullRequest')->scored()->create([
+            'risk_level' => PullRequestRiskLevel::Medium->value,
+            'risk_score' => 44,
+        ]);
+        Alert::factory()->resolved()->create([
+            'project_id' => $pullRequest->repository->project_id,
+            'source' => AlertSource::Github->value,
+            'source_id' => $pullRequest->id,
+            'type' => 'pull_request.risk.high',
+            'severity' => AlertSeverity::Warning->value,
+        ]);
+        $this->app->instance(LlmClient::class, new RiskAssessmentFakeLlmClient(new LlmResponse(json_encode([
+            'risk_level' => 'high',
+            'risk_score' => 86,
+            'summary' => 'Risk increased again after the prior alert was resolved.',
+            'reasons' => ['Changed files increased materially.'],
+            'recommended_actions' => [],
+        ], JSON_THROW_ON_ERROR))));
+
+        app(GeneratePullRequestRiskAssessmentAction::class)->execute($pullRequest, $this->snapshot());
+
+        $this->assertDatabaseCount('alerts', 2);
+        $this->assertSame(1, Alert::query()
+            ->where('type', 'pull_request.risk.high')
+            ->where('status', 'open')
+            ->count());
+        Bus::assertDispatchedTimes(DispatchAlertNotificationJob::class, 1);
+    }
+
     /** @return array<string, mixed> */
     private function snapshot(): array
     {

--- a/tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentActionTest.php
+++ b/tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentActionTest.php
@@ -6,11 +6,21 @@ use App\Domain\AI\Contracts\LlmClient;
 use App\Domain\AI\DataTransferObjects\LlmPrompt;
 use App\Domain\AI\DataTransferObjects\LlmResponse;
 use App\Domain\AiInsights\Actions\GeneratePullRequestRiskAssessmentAction;
+use App\Domain\Notifications\Jobs\DispatchAlertNotificationJob;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
 use App\Enums\PullRequestRiskAssessmentStatus;
 use App\Enums\PullRequestRiskLevel;
+use App\Models\Alert;
+use App\Models\AlertNotificationChannel;
+use App\Models\AlertNotificationPreference;
 use App\Models\GithubPullRequest;
+use App\Models\Project;
 use App\Models\PullRequestRiskAssessment;
+use App\Models\Repository;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
 use RuntimeException;
 use Tests\TestCase;
 
@@ -21,6 +31,7 @@ class GeneratePullRequestRiskAssessmentActionTest extends TestCase
     public function test_builds_versioned_prompt_calls_llm_and_persists_scored_output(): void
     {
         config(['services.llm.enabled' => true]);
+        Bus::fake();
 
         $pullRequest = GithubPullRequest::factory()->create();
         $client = new RiskAssessmentFakeLlmClient(new LlmResponse(json_encode([
@@ -152,6 +163,145 @@ class GeneratePullRequestRiskAssessmentActionTest extends TestCase
         $this->assertDatabaseCount('pull_request_risk_assessments', 1);
     }
 
+    public function test_high_risk_increase_dispatches_one_spec_042_notification(): void
+    {
+        config(['services.llm.enabled' => true]);
+        Bus::fake();
+
+        $pullRequest = $this->ownedPullRequest();
+        $channel = AlertNotificationChannel::factory()->slack()->for($pullRequest->repository->project->owner)->create();
+        AlertNotificationPreference::factory()
+            ->for($pullRequest->repository->project->owner)
+            ->for($channel, 'channel')
+            ->create(['min_severity' => AlertSeverity::Warning->value]);
+        PullRequestRiskAssessment::factory()->for($pullRequest, 'pullRequest')->scored()->create([
+            'risk_level' => PullRequestRiskLevel::Medium->value,
+            'risk_score' => 45,
+        ]);
+        $this->app->instance(LlmClient::class, new RiskAssessmentFakeLlmClient(new LlmResponse(json_encode([
+            'risk_level' => 'high',
+            'risk_score' => 82,
+            'summary' => 'Large change with failing workflow needs careful review.',
+            'reasons' => ['Changed files are high.'],
+            'recommended_actions' => [],
+        ], JSON_THROW_ON_ERROR))));
+
+        app(GeneratePullRequestRiskAssessmentAction::class)->execute($pullRequest, $this->snapshot());
+
+        $alert = Alert::query()->where('source', AlertSource::Github->value)->firstOrFail();
+        $this->assertSame($pullRequest->repository->project_id, $alert->project_id);
+        $this->assertSame($pullRequest->id, $alert->source_id);
+        $this->assertSame('pull_request.risk.high', $alert->type);
+        $this->assertSame(AlertSeverity::Warning, $alert->severity);
+        $this->assertSame('high', $alert->metadata['risk_level']);
+        Bus::assertDispatchedTimes(DispatchAlertNotificationJob::class, 1);
+    }
+
+    public function test_unchanged_low_or_medium_risk_does_not_notify(): void
+    {
+        config(['services.llm.enabled' => true]);
+        Bus::fake();
+
+        $pullRequest = $this->ownedPullRequest();
+        AlertNotificationPreference::factory()
+            ->for($pullRequest->repository->project->owner)
+            ->for(AlertNotificationChannel::factory()->for($pullRequest->repository->project->owner)->create(), 'channel')
+            ->create(['min_severity' => AlertSeverity::Warning->value]);
+        PullRequestRiskAssessment::factory()->for($pullRequest, 'pullRequest')->scored()->create([
+            'risk_level' => PullRequestRiskLevel::Low->value,
+            'risk_score' => 14,
+        ]);
+        $this->app->instance(LlmClient::class, new RiskAssessmentFakeLlmClient(new LlmResponse(json_encode([
+            'risk_level' => 'medium',
+            'risk_score' => 51,
+            'summary' => 'Moderate risk from size.',
+            'reasons' => ['Changed files are moderate.'],
+            'recommended_actions' => [],
+        ], JSON_THROW_ON_ERROR))));
+
+        app(GeneratePullRequestRiskAssessmentAction::class)->execute($pullRequest, $this->snapshot());
+
+        $this->assertDatabaseCount('alerts', 0);
+        Bus::assertNotDispatched(DispatchAlertNotificationJob::class);
+    }
+
+    public function test_repeated_same_high_risk_level_does_not_notify_again(): void
+    {
+        config(['services.llm.enabled' => true]);
+        Bus::fake();
+
+        $pullRequest = $this->ownedPullRequest();
+        AlertNotificationPreference::factory()
+            ->for($pullRequest->repository->project->owner)
+            ->for(AlertNotificationChannel::factory()->for($pullRequest->repository->project->owner)->create(), 'channel')
+            ->create(['min_severity' => AlertSeverity::Warning->value]);
+        PullRequestRiskAssessment::factory()->for($pullRequest, 'pullRequest')->scored()->create([
+            'risk_level' => PullRequestRiskLevel::High->value,
+            'risk_score' => 76,
+        ]);
+        Alert::factory()->create([
+            'project_id' => $pullRequest->repository->project_id,
+            'source' => AlertSource::Github->value,
+            'source_id' => $pullRequest->id,
+            'type' => 'pull_request.risk.high',
+            'severity' => AlertSeverity::Warning->value,
+        ]);
+        $this->app->instance(LlmClient::class, new RiskAssessmentFakeLlmClient(new LlmResponse(json_encode([
+            'risk_level' => 'high',
+            'risk_score' => 84,
+            'summary' => 'Risk remains high.',
+            'reasons' => ['Changed files remain high.'],
+            'recommended_actions' => [],
+        ], JSON_THROW_ON_ERROR))));
+
+        app(GeneratePullRequestRiskAssessmentAction::class)->execute($pullRequest, $this->snapshot());
+
+        $this->assertDatabaseCount('alerts', 1);
+        Bus::assertNotDispatched(DispatchAlertNotificationJob::class);
+    }
+
+    public function test_high_to_critical_increase_dispatches_critical_notification(): void
+    {
+        config(['services.llm.enabled' => true]);
+        Bus::fake();
+
+        $pullRequest = $this->ownedPullRequest();
+        $channel = AlertNotificationChannel::factory()->for($pullRequest->repository->project->owner)->create();
+        AlertNotificationPreference::factory()
+            ->for($pullRequest->repository->project->owner)
+            ->for($channel, 'channel')
+            ->create(['min_severity' => AlertSeverity::Critical->value]);
+        PullRequestRiskAssessment::factory()->for($pullRequest, 'pullRequest')->scored()->create([
+            'risk_level' => PullRequestRiskLevel::High->value,
+            'risk_score' => 78,
+        ]);
+        Alert::factory()->create([
+            'project_id' => $pullRequest->repository->project_id,
+            'source' => AlertSource::Github->value,
+            'source_id' => $pullRequest->id,
+            'type' => 'pull_request.risk.high',
+            'severity' => AlertSeverity::Warning->value,
+        ]);
+        $this->app->instance(LlmClient::class, new RiskAssessmentFakeLlmClient(new LlmResponse(json_encode([
+            'risk_level' => 'critical',
+            'risk_score' => 96,
+            'summary' => 'Critical risk from failing checks and large scope.',
+            'reasons' => ['Failing checks combine with large scope.'],
+            'recommended_actions' => ['Escalate before merge.'],
+        ], JSON_THROW_ON_ERROR))));
+
+        app(GeneratePullRequestRiskAssessmentAction::class)->execute($pullRequest, $this->snapshot());
+
+        $this->assertDatabaseHas('alerts', [
+            'source' => AlertSource::Github->value,
+            'source_id' => $pullRequest->id,
+            'type' => 'pull_request.risk.critical',
+            'severity' => AlertSeverity::Critical->value,
+        ]);
+        $this->assertDatabaseCount('alerts', 2);
+        Bus::assertDispatchedTimes(DispatchAlertNotificationJob::class, 1);
+    }
+
     /** @return array<string, mixed> */
     private function snapshot(): array
     {
@@ -163,6 +313,15 @@ class GeneratePullRequestRiskAssessmentActionTest extends TestCase
             'recent_failed_workflows' => [['id' => 1, 'conclusion' => 'failure']],
             'active_alerts' => [],
         ];
+    }
+
+    private function ownedPullRequest(): GithubPullRequest
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->for($user, 'owner')->create();
+        $repository = Repository::factory()->for($project)->create();
+
+        return GithubPullRequest::factory()->for($repository, 'repository')->create();
     }
 }
 
@@ -177,7 +336,7 @@ class RiskAssessmentFakeLlmClient implements LlmClient
 
     public function complete(LlmPrompt $prompt): LlmResponse
     {
-        $this->prompt = $prompt;
+        $this->prompt ??= $prompt;
 
         if ($this->exception !== null) {
             throw $this->exception;

--- a/tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentActionTest.php
+++ b/tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentActionTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Tests\Feature\AiInsights;
+
+use App\Domain\AI\Contracts\LlmClient;
+use App\Domain\AI\DataTransferObjects\LlmPrompt;
+use App\Domain\AI\DataTransferObjects\LlmResponse;
+use App\Domain\AiInsights\Actions\GeneratePullRequestRiskAssessmentAction;
+use App\Enums\PullRequestRiskAssessmentStatus;
+use App\Enums\PullRequestRiskLevel;
+use App\Models\GithubPullRequest;
+use App\Models\PullRequestRiskAssessment;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use RuntimeException;
+use Tests\TestCase;
+
+class GeneratePullRequestRiskAssessmentActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_builds_versioned_prompt_calls_llm_and_persists_scored_output(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $pullRequest = GithubPullRequest::factory()->create();
+        $client = new RiskAssessmentFakeLlmClient(new LlmResponse(json_encode([
+            'risk_level' => 'high',
+            'risk_score' => 82,
+            'summary' => 'Large change with failing workflow needs careful review.',
+            'reasons' => ['Changed files are high.', 'Recent workflow failed.'],
+            'recommended_actions' => ['Review failed workflow before merge.'],
+        ], JSON_THROW_ON_ERROR), 'claude-3-5-haiku-latest'));
+        $this->app->instance(LlmClient::class, $client);
+
+        $assessment = app(GeneratePullRequestRiskAssessmentAction::class)->execute($pullRequest, $this->snapshot());
+
+        $this->assertSame(PullRequestRiskAssessmentStatus::Scored, $assessment->status);
+        $this->assertSame(PullRequestRiskLevel::High, $assessment->risk_level);
+        $this->assertSame(82, $assessment->risk_score);
+        $this->assertSame('Large change with failing workflow needs careful review.', $assessment->summary);
+        $this->assertSame(['Changed files are high.', 'Recent workflow failed.'], $assessment->reasons);
+        $this->assertSame(['Review failed workflow before merge.'], $assessment->recommended_actions);
+        $this->assertSame($this->snapshot(), $assessment->input_snapshot);
+        $this->assertSame(GeneratePullRequestRiskAssessmentAction::PROMPT_VERSION, $assessment->prompt_version);
+        $this->assertSame('claude-3-5-haiku-latest', $assessment->model);
+        $this->assertNotNull($assessment->assessed_at);
+        $this->assertNull($assessment->failed_at);
+        $this->assertNull($assessment->error_message);
+
+        $this->assertNotNull($client->prompt);
+        $this->assertSame(GeneratePullRequestRiskAssessmentAction::PROMPT_VERSION, $client->prompt->version);
+        $this->assertStringContainsString('Return only valid JSON', $client->prompt->system);
+        $this->assertStringContainsString('"prompt_version":"pr-risk-v1"', $client->prompt->user);
+        $this->assertStringContainsString('"Checkout refactor"', $client->prompt->user);
+    }
+
+    public function test_sanitizes_structured_output_before_persisting(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $pullRequest = GithubPullRequest::factory()->create();
+        $this->app->instance(LlmClient::class, new RiskAssessmentFakeLlmClient(new LlmResponse(json_encode([
+            'risk_level' => 'medium',
+            'risk_score' => 54,
+            'summary' => '<strong>Moderate</strong> risk from size.',
+            'reasons' => ["<b>Large diff</b>\nneeds review"],
+            'recommended_actions' => ['<script>bad()</script>Review workflow status.'],
+        ], JSON_THROW_ON_ERROR))));
+
+        $assessment = app(GeneratePullRequestRiskAssessmentAction::class)->execute($pullRequest, $this->snapshot());
+
+        $this->assertSame('Moderate risk from size.', $assessment->summary);
+        $this->assertSame(['Large diff needs review'], $assessment->reasons);
+        $this->assertSame(['bad()Review workflow status.'], $assessment->recommended_actions);
+    }
+
+    public function test_persists_failed_status_when_llm_client_errors(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $pullRequest = GithubPullRequest::factory()->create();
+        $this->app->instance(LlmClient::class, new RiskAssessmentFakeLlmClient(exception: new RuntimeException('Provider timed out')));
+
+        $assessment = app(GeneratePullRequestRiskAssessmentAction::class)->execute($pullRequest, $this->snapshot());
+
+        $this->assertSame(PullRequestRiskAssessmentStatus::Failed, $assessment->status);
+        $this->assertNull($assessment->risk_level);
+        $this->assertNull($assessment->risk_score);
+        $this->assertNull($assessment->summary);
+        $this->assertSame([], $assessment->reasons);
+        $this->assertSame($this->snapshot(), $assessment->input_snapshot);
+        $this->assertNull($assessment->assessed_at);
+        $this->assertNotNull($assessment->failed_at);
+        $this->assertSame('Provider timed out', $assessment->error_message);
+    }
+
+    public function test_fails_closed_without_calling_llm_when_ai_features_are_disabled(): void
+    {
+        config(['services.llm.enabled' => false]);
+
+        $pullRequest = GithubPullRequest::factory()->create();
+        $client = new RiskAssessmentFakeLlmClient(new LlmResponse('{}'));
+        $this->app->instance(LlmClient::class, $client);
+
+        $assessment = app(GeneratePullRequestRiskAssessmentAction::class)->execute($pullRequest, $this->snapshot());
+
+        $this->assertSame(PullRequestRiskAssessmentStatus::Failed, $assessment->status);
+        $this->assertSame('AI features are disabled.', $assessment->error_message);
+        $this->assertNull($client->prompt);
+    }
+
+    public function test_invalid_llm_output_is_stored_as_failed_assessment(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $pullRequest = GithubPullRequest::factory()->create();
+        $this->app->instance(LlmClient::class, new RiskAssessmentFakeLlmClient(new LlmResponse(json_encode([
+            'risk_level' => 'urgent',
+            'risk_score' => 101,
+            'summary' => 'Invalid risk.',
+            'reasons' => ['Unsupported risk level.'],
+        ], JSON_THROW_ON_ERROR))));
+
+        $assessment = app(GeneratePullRequestRiskAssessmentAction::class)->execute($pullRequest, $this->snapshot());
+
+        $this->assertSame(PullRequestRiskAssessmentStatus::Failed, $assessment->status);
+        $this->assertSame('LLM response risk_level is invalid.', $assessment->error_message);
+    }
+
+    public function test_reuses_existing_current_row_when_regenerating(): void
+    {
+        config(['services.llm.enabled' => true]);
+
+        $pullRequest = GithubPullRequest::factory()->create();
+        $existing = PullRequestRiskAssessment::factory()->for($pullRequest, 'pullRequest')->create([
+            'status' => PullRequestRiskAssessmentStatus::Failed->value,
+            'error_message' => 'Previous failure',
+        ]);
+        $this->app->instance(LlmClient::class, new RiskAssessmentFakeLlmClient(new LlmResponse(json_encode([
+            'risk_level' => 'low',
+            'risk_score' => 12,
+            'summary' => 'Small PR with no active risk signals.',
+            'reasons' => ['Small changed file count.'],
+            'recommended_actions' => [],
+        ], JSON_THROW_ON_ERROR))));
+
+        $assessment = app(GeneratePullRequestRiskAssessmentAction::class)->execute($pullRequest, $this->snapshot());
+
+        $this->assertSame($existing->id, $assessment->id);
+        $this->assertSame(PullRequestRiskAssessmentStatus::Scored, $assessment->status);
+        $this->assertSame(PullRequestRiskLevel::Low, $assessment->risk_level);
+        $this->assertDatabaseCount('pull_request_risk_assessments', 1);
+    }
+
+    /** @return array<string, mixed> */
+    private function snapshot(): array
+    {
+        return [
+            'snapshot_version' => 'pr-risk-input-v1',
+            'project' => ['id' => 1, 'name' => 'Checkout API', 'health_score' => 42],
+            'repository' => ['id' => 1, 'full_name' => 'nexus/checkout-api'],
+            'pull_request' => ['id' => 1, 'number' => 10, 'title' => 'Checkout refactor', 'changed_files' => 12],
+            'recent_failed_workflows' => [['id' => 1, 'conclusion' => 'failure']],
+            'active_alerts' => [],
+        ];
+    }
+}
+
+class RiskAssessmentFakeLlmClient implements LlmClient
+{
+    public ?LlmPrompt $prompt = null;
+
+    public function __construct(
+        private readonly ?LlmResponse $response = null,
+        private readonly ?RuntimeException $exception = null,
+    ) {}
+
+    public function complete(LlmPrompt $prompt): LlmResponse
+    {
+        $this->prompt = $prompt;
+
+        if ($this->exception !== null) {
+            throw $this->exception;
+        }
+
+        return $this->response ?? new LlmResponse('{}');
+    }
+}

--- a/tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentJobTest.php
+++ b/tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentJobTest.php
@@ -28,7 +28,7 @@ class GeneratePullRequestRiskAssessmentJobTest extends TestCase
         $job = new GeneratePullRequestRiskAssessmentJob(123);
 
         $this->assertSame('123', $job->uniqueId());
-        $this->assertSame(2, $job->tries);
+        $this->assertSame(1, $job->tries);
     }
 
     public function test_builds_input_snapshot_and_generates_risk_assessment(): void
@@ -63,6 +63,26 @@ class GeneratePullRequestRiskAssessmentJobTest extends TestCase
         );
 
         $this->assertDatabaseCount('pull_request_risk_assessments', 0);
+        $this->assertNull($client->prompt);
+    }
+
+    public function test_marks_existing_pending_assessment_skipped_when_ai_is_disabled(): void
+    {
+        config(['services.llm.enabled' => false]);
+        $pullRequest = $this->pullRequest();
+        $assessment = PullRequestRiskAssessment::factory()->for($pullRequest, 'pullRequest')->create([
+            'status' => PullRequestRiskAssessmentStatus::Pending->value,
+        ]);
+        $client = new RiskJobFakeLlmClient;
+        $this->app->instance(LlmClient::class, $client);
+
+        (new GeneratePullRequestRiskAssessmentJob($pullRequest->id))->handle(
+            app(GetPullRequestRiskInputQuery::class),
+            app(GeneratePullRequestRiskAssessmentAction::class),
+        );
+
+        $this->assertSame(PullRequestRiskAssessmentStatus::Skipped, $assessment->refresh()->status);
+        $this->assertSame('AI features are disabled.', $assessment->error_message);
         $this->assertNull($client->prompt);
     }
 

--- a/tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentJobTest.php
+++ b/tests/Feature/AiInsights/GeneratePullRequestRiskAssessmentJobTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Tests\Feature\AiInsights;
+
+use App\Domain\AI\Contracts\LlmClient;
+use App\Domain\AI\DataTransferObjects\LlmPrompt;
+use App\Domain\AI\DataTransferObjects\LlmResponse;
+use App\Domain\AiInsights\Actions\GeneratePullRequestRiskAssessmentAction;
+use App\Domain\AiInsights\Jobs\GeneratePullRequestRiskAssessmentJob;
+use App\Domain\AiInsights\Queries\GetPullRequestRiskInputQuery;
+use App\Enums\PullRequestRiskAssessmentStatus;
+use App\Enums\PullRequestRiskLevel;
+use App\Models\GithubPullRequest;
+use App\Models\Project;
+use App\Models\PullRequestRiskAssessment;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class GeneratePullRequestRiskAssessmentJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_is_unique_by_pull_request(): void
+    {
+        $job = new GeneratePullRequestRiskAssessmentJob(123);
+
+        $this->assertSame('123', $job->uniqueId());
+        $this->assertSame(2, $job->tries);
+    }
+
+    public function test_builds_input_snapshot_and_generates_risk_assessment(): void
+    {
+        config(['services.llm.enabled' => true]);
+        $pullRequest = $this->pullRequest();
+        $client = new RiskJobFakeLlmClient;
+        $this->app->instance(LlmClient::class, $client);
+
+        (new GeneratePullRequestRiskAssessmentJob($pullRequest->id))->handle(
+            app(GetPullRequestRiskInputQuery::class),
+            app(GeneratePullRequestRiskAssessmentAction::class),
+        );
+
+        $assessment = PullRequestRiskAssessment::query()->sole();
+        $this->assertSame(PullRequestRiskAssessmentStatus::Scored, $assessment->status);
+        $this->assertSame(PullRequestRiskLevel::High, $assessment->risk_level);
+        $this->assertSame($pullRequest->id, $assessment->input_snapshot['pull_request']['id']);
+        $this->assertNotNull($client->prompt);
+    }
+
+    public function test_does_not_generate_when_ai_is_disabled(): void
+    {
+        config(['services.llm.enabled' => false]);
+        $pullRequest = $this->pullRequest();
+        $client = new RiskJobFakeLlmClient;
+        $this->app->instance(LlmClient::class, $client);
+
+        (new GeneratePullRequestRiskAssessmentJob($pullRequest->id))->handle(
+            app(GetPullRequestRiskInputQuery::class),
+            app(GeneratePullRequestRiskAssessmentAction::class),
+        );
+
+        $this->assertDatabaseCount('pull_request_risk_assessments', 0);
+        $this->assertNull($client->prompt);
+    }
+
+    public function test_failed_handler_marks_pending_assessment_failed_after_retries_are_exhausted(): void
+    {
+        $pullRequest = $this->pullRequest();
+        $assessment = PullRequestRiskAssessment::factory()->for($pullRequest, 'pullRequest')->create([
+            'status' => PullRequestRiskAssessmentStatus::Pending->value,
+        ]);
+
+        (new GeneratePullRequestRiskAssessmentJob($pullRequest->id))->failed(new \RuntimeException('Snapshot failed'));
+
+        $this->assertSame(PullRequestRiskAssessmentStatus::Failed, $assessment->refresh()->status);
+        $this->assertSame('Snapshot failed', $assessment->error_message);
+        $this->assertNotNull($assessment->failed_at);
+    }
+
+    public function test_null_scoped_snapshot_marks_pending_assessment_skipped(): void
+    {
+        config(['services.llm.enabled' => true]);
+        Queue::fake();
+        $pullRequest = $this->pullRequest();
+        $client = new RiskJobFakeLlmClient;
+        $this->app->instance(LlmClient::class, $client);
+
+        (new GeneratePullRequestRiskAssessmentJob($pullRequest->id))->handle(
+            new NullPullRequestRiskInputQuery,
+            app(GeneratePullRequestRiskAssessmentAction::class),
+        );
+
+        $assessment = PullRequestRiskAssessment::query()->sole();
+        $this->assertSame(PullRequestRiskAssessmentStatus::Skipped, $assessment->status);
+        $this->assertStringContainsString('scoped AI input query', $assessment->error_message);
+        $this->assertNull($client->prompt);
+    }
+
+    private function pullRequest(): GithubPullRequest
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repository = Repository::factory()->create(['project_id' => $project->id]);
+
+        return GithubPullRequest::factory()->create(['repository_id' => $repository->id]);
+    }
+}
+
+class NullPullRequestRiskInputQuery extends GetPullRequestRiskInputQuery
+{
+    public function execute(User $user, GithubPullRequest $pullRequest): ?array
+    {
+        return null;
+    }
+}
+
+class RiskJobFakeLlmClient implements LlmClient
+{
+    public ?LlmPrompt $prompt = null;
+
+    public function complete(LlmPrompt $prompt): LlmResponse
+    {
+        $this->prompt = $prompt;
+
+        return new LlmResponse(json_encode([
+            'risk_level' => 'high',
+            'risk_score' => 82,
+            'summary' => 'Large PR with failed checks needs careful review.',
+            'reasons' => ['Large change size', 'Recent workflow failure'],
+            'recommended_actions' => ['Review failing workflow before merge'],
+        ], JSON_THROW_ON_ERROR));
+    }
+}

--- a/tests/Feature/AiInsights/GetProjectHealthExplanationInputQueryTest.php
+++ b/tests/Feature/AiInsights/GetProjectHealthExplanationInputQueryTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Tests\Feature\AiInsights;
+
+use App\Domain\AiInsights\Queries\GetProjectHealthExplanationInputQuery;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
+use App\Enums\ProjectPriority;
+use App\Enums\ProjectStatus;
+use App\Enums\RepositorySyncStatus;
+use App\Enums\WebsiteStatus;
+use App\Enums\WorkflowRunConclusion;
+use App\Enums\WorkflowRunStatus;
+use App\Models\Alert;
+use App\Models\Container;
+use App\Models\Host;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\Website;
+use App\Models\WorkflowRun;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class GetProjectHealthExplanationInputQueryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_scopes_health_snapshot_to_owned_project(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        $this->assertNull(app(GetProjectHealthExplanationInputQuery::class)->execute($otherUser, $project));
+        $this->assertSame($project->id, app(GetProjectHealthExplanationInputQuery::class)->execute($user, $project)['project']['id']);
+    }
+
+    public function test_includes_health_score_drivers_with_bounded_samples(): void
+    {
+        Carbon::setTestNow('2026-07-21 12:00:00');
+
+        $user = User::factory()->create();
+        $project = Project::factory()->create([
+            'owner_user_id' => $user->id,
+            'name' => 'Checkout Platform',
+            'status' => ProjectStatus::Active->value,
+            'priority' => ProjectPriority::Critical->value,
+            'environment' => 'production',
+            'health_score' => 28,
+            'last_activity_at' => '2026-07-21 09:00:00',
+        ]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'nexus/checkout-platform',
+            'default_branch' => 'main',
+            'sync_status' => RepositorySyncStatus::Failed->value,
+            'sync_failed_at' => '2026-07-21 08:00:00',
+        ]);
+        $otherProject = Project::factory()->create(['owner_user_id' => $user->id]);
+        $otherRepository = Repository::factory()->create(['project_id' => $otherProject->id]);
+
+        Alert::factory()->count(GetProjectHealthExplanationInputQuery::SAMPLE_LIMIT + 2)->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Website->value,
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+            'title' => 'Production site down',
+            'last_seen_at' => '2026-07-21 11:00:00',
+        ]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Deployment->value,
+            'severity' => AlertSeverity::Warning->value,
+            'status' => AlertStatus::Acknowledged->value,
+        ]);
+        Alert::factory()->create([
+            'project_id' => $otherProject->id,
+            'source' => AlertSource::Website->value,
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+            'title' => 'Other project leak',
+        ]);
+        WorkflowRun::factory()->count(GetProjectHealthExplanationInputQuery::SAMPLE_LIMIT + 2)->create([
+            'repository_id' => $repository->id,
+            'status' => WorkflowRunStatus::Completed->value,
+            'conclusion' => WorkflowRunConclusion::Failure->value,
+            'head_branch' => 'main',
+            'run_completed_at' => '2026-07-21 10:00:00',
+        ]);
+        WorkflowRun::factory()->create([
+            'repository_id' => $otherRepository->id,
+            'status' => WorkflowRunStatus::Completed->value,
+            'conclusion' => WorkflowRunConclusion::Failure->value,
+            'head_branch' => 'main',
+            'run_completed_at' => '2026-07-21 10:00:00',
+        ]);
+        Website::factory()->count(GetProjectHealthExplanationInputQuery::SAMPLE_LIMIT + 2)->create([
+            'project_id' => $project->id,
+            'name' => 'Marketing site',
+            'url' => 'https://example.test/private?token=secret',
+            'status' => WebsiteStatus::Down->value,
+            'last_checked_at' => '2026-07-21 10:00:00',
+            'last_failure_at' => '2026-07-21 10:00:00',
+        ]);
+        Host::factory()->offline()->count(GetProjectHealthExplanationInputQuery::SAMPLE_LIMIT + 2)->create([
+            'project_id' => $project->id,
+            'endpoint_url' => 'https://agent.example.test/webhook',
+        ]);
+        $host = Host::factory()->online()->create(['project_id' => $project->id]);
+        Container::factory()->count(GetProjectHealthExplanationInputQuery::SAMPLE_LIMIT + 2)->create([
+            'host_id' => $host->id,
+            'project_id' => $project->id,
+            'health_status' => 'unhealthy',
+            'last_seen_at' => '2026-07-21 10:00:00',
+            'labels' => ['SECRET_TOKEN' => 'abc123'],
+        ]);
+
+        $snapshot = app(GetProjectHealthExplanationInputQuery::class)->execute($user, $project);
+
+        $this->assertSame('project-health-explanation-input-v1', $snapshot['snapshot_version']);
+        $this->assertSame(28, $snapshot['project']['health_score']);
+        $this->assertSame('critical', $snapshot['project']['health_band']);
+        $this->assertSame(8, $snapshot['drivers']['alerts']['active_total']);
+        $this->assertSame(7, $snapshot['drivers']['alerts']['active_by_severity']['critical']);
+        $this->assertCount(GetProjectHealthExplanationInputQuery::SAMPLE_LIMIT, $snapshot['drivers']['alerts']['sample']);
+        $this->assertSame(7, $snapshot['drivers']['deployments']['failed_default_branch_last_24h']);
+        $this->assertCount(GetProjectHealthExplanationInputQuery::SAMPLE_LIMIT, $snapshot['drivers']['deployments']['failed_workflows_sample']);
+        $this->assertSame(7, $snapshot['drivers']['websites']['by_status']['down']);
+        $this->assertCount(GetProjectHealthExplanationInputQuery::SAMPLE_LIMIT, $snapshot['drivers']['websites']['problem_sample']);
+        $this->assertSame(7, $snapshot['drivers']['hosts']['offline_count']);
+        $this->assertCount(GetProjectHealthExplanationInputQuery::SAMPLE_LIMIT, $snapshot['drivers']['hosts']['problem_sample']);
+        $this->assertSame(7, $snapshot['drivers']['containers']['unhealthy_count']);
+        $this->assertCount(GetProjectHealthExplanationInputQuery::SAMPLE_LIMIT, $snapshot['drivers']['containers']['problem_sample']);
+        $this->assertSame(1, $snapshot['drivers']['github_sync']['repositories_total']);
+        $this->assertSame('nexus/checkout-platform', $snapshot['drivers']['github_sync']['failed_repositories_sample'][0]['full_name']);
+    }
+
+    public function test_excludes_sensitive_urls_tokens_logs_and_secrets_from_snapshot(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        Repository::factory()->create([
+            'project_id' => $project->id,
+            'html_url' => 'https://github.com/acme/private?access_token=secret',
+            'sync_error' => 'raw logs include TOKEN',
+            'sync_failed_at' => now(),
+        ]);
+        Website::factory()->create([
+            'project_id' => $project->id,
+            'name' => 'SECRET_KEY=abc123 marketing',
+            'url' => 'https://example.test?token=secret',
+            'status' => WebsiteStatus::Down->value,
+        ]);
+        Host::factory()->offline()->create([
+            'project_id' => $project->id,
+            'endpoint_url' => 'https://agent.example.test/webhook',
+            'metadata' => ['secret' => 'abc'],
+        ]);
+        $host = Host::factory()->online()->create(['project_id' => $project->id]);
+        Container::factory()->create([
+            'host_id' => $host->id,
+            'project_id' => $project->id,
+            'health_status' => 'unhealthy',
+            'labels' => ['ACCESS_TOKEN' => 'abc123'],
+        ]);
+
+        $encoded = json_encode(app(GetProjectHealthExplanationInputQuery::class)->execute($user, $project), JSON_THROW_ON_ERROR);
+
+        $this->assertStringNotContainsString('access_token', $encoded);
+        $this->assertStringNotContainsString('TOKEN', $encoded);
+        $this->assertStringNotContainsString('token=secret', $encoded);
+        $this->assertStringNotContainsString('webhook', $encoded);
+        $this->assertStringNotContainsString('ACCESS_TOKEN', $encoded);
+        $this->assertStringNotContainsString('SECRET_KEY', $encoded);
+        $this->assertStringNotContainsString('abc123', $encoded);
+        $this->assertStringNotContainsString('raw logs', $encoded);
+        $this->assertStringNotContainsString('sync_error', $encoded);
+    }
+}

--- a/tests/Feature/AiInsights/GetPullRequestRiskInputQueryTest.php
+++ b/tests/Feature/AiInsights/GetPullRequestRiskInputQueryTest.php
@@ -121,7 +121,7 @@ class GetPullRequestRiskInputQueryTest extends TestCase
         $this->assertSame('nexus/billing-api', $snapshot['repository']['full_name']);
         $this->assertSame('failed', $snapshot['repository']['workflow_runs_sync_status']);
         $this->assertSame(123, $snapshot['pull_request']['number']);
-        $this->assertSame(500, strlen($snapshot['pull_request']['body_preview']));
+        $this->assertArrayNotHasKey('body_preview', $snapshot['pull_request']);
         $this->assertSame(10, $snapshot['pull_request']['age_days']);
         $this->assertTrue($snapshot['pull_request']['stale']);
         $this->assertCount(GetPullRequestRiskInputQuery::FAILED_WORKFLOWS_LIMIT, $snapshot['recent_failed_workflows']);
@@ -142,7 +142,7 @@ class GetPullRequestRiskInputQueryTest extends TestCase
         ]);
         $pullRequest = GithubPullRequest::factory()->create([
             'repository_id' => $repository->id,
-            'body_preview' => 'SECRET_TOKEN=abc123 bounded body preview only',
+            'body_preview' => '{"SECRET_TOKEN":"abc123"} SECRET_TOKEN=abc123 bounded body preview only',
         ]);
 
         $encoded = json_encode(app(GetPullRequestRiskInputQuery::class)->execute($user, $pullRequest), JSON_THROW_ON_ERROR);
@@ -154,5 +154,6 @@ class GetPullRequestRiskInputQueryTest extends TestCase
         $this->assertStringNotContainsString('abc123', $encoded);
         $this->assertStringNotContainsString('raw logs', $encoded);
         $this->assertStringNotContainsString('sync_error', $encoded);
+        $this->assertArrayNotHasKey('body_preview', json_decode($encoded, true, flags: JSON_THROW_ON_ERROR)['pull_request']);
     }
 }

--- a/tests/Feature/AiInsights/GetPullRequestRiskInputQueryTest.php
+++ b/tests/Feature/AiInsights/GetPullRequestRiskInputQueryTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Feature\AiInsights;
+
+use App\Domain\AiInsights\Queries\GetPullRequestRiskInputQuery;
+use App\Enums\AlertSeverity;
+use App\Enums\AlertSource;
+use App\Enums\AlertStatus;
+use App\Enums\GithubPullRequestState;
+use App\Enums\ProjectPriority;
+use App\Enums\RepositorySyncStatus;
+use App\Enums\WorkflowRunConclusion;
+use App\Enums\WorkflowRunStatus;
+use App\Models\Alert;
+use App\Models\GithubPullRequest;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use App\Models\WorkflowRun;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class GetPullRequestRiskInputQueryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_scopes_pr_snapshot_to_owned_project(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repository = Repository::factory()->create(['project_id' => $project->id]);
+        $pullRequest = GithubPullRequest::factory()->create(['repository_id' => $repository->id]);
+
+        $this->assertNull(app(GetPullRequestRiskInputQuery::class)->execute($otherUser, $pullRequest));
+        $this->assertSame($pullRequest->id, app(GetPullRequestRiskInputQuery::class)->execute($user, $pullRequest)['pull_request']['id']);
+    }
+
+    public function test_includes_bounded_pr_facts_workflows_alerts_and_project_signals(): void
+    {
+        Carbon::setTestNow('2026-07-21 12:00:00');
+
+        $user = User::factory()->create();
+        $project = Project::factory()->create([
+            'owner_user_id' => $user->id,
+            'name' => 'Billing API',
+            'priority' => ProjectPriority::High->value,
+            'health_score' => 42,
+        ]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'full_name' => 'nexus/billing-api',
+            'default_branch' => 'main',
+            'language' => 'PHP',
+            'sync_status' => RepositorySyncStatus::Synced->value,
+            'prs_sync_status' => RepositorySyncStatus::Synced->value,
+            'workflow_runs_sync_status' => RepositorySyncStatus::Failed->value,
+        ]);
+        $pullRequest = GithubPullRequest::factory()->create([
+            'repository_id' => $repository->id,
+            'number' => 123,
+            'title' => 'Refactor checkout workflow',
+            'body_preview' => str_repeat('safe context ', 80).'SECRET_TOKEN=abc123',
+            'state' => GithubPullRequestState::Open->value,
+            'author_login' => 'octo-dev',
+            'base_branch' => 'main',
+            'head_branch' => 'feature/checkout-risk',
+            'draft' => true,
+            'merged' => false,
+            'additions' => 320,
+            'deletions' => 40,
+            'changed_files' => 12,
+            'comments_count' => 4,
+            'review_comments_count' => 2,
+            'created_at_github' => '2026-07-11 12:00:00',
+            'updated_at_github' => '2026-07-12 12:00:00',
+        ]);
+
+        WorkflowRun::factory()->count(GetPullRequestRiskInputQuery::FAILED_WORKFLOWS_LIMIT + 2)->create([
+            'repository_id' => $repository->id,
+            'status' => WorkflowRunStatus::Completed->value,
+            'conclusion' => WorkflowRunConclusion::Failure->value,
+            'head_branch' => 'feature/checkout-risk',
+            'run_completed_at' => '2026-07-21 10:00:00',
+        ]);
+        WorkflowRun::factory()->create([
+            'repository_id' => $repository->id,
+            'status' => WorkflowRunStatus::Completed->value,
+            'conclusion' => WorkflowRunConclusion::Failure->value,
+            'head_branch' => 'unrelated-branch',
+            'run_completed_at' => '2026-07-21 11:00:00',
+        ]);
+        Alert::factory()->count(GetPullRequestRiskInputQuery::ALERTS_LIMIT + 2)->create([
+            'project_id' => $project->id,
+            'source' => AlertSource::Deployment->value,
+            'severity' => AlertSeverity::Critical->value,
+            'status' => AlertStatus::Open->value,
+            'title' => 'CI failed repeatedly',
+            'last_seen_at' => '2026-07-21 09:00:00',
+        ]);
+        Alert::factory()->resolved()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Critical->value,
+            'title' => 'Resolved alert should not appear',
+        ]);
+
+        $snapshot = app(GetPullRequestRiskInputQuery::class)->execute($user, $pullRequest);
+
+        $this->assertSame('pr-risk-input-v1', $snapshot['snapshot_version']);
+        $this->assertSame('high', $snapshot['project']['priority']);
+        $this->assertSame(42, $snapshot['project']['health_score']);
+        $this->assertSame('warning', $snapshot['project']['health_band']);
+        $this->assertSame('nexus/billing-api', $snapshot['repository']['full_name']);
+        $this->assertSame('failed', $snapshot['repository']['workflow_runs_sync_status']);
+        $this->assertSame(123, $snapshot['pull_request']['number']);
+        $this->assertSame(500, strlen($snapshot['pull_request']['body_preview']));
+        $this->assertSame(10, $snapshot['pull_request']['age_days']);
+        $this->assertTrue($snapshot['pull_request']['stale']);
+        $this->assertCount(GetPullRequestRiskInputQuery::FAILED_WORKFLOWS_LIMIT, $snapshot['recent_failed_workflows']);
+        $this->assertSame(['feature/checkout-risk'], array_values(array_unique(array_column($snapshot['recent_failed_workflows'], 'head_branch'))));
+        $this->assertCount(GetPullRequestRiskInputQuery::ALERTS_LIMIT, $snapshot['active_alerts']);
+        $this->assertNotContains('Resolved alert should not appear', array_column($snapshot['active_alerts'], 'title'));
+    }
+
+    public function test_excludes_sensitive_raw_fields_from_snapshot(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+        $repository = Repository::factory()->create([
+            'project_id' => $project->id,
+            'html_url' => 'https://github.com/acme/private-repo?access_token=secret',
+            'sync_error' => 'webhook_url=https://hooks.example.test/token',
+            'prs_sync_error' => 'raw logs include ACCESS_TOKEN',
+        ]);
+        $pullRequest = GithubPullRequest::factory()->create([
+            'repository_id' => $repository->id,
+            'body_preview' => 'SECRET_TOKEN=abc123 bounded body preview only',
+        ]);
+
+        $encoded = json_encode(app(GetPullRequestRiskInputQuery::class)->execute($user, $pullRequest), JSON_THROW_ON_ERROR);
+
+        $this->assertStringNotContainsString('access_token', $encoded);
+        $this->assertStringNotContainsString('webhook_url', $encoded);
+        $this->assertStringNotContainsString('ACCESS_TOKEN', $encoded);
+        $this->assertStringNotContainsString('SECRET_TOKEN', $encoded);
+        $this->assertStringNotContainsString('abc123', $encoded);
+        $this->assertStringNotContainsString('raw logs', $encoded);
+        $this->assertStringNotContainsString('sync_error', $encoded);
+    }
+}

--- a/tests/Feature/AiInsights/PullRequestRiskBackfillCommandTest.php
+++ b/tests/Feature/AiInsights/PullRequestRiskBackfillCommandTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Tests\Feature\AiInsights;
+
+use App\Domain\AiInsights\Jobs\GeneratePullRequestRiskAssessmentJob;
+use App\Enums\GithubPullRequestState;
+use App\Models\GithubPullRequest;
+use App\Models\Project;
+use App\Models\Repository;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class PullRequestRiskBackfillCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_queues_only_open_pull_requests_for_the_scoped_user(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => true]);
+        $owner = User::factory()->create(['email' => 'owner@example.com']);
+        $other = User::factory()->create();
+        $openPullRequest = $this->pullRequestForUser($owner, GithubPullRequestState::Open);
+        $closedPullRequest = $this->pullRequestForUser($owner, GithubPullRequestState::Closed);
+        $mergedPullRequest = $this->pullRequestForUser($owner, GithubPullRequestState::Merged);
+        $otherPullRequest = $this->pullRequestForUser($other, GithubPullRequestState::Open);
+
+        $this->artisan('ai-insights:backfill-pr-risk', ['--user' => 'owner@example.com'])
+            ->expectsOutput('Queued 1 PR risk assessment backfill job(s).')
+            ->assertSuccessful();
+
+        Queue::assertPushed(
+            GeneratePullRequestRiskAssessmentJob::class,
+            fn (GeneratePullRequestRiskAssessmentJob $job): bool => $job->pullRequestId === $openPullRequest->id,
+        );
+        Queue::assertNotPushed(
+            GeneratePullRequestRiskAssessmentJob::class,
+            fn (GeneratePullRequestRiskAssessmentJob $job): bool => in_array($job->pullRequestId, [
+                $closedPullRequest->id,
+                $mergedPullRequest->id,
+                $otherPullRequest->id,
+            ], true),
+        );
+    }
+
+    public function test_repository_scope_is_constrained_by_the_user_scope(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => true]);
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $repository = $this->repositoryForUser($owner, ['full_name' => 'octocat/hello-world']);
+        $openPullRequest = GithubPullRequest::factory()->create([
+            'repository_id' => $repository->id,
+            'state' => GithubPullRequestState::Open->value,
+            'closed_at_github' => null,
+            'merged_at' => null,
+        ]);
+        $otherPullRequest = $this->pullRequestForUser($other, GithubPullRequestState::Open);
+
+        $this->artisan('ai-insights:backfill-pr-risk', [
+            '--user' => (string) $owner->id,
+            '--repository' => 'octocat/hello-world',
+        ])
+            ->expectsOutput('Queued 1 PR risk assessment backfill job(s).')
+            ->assertSuccessful();
+
+        Queue::assertPushed(
+            GeneratePullRequestRiskAssessmentJob::class,
+            fn (GeneratePullRequestRiskAssessmentJob $job): bool => $job->pullRequestId === $openPullRequest->id,
+        );
+        Queue::assertNotPushed(
+            GeneratePullRequestRiskAssessmentJob::class,
+            fn (GeneratePullRequestRiskAssessmentJob $job): bool => $job->pullRequestId === $otherPullRequest->id,
+        );
+    }
+
+    public function test_project_scope_does_not_include_other_projects_for_the_same_user(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => true]);
+        $owner = User::factory()->create();
+        $project = Project::factory()->create(['owner_user_id' => $owner->id, 'slug' => 'api']);
+        $repository = Repository::factory()->create(['project_id' => $project->id]);
+        $scopedPullRequest = GithubPullRequest::factory()->create([
+            'repository_id' => $repository->id,
+            'state' => GithubPullRequestState::Open->value,
+            'closed_at_github' => null,
+            'merged_at' => null,
+        ]);
+        $otherProjectPullRequest = $this->pullRequestForUser($owner, GithubPullRequestState::Open);
+
+        $this->artisan('ai-insights:backfill-pr-risk', [
+            '--user' => (string) $owner->id,
+            '--project' => 'api',
+        ])
+            ->expectsOutput('Queued 1 PR risk assessment backfill job(s).')
+            ->assertSuccessful();
+
+        Queue::assertPushed(
+            GeneratePullRequestRiskAssessmentJob::class,
+            fn (GeneratePullRequestRiskAssessmentJob $job): bool => $job->pullRequestId === $scopedPullRequest->id,
+        );
+        Queue::assertNotPushed(
+            GeneratePullRequestRiskAssessmentJob::class,
+            fn (GeneratePullRequestRiskAssessmentJob $job): bool => $job->pullRequestId === $otherProjectPullRequest->id,
+        );
+    }
+
+    public function test_ai_gate_prevents_backfill_dispatch(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => false]);
+        $owner = User::factory()->create();
+        $this->pullRequestForUser($owner, GithubPullRequestState::Open);
+
+        $this->artisan('ai-insights:backfill-pr-risk', ['--user' => (string) $owner->id])
+            ->expectsOutput('AI features are disabled; no PR risk backfill jobs were queued.')
+            ->assertSuccessful();
+
+        Queue::assertNotPushed(GeneratePullRequestRiskAssessmentJob::class);
+    }
+
+    public function test_requires_an_explicit_scope(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => true]);
+
+        $this->artisan('ai-insights:backfill-pr-risk')
+            ->expectsOutput('Provide at least one scope option: --user, --project, or --repository.')
+            ->assertFailed();
+
+        Queue::assertNotPushed(GeneratePullRequestRiskAssessmentJob::class);
+    }
+
+    private function pullRequestForUser(User $user, GithubPullRequestState $state): GithubPullRequest
+    {
+        $isOpen = $state === GithubPullRequestState::Open;
+
+        return GithubPullRequest::factory()->create([
+            'repository_id' => $this->repositoryForUser($user)->id,
+            'state' => $state->value,
+            'closed_at_github' => $isOpen ? null : now(),
+            'merged_at' => $state === GithubPullRequestState::Merged ? now() : null,
+        ]);
+    }
+
+    /** @param array<string, mixed> $attributes */
+    private function repositoryForUser(User $user, array $attributes = []): Repository
+    {
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        return Repository::factory()->create([
+            ...$attributes,
+            'project_id' => $project->id,
+        ]);
+    }
+}

--- a/tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php
+++ b/tests/Feature/Dashboard/GetOverviewDashboardQueryTest.php
@@ -4,11 +4,13 @@ namespace Tests\Feature\Dashboard;
 
 use App\Domain\Dashboard\Queries\GetOverviewDashboardQuery;
 use App\Enums\AlertSeverity;
+use App\Enums\ProjectHealthExplanationStatus;
 use App\Models\ActivityEvent;
 use App\Models\Alert;
 use App\Models\Host;
 use App\Models\HostMetricSnapshot;
 use App\Models\Project;
+use App\Models\ProjectHealthExplanation;
 use App\Models\Repository;
 use App\Models\User;
 use App\Models\WorkflowRun;
@@ -388,6 +390,58 @@ class GetOverviewDashboardQueryTest extends TestCase
         $this->assertNull($payload['dashboard']['uptime']['overall']);
         $this->assertSame('muted', $payload['dashboard']['uptime']['status']);
         $this->assertCount(12, $payload['dashboard']['uptime']['sparkline']);
+    }
+
+    public function test_risky_projects_include_latest_health_explanation_payload(): void
+    {
+        $owner = User::factory()->create();
+        $project = Project::factory()->create([
+            'owner_user_id' => $owner->id,
+            'health_score' => 42,
+        ]);
+        ProjectHealthExplanation::factory()->explained()->create([
+            'project_id' => $project->id,
+            'summary' => 'Critical alerts are dragging the score down.',
+            'drivers' => ['2 critical alerts'],
+            'recommended_actions' => ['Acknowledge or resolve the critical alerts'],
+            'explained_at' => now()->subMinutes(5),
+        ]);
+
+        $payload = (new GetOverviewDashboardQuery)->handle($owner);
+        $row = $payload['dashboard']['riskyProjects'][0];
+
+        $this->assertSame('explained', $row['health_explanation']['status']);
+        $this->assertSame('Critical alerts are dragging the score down.', $row['health_explanation']['summary']);
+        $this->assertSame(['2 critical alerts'], $row['health_explanation']['drivers']);
+        $this->assertSame(['Acknowledge or resolve the critical alerts'], $row['health_explanation']['recommended_actions']);
+        $this->assertNotNull($row['health_explanation']['explained_at']);
+        $this->assertNull($row['health_explanation']['error_message']);
+    }
+
+    public function test_risky_projects_include_failed_health_explanation_error_but_no_cross_user_rows(): void
+    {
+        $owner = User::factory()->create();
+        $project = Project::factory()->create([
+            'owner_user_id' => $owner->id,
+            'health_score' => 35,
+        ]);
+        ProjectHealthExplanation::factory()->create([
+            'project_id' => $project->id,
+            'status' => ProjectHealthExplanationStatus::Failed->value,
+            'error_message' => 'Provider unavailable',
+            'failed_at' => now()->subMinute(),
+        ]);
+        $otherProject = Project::factory()->create(['health_score' => 20]);
+        ProjectHealthExplanation::factory()->explained()->create([
+            'project_id' => $otherProject->id,
+            'summary' => 'Other user explanation',
+        ]);
+
+        $payload = (new GetOverviewDashboardQuery)->handle($owner);
+
+        $this->assertCount(1, $payload['dashboard']['riskyProjects']);
+        $this->assertSame('failed', $payload['dashboard']['riskyProjects'][0]['health_explanation']['status']);
+        $this->assertSame('Provider unavailable', $payload['dashboard']['riskyProjects'][0]['health_explanation']['error_message']);
     }
 
     // ────────────────────────────────────────────────────────────────

--- a/tests/Feature/Dashboard/ProjectHealthExplanationUiTest.php
+++ b/tests/Feature/Dashboard/ProjectHealthExplanationUiTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature\Dashboard;
+
+use App\Domain\AiInsights\Jobs\GenerateProjectHealthExplanationJob;
+use App\Enums\ProjectHealthExplanationStatus;
+use App\Models\Project;
+use App\Models\ProjectHealthExplanation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class ProjectHealthExplanationUiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_overview_exposes_health_explanation_and_regenerate_gate(): void
+    {
+        config(['services.llm.enabled' => true]);
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create([
+            'owner_user_id' => $user->id,
+            'health_score' => 44,
+        ]);
+        ProjectHealthExplanation::factory()->explained()->create([
+            'project_id' => $project->id,
+            'summary' => 'Failed deployments and open alerts lowered confidence.',
+            'drivers' => ['1 failed deployment', '2 open alerts'],
+            'recommended_actions' => ['Inspect the failed workflow first'],
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('overview'))
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Overview')
+                    ->where('canRegenerateProjectHealthExplanation', true)
+                    ->where('dashboard.riskyProjects.0.health_explanation.status', 'explained')
+                    ->where('dashboard.riskyProjects.0.health_explanation.summary', 'Failed deployments and open alerts lowered confidence.')
+                    ->where('dashboard.riskyProjects.0.health_explanation.drivers.0', '1 failed deployment')
+                    ->where('dashboard.riskyProjects.0.health_explanation.recommended_actions.0', 'Inspect the failed workflow first')
+            );
+    }
+
+    public function test_regenerate_marks_project_health_explanation_pending_and_dispatches_job_when_ai_is_enabled(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => true]);
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create([
+            'owner_user_id' => $user->id,
+            'health_score' => 38,
+        ]);
+        ProjectHealthExplanation::factory()->explained()->create([
+            'project_id' => $project->id,
+            'error_message' => 'Old error',
+            'failed_at' => now()->subHour(),
+        ]);
+
+        $this->actingAs($user)
+            ->from(route('overview'))
+            ->post(route('overview.projects.health-explanation.regenerate', $project))
+            ->assertRedirect(route('overview'))
+            ->assertSessionHas('status', 'Project health explanation queued.');
+
+        $this->assertDatabaseHas('project_health_explanations', [
+            'project_id' => $project->id,
+            'status' => ProjectHealthExplanationStatus::Pending->value,
+            'health_score' => 38,
+            'failed_at' => null,
+            'error_message' => null,
+        ]);
+        Queue::assertPushed(
+            GenerateProjectHealthExplanationJob::class,
+            fn (GenerateProjectHealthExplanationJob $job): bool => $job->projectId === $project->id,
+        );
+    }
+
+    public function test_regenerate_is_rejected_when_ai_is_disabled(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => false]);
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $user->id]);
+
+        $this->actingAs($user)
+            ->from(route('overview'))
+            ->post(route('overview.projects.health-explanation.regenerate', $project))
+            ->assertRedirect(route('overview'))
+            ->assertSessionHasErrors('health_explanation');
+
+        $this->assertDatabaseMissing('project_health_explanations', [
+            'project_id' => $project->id,
+        ]);
+        Queue::assertNotPushed(GenerateProjectHealthExplanationJob::class);
+    }
+
+    public function test_regenerate_is_forbidden_for_other_users_projects(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => true]);
+        $owner = User::factory()->create(['email_verified_at' => now()]);
+        $other = User::factory()->create(['email_verified_at' => now()]);
+        $project = Project::factory()->create(['owner_user_id' => $owner->id]);
+
+        $this->actingAs($other)
+            ->post(route('overview.projects.health-explanation.regenerate', $project))
+            ->assertForbidden();
+
+        Queue::assertNotPushed(GenerateProjectHealthExplanationJob::class);
+    }
+}

--- a/tests/Feature/GitHub/Webhooks/PullRequestWebhookHandlerTest.php
+++ b/tests/Feature/GitHub/Webhooks/PullRequestWebhookHandlerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\GitHub\Webhooks;
 
 use App\Domain\Activity\Actions\CreateActivityEventAction;
+use App\Domain\AiInsights\Jobs\GeneratePullRequestRiskAssessmentJob;
 use App\Domain\GitHub\Actions\NormalizeGitHubPullRequestAction;
 use App\Domain\GitHub\WebhookHandlers\PullRequestWebhookHandler;
 use App\Enums\WebhookDeliveryStatus;
@@ -12,6 +13,7 @@ use App\Models\Repository;
 use App\Models\User;
 use App\Models\WebhookDelivery;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
 class PullRequestWebhookHandlerTest extends TestCase
@@ -134,12 +136,46 @@ class PullRequestWebhookHandlerTest extends TestCase
     public function test_unknown_action_is_skipped(): void
     {
         $this->importedRepository();
-        $delivery = $this->deliveryFor('synchronize');
+        $delivery = $this->deliveryFor('labeled');
 
         $status = $this->handler()->handle($delivery);
 
         $this->assertSame(WebhookDeliveryStatus::Skipped, $status);
         $this->assertNotNull($delivery->fresh()->error_message);
+    }
+
+    public function test_material_actions_dispatch_risk_assessment_after_pr_is_updated_when_ai_is_enabled(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => true]);
+        $this->importedRepository();
+        $delivery = $this->deliveryFor('synchronize', [
+            'id' => 4242,
+            'number' => 42,
+            'title' => 'Refresh cache layer',
+        ]);
+
+        $status = $this->handler()->handle($delivery);
+
+        $pullRequest = GithubPullRequest::query()->sole();
+        $this->assertSame(WebhookDeliveryStatus::Processed, $status);
+        $this->assertSame(42, $pullRequest->number);
+        Queue::assertPushed(
+            GeneratePullRequestRiskAssessmentJob::class,
+            fn (GeneratePullRequestRiskAssessmentJob $job): bool => $job->pullRequestId === $pullRequest->id,
+        );
+    }
+
+    public function test_material_actions_do_not_dispatch_risk_assessment_when_ai_is_disabled(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => false]);
+        $this->importedRepository();
+
+        $status = $this->handler()->handle($this->deliveryFor('opened'));
+
+        $this->assertSame(WebhookDeliveryStatus::Processed, $status);
+        Queue::assertNotPushed(GeneratePullRequestRiskAssessmentJob::class);
     }
 
     public function test_unimported_repository_is_skipped(): void

--- a/tests/Feature/GitHub/WorkItemControllerTest.php
+++ b/tests/Feature/GitHub/WorkItemControllerTest.php
@@ -2,14 +2,18 @@
 
 namespace Tests\Feature\GitHub;
 
+use App\Domain\AiInsights\Jobs\GeneratePullRequestRiskAssessmentJob;
 use App\Enums\GithubIssueState;
 use App\Enums\GithubPullRequestState;
+use App\Enums\PullRequestRiskAssessmentStatus;
 use App\Models\GithubIssue;
 use App\Models\GithubPullRequest;
 use App\Models\Project;
+use App\Models\PullRequestRiskAssessment;
 use App\Models\Repository;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
 
@@ -90,6 +94,94 @@ class WorkItemControllerTest extends TestCase
                     ->where('items.0.state', 'open')
                     ->where('items.1.state', 'open')
             );
+    }
+
+    public function test_pull_request_rows_include_risk_assessment_payload_but_issue_rows_do_not(): void
+    {
+        $context = $this->setUpUserWithItems();
+        PullRequestRiskAssessment::factory()->scored()->create([
+            'github_pull_request_id' => $context['openPr']->id,
+            'risk_score' => 91,
+            'summary' => 'Critical files changed with failing checks.',
+            'reasons' => ['Critical path touched', 'Checks failing'],
+            'recommended_actions' => ['Review CI before merge'],
+            'assessed_at' => now()->subMinutes(10),
+        ]);
+
+        $this->actingAs($context['user'])
+            ->get(route('work-items.index'))
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->where('items.0.kind', 'pull_request')
+                    ->where('items.0.risk_assessment.status', 'scored')
+                    ->where('items.0.risk_assessment.risk_score', 91)
+                    ->where('items.0.risk_assessment.summary', 'Critical files changed with failing checks.')
+                    ->where('items.0.risk_assessment.reasons.0', 'Critical path touched')
+                    ->where('items.0.risk_assessment.recommended_actions.0', 'Review CI before merge')
+                    ->where('items.1.kind', 'issue')
+                    ->missing('items.1.risk_assessment')
+            );
+    }
+
+    public function test_regenerate_marks_pull_request_risk_pending_and_dispatches_job_when_ai_is_enabled(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => true]);
+        $context = $this->setUpUserWithItems();
+        PullRequestRiskAssessment::factory()->scored()->create([
+            'github_pull_request_id' => $context['openPr']->id,
+            'error_message' => 'Old error',
+            'failed_at' => now()->subHour(),
+        ]);
+
+        $this->actingAs($context['user'])
+            ->from(route('work-items.index'))
+            ->post(route('work-items.pull-requests.risk.regenerate', $context['openPr']))
+            ->assertRedirect(route('work-items.index'))
+            ->assertSessionHas('status', 'PR risk assessment queued.');
+
+        $this->assertDatabaseHas('pull_request_risk_assessments', [
+            'github_pull_request_id' => $context['openPr']->id,
+            'status' => PullRequestRiskAssessmentStatus::Pending->value,
+            'failed_at' => null,
+            'error_message' => null,
+        ]);
+        Queue::assertPushed(
+            GeneratePullRequestRiskAssessmentJob::class,
+            fn (GeneratePullRequestRiskAssessmentJob $job): bool => $job->pullRequestId === $context['openPr']->id,
+        );
+    }
+
+    public function test_regenerate_is_rejected_when_ai_is_disabled(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => false]);
+        $context = $this->setUpUserWithItems();
+
+        $this->actingAs($context['user'])
+            ->from(route('work-items.index'))
+            ->post(route('work-items.pull-requests.risk.regenerate', $context['openPr']))
+            ->assertRedirect(route('work-items.index'))
+            ->assertSessionHasErrors('risk');
+
+        $this->assertDatabaseMissing('pull_request_risk_assessments', [
+            'github_pull_request_id' => $context['openPr']->id,
+        ]);
+        Queue::assertNotPushed(GeneratePullRequestRiskAssessmentJob::class);
+    }
+
+    public function test_regenerate_is_forbidden_for_other_users_pull_requests(): void
+    {
+        Queue::fake();
+        config(['services.llm.enabled' => true]);
+        $context = $this->setUpUserWithItems();
+        $other = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($other)
+            ->post(route('work-items.pull-requests.risk.regenerate', $context['openPr']))
+            ->assertForbidden();
+
+        Queue::assertNotPushed(GeneratePullRequestRiskAssessmentJob::class);
     }
 
     public function test_kind_filter_pulls_narrows_to_pull_requests(): void

--- a/tests/Unit/Domain/Analytics/RefreshProjectHealthScoreActionTest.php
+++ b/tests/Unit/Domain/Analytics/RefreshProjectHealthScoreActionTest.php
@@ -2,15 +2,20 @@
 
 namespace Tests\Unit\Domain\Analytics;
 
+use App\Domain\AiInsights\Jobs\GenerateProjectHealthExplanationJob;
 use App\Domain\Analytics\Actions\RefreshProjectHealthScoreAction;
 use App\Enums\AlertSeverity;
 use App\Enums\AlertStatus;
+use App\Enums\HealthScoreBand;
 use App\Events\HealthScoreUpdated;
 use App\Models\Alert;
 use App\Models\Project;
+use App\Models\ProjectHealthExplanation;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
 class RefreshProjectHealthScoreActionTest extends TestCase
@@ -20,6 +25,8 @@ class RefreshProjectHealthScoreActionTest extends TestCase
     public function test_first_run_persists_the_score_and_dispatches(): void
     {
         Event::fake([HealthScoreUpdated::class]);
+        Queue::fake();
+        config(['services.llm.enabled' => false]);
         $owner = User::factory()->create();
         $project = Project::factory()->create([
             'owner_user_id' => $owner->id,
@@ -43,6 +50,8 @@ class RefreshProjectHealthScoreActionTest extends TestCase
     public function test_unchanged_score_is_a_full_noop(): void
     {
         Event::fake([HealthScoreUpdated::class]);
+        Queue::fake();
+        config(['services.llm.enabled' => false]);
         $project = Project::factory()->create(['health_score' => 100]);
         $originalUpdatedAt = $project->updated_at;
 
@@ -51,11 +60,14 @@ class RefreshProjectHealthScoreActionTest extends TestCase
         $this->assertSame(100, $score);
         $this->assertEquals($originalUpdatedAt, $project->fresh()->updated_at, 'no spurious updated_at bump');
         Event::assertNotDispatched(HealthScoreUpdated::class);
+        Queue::assertNotPushed(GenerateProjectHealthExplanationJob::class);
     }
 
     public function test_score_drop_persists_and_broadcasts_with_correct_band(): void
     {
         Event::fake([HealthScoreUpdated::class]);
+        Queue::fake();
+        config(['services.llm.enabled' => false]);
         $owner = User::factory()->create();
         $project = Project::factory()->create([
             'owner_user_id' => $owner->id,
@@ -85,5 +97,97 @@ class RefreshProjectHealthScoreActionTest extends TestCase
                 && $event->score === 25
                 && $event->band === 'critical',
         );
+    }
+
+    public function test_material_score_change_dispatches_health_explanation_after_score_is_persisted_when_ai_is_enabled(): void
+    {
+        Event::fake([HealthScoreUpdated::class]);
+        Queue::fake();
+        config(['services.llm.enabled' => true]);
+        $owner = User::factory()->create();
+        $project = Project::factory()->create([
+            'owner_user_id' => $owner->id,
+            'health_score' => 100,
+        ]);
+        ProjectHealthExplanation::factory()->explained()->for($project)->create([
+            'health_score' => 100,
+            'health_band' => HealthScoreBand::Healthy->value,
+            'updated_at' => now()->subHour(),
+        ]);
+        Alert::factory()->create([
+            'project_id' => $project->id,
+            'severity' => AlertSeverity::Warning->value,
+            'status' => AlertStatus::Open->value,
+        ]);
+
+        app(RefreshProjectHealthScoreAction::class)->execute($project);
+
+        $this->assertSame(85, $project->fresh()->health_score);
+        Queue::assertPushed(
+            GenerateProjectHealthExplanationJob::class,
+            fn (GenerateProjectHealthExplanationJob $job): bool => $job->projectId === $project->id,
+        );
+    }
+
+    public function test_stale_health_explanation_dispatches_even_when_score_is_unchanged(): void
+    {
+        Event::fake([HealthScoreUpdated::class]);
+        Queue::fake();
+        config(['services.llm.enabled' => true]);
+        $project = Project::factory()->create(['health_score' => 100]);
+        ProjectHealthExplanation::factory()->explained()->for($project)->create([
+            'health_score' => 100,
+            'health_band' => HealthScoreBand::Healthy->value,
+            'explained_at' => now()->subDays(8),
+            'updated_at' => now()->subHour(),
+        ]);
+        $originalUpdatedAt = $project->updated_at;
+
+        app(RefreshProjectHealthScoreAction::class)->execute($project);
+
+        $this->assertEquals($originalUpdatedAt, $project->fresh()->updated_at, 'unchanged score still avoids project churn');
+        Event::assertNotDispatched(HealthScoreUpdated::class);
+        Queue::assertPushed(GenerateProjectHealthExplanationJob::class);
+    }
+
+    public function test_health_explanation_dispatch_respects_recent_row_rate_limit(): void
+    {
+        Event::fake([HealthScoreUpdated::class]);
+        Queue::fake();
+        config(['services.llm.enabled' => true]);
+        $project = Project::factory()->create(['health_score' => 100]);
+        ProjectHealthExplanation::factory()->explained()->for($project)->create([
+            'health_score' => 100,
+            'health_band' => HealthScoreBand::Healthy->value,
+            'explained_at' => now()->subDays(8),
+            'updated_at' => now()->subMinutes(10),
+        ]);
+
+        app(RefreshProjectHealthScoreAction::class)->execute($project);
+
+        Queue::assertNotPushed(GenerateProjectHealthExplanationJob::class);
+    }
+
+    public function test_health_explanation_dispatch_is_skipped_when_ai_is_disabled(): void
+    {
+        Event::fake([HealthScoreUpdated::class]);
+        Queue::fake();
+        config(['services.llm.enabled' => false]);
+        $project = Project::factory()->create(['health_score' => 100]);
+        ProjectHealthExplanation::factory()->explained()->for($project)->create([
+            'explained_at' => now()->subDays(8),
+            'updated_at' => now()->subHour(),
+        ]);
+
+        app(RefreshProjectHealthScoreAction::class)->execute($project);
+
+        Queue::assertNotPushed(GenerateProjectHealthExplanationJob::class);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
     }
 }


### PR DESCRIPTION
Closes #134

Spec: specs/phase-10-innovation/045-ai-pr-risk-score-and-project-health-explanation.md

## Summary
- Adds AI insight persistence, bounded snapshots, generation actions, queued jobs, PR webhook dispatch, health-score refresh integration, and scoped PR risk backfill.
- Surfaces PR risk in Work Items with regenerate support, and adds project health explanation overlays/regenerate support on Overview.
- Sends conservative Spec 042 notifications only for material high/critical PR risk increases, with prompt-safety and operator checklist updates.

## Test plan
- [x] `php artisan test` — 978 passed, 3706 assertions
- [x] `npm run build` — passed
- [x] `vendor/bin/pint --dirty --test` — passed
- [x] Fresh 4-lens self-review completed; findings fixed in `ca181c6`
- [x] Scoped fix validation passed: 26 tests, 111 assertions

## Self-review notes
- Ran fresh risk/reliability/resilience/readability review because this is a large AI/webhook/notification/UI change.
- Fixed review findings: removed PR body preview from LLM snapshots, aligned jobs to fail-closed/no queue retry, marked pending rows skipped when AI is disabled at execution time, and allowed resolved historical alerts to re-notify on later material risk increase.
- Known limitation: project health delta remains null until Nexus has a historical health-score source; explanations still use current bounded health drivers.
