### PR TITLE
feat(ui): add focused skeleton loading states

### DIFF
--- a/resources/js/Components/Dashboard/RiskyProjects.vue
+++ b/resources/js/Components/Dashboard/RiskyProjects.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import HealthScoreBadge from '@/Components/Project/HealthScoreBadge.vue';
+import Skeleton from '@/Components/Skeleton/Skeleton.vue';
 import { projectIcon } from '@/lib/projectIcons';
 import type { RiskyProjectRow } from '@/types';
 import { Link, router } from '@inertiajs/vue3';
 import { FolderKanban, RefreshCw, ShieldCheck } from 'lucide-vue-next';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 
 /**
  * Spec 035 — Overview "Risky projects" panel. The query layer
@@ -29,6 +30,7 @@ const props = defineProps<{
 }>();
 
 const HIDING_BANDS = new Set(['healthy', 'good']);
+const regeneratingSlug = ref<string | null>(null);
 
 const shouldShowList = computed<boolean>(() => {
     if (props.projects.length === 0) {
@@ -68,10 +70,16 @@ const fallbackSummary = (project: RiskyProjectRow): string => {
 };
 
 const regenerateExplanation = (project: RiskyProjectRow): void => {
+    regeneratingSlug.value = project.slug;
     router.post(
         route('overview.projects.health-explanation.regenerate', project.slug),
         {},
-        { preserveScroll: true },
+        {
+            preserveScroll: true,
+            onFinish: () => {
+                regeneratingSlug.value = null;
+            },
+        },
     );
 };
 </script>
@@ -212,11 +220,27 @@ const regenerateExplanation = (project: RiskyProjectRow): void => {
                                     v-if="props.canRegenerate"
                                     type="button"
                                     class="inline-flex items-center justify-center gap-1.5 rounded-md border border-accent-cyan/30 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.16em] text-accent-cyan transition hover:border-accent-cyan/60 hover:bg-accent-cyan/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                    :disabled="regeneratingSlug !== null"
                                     @click="regenerateExplanation(project)"
                                 >
-                                    <RefreshCw class="h-3 w-3" aria-hidden="true" />
-                                    Regenerate
+                                    <RefreshCw
+                                        class="h-3 w-3"
+                                        :class="{ 'animate-spin': regeneratingSlug === project.slug }"
+                                        aria-hidden="true"
+                                    />
+                                    {{ regeneratingSlug === project.slug ? 'Regenerating…' : 'Regenerate' }}
                                 </button>
+                            </div>
+
+                            <div
+                                v-if="regeneratingSlug === project.slug"
+                                class="space-y-2 rounded-md border border-accent-cyan/20 bg-accent-cyan/5 p-3"
+                                role="status"
+                                aria-label="Regenerating health explanation"
+                            >
+                                <Skeleton width="70%" height="0.75rem" />
+                                <Skeleton width="45%" height="0.75rem" />
+                                <span class="sr-only">Regenerating health explanation</span>
                             </div>
                         </div>
                     </details>

--- a/resources/js/Pages/Alerts/Index.vue
+++ b/resources/js/Pages/Alerts/Index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import SkeletonRow from '@/Components/Skeleton/SkeletonRow.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import type { PageProps } from '@/types';
 import { Head, router, usePage } from '@inertiajs/vue3';
@@ -68,6 +69,8 @@ const props = defineProps<{
 const page = usePage<PageProps>();
 
 const filterDraft = ref<FilterState>({ ...props.filters });
+const isAlertsLoading = ref(false);
+const actingAlertId = ref<number | null>(null);
 
 const hasFilterActive = computed<boolean>(() => {
     const f = props.filters;
@@ -99,6 +102,12 @@ const applyFilters = () => {
         preserveScroll: true,
         preserveState: true,
         only: ['alerts', 'filters', 'filterOptions'],
+        onStart: () => {
+            isAlertsLoading.value = true;
+        },
+        onFinish: () => {
+            isAlertsLoading.value = false;
+        },
     });
 };
 
@@ -116,28 +125,52 @@ const clearFilters = () => {
             preserveScroll: true,
             preserveState: true,
             only: ['alerts', 'filters', 'filterOptions'],
+            onStart: () => {
+                isAlertsLoading.value = true;
+            },
+            onFinish: () => {
+                isAlertsLoading.value = false;
+            },
         },
     );
 };
 
 const acknowledge = (alert: AlertRow) => {
+    actingAlertId.value = alert.id;
     router.post(
         route('alerts.acknowledge', alert.id),
         {},
-        { preserveScroll: true },
+        {
+            preserveScroll: true,
+            onFinish: () => {
+                actingAlertId.value = null;
+            },
+        },
     );
 };
 
 const resolve = (alert: AlertRow) => {
+    actingAlertId.value = alert.id;
     router.post(
         route('alerts.resolve', alert.id),
         {},
-        { preserveScroll: true },
+        {
+            preserveScroll: true,
+            onFinish: () => {
+                actingAlertId.value = null;
+            },
+        },
     );
 };
 
 const mute = (alert: AlertRow) => {
-    router.post(route('alerts.mute', alert.id), {}, { preserveScroll: true });
+    actingAlertId.value = alert.id;
+    router.post(route('alerts.mute', alert.id), {}, {
+        preserveScroll: true,
+        onFinish: () => {
+            actingAlertId.value = null;
+        },
+    });
 };
 
 const capitalize = (value: string | null): string =>
@@ -190,7 +223,15 @@ onMounted(() => {
     const channel = window.Echo.private(channelName);
 
     const reloadList = () => {
-        router.reload({ only: ['alerts', 'filters', 'filterOptions'] });
+        router.reload({
+            only: ['alerts', 'filters', 'filterOptions'],
+            onStart: () => {
+                isAlertsLoading.value = true;
+            },
+            onFinish: () => {
+                isAlertsLoading.value = false;
+            },
+        });
     };
 
     channel.listen('.AlertTriggered', reloadList);
@@ -381,7 +422,17 @@ onBeforeUnmount(() => {
             </header>
 
             <div
-                v-if="alerts.length === 0 && !hasFilterActive"
+                v-if="isAlertsLoading"
+                class="flex flex-col gap-2"
+                role="status"
+                aria-label="Loading alerts"
+            >
+                <SkeletonRow v-for="n in 4" :key="n" />
+                <span class="sr-only">Loading alerts</span>
+            </div>
+
+            <div
+                v-else-if="alerts.length === 0 && !hasFilterActive"
                 class="glass-card flex flex-col items-center justify-center gap-3 px-6 py-16 text-center"
             >
                 <span
@@ -505,31 +556,34 @@ onBeforeUnmount(() => {
                             v-if="alert.can_acknowledge"
                             type="button"
                             class="inline-flex items-center gap-1 rounded-md border border-border-subtle bg-background-panel-hover px-2 py-1 text-xs font-semibold text-text-secondary transition hover:border-accent-cyan/60 hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                            :disabled="actingAlertId !== null"
                             @click="acknowledge(alert)"
                         >
                             <Eye class="h-3 w-3" aria-hidden="true" />
-                            Ack
+                            {{ actingAlertId === alert.id ? 'Saving…' : 'Ack' }}
                         </button>
                         <button
                             v-if="alert.can_resolve"
                             type="button"
                             class="inline-flex items-center gap-1 rounded-md border border-status-success/40 bg-status-success/10 px-2 py-1 text-xs font-semibold text-status-success transition hover:border-status-success/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-status-success/60"
+                            :disabled="actingAlertId !== null"
                             @click="resolve(alert)"
                         >
                             <CheckCircle2
                                 class="h-3 w-3"
                                 aria-hidden="true"
                             />
-                            Resolve
+                            {{ actingAlertId === alert.id ? 'Saving…' : 'Resolve' }}
                         </button>
                         <button
                             v-if="alert.can_mute"
                             type="button"
                             class="inline-flex items-center gap-1 rounded-md border border-border-subtle bg-background-panel-hover px-2 py-1 text-xs font-semibold text-text-muted transition hover:border-status-warning/40 hover:text-status-warning focus:outline-none focus-visible:ring-2 focus-visible:ring-status-warning/60"
+                            :disabled="actingAlertId !== null"
                             @click="mute(alert)"
                         >
                             <BellOff class="h-3 w-3" aria-hidden="true" />
-                            Mute
+                            {{ actingAlertId === alert.id ? 'Saving…' : 'Mute' }}
                         </button>
                         <a
                             v-if="alert.affected_entity_url"

--- a/resources/js/Pages/Analytics/Index.vue
+++ b/resources/js/Pages/Analytics/Index.vue
@@ -3,6 +3,7 @@ import DateRangeFilter, {
     type RangeOption,
 } from '@/Components/Analytics/DateRangeFilter.vue';
 import KpiCard from '@/Components/Dashboard/KpiCard.vue';
+import SkeletonCard from '@/Components/Skeleton/SkeletonCard.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import { Head, router } from '@inertiajs/vue3';
 import {
@@ -16,7 +17,7 @@ import {
     ShieldCheck,
     Timer,
 } from 'lucide-vue-next';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 
 type Status = 'success' | 'warning' | 'danger' | 'info' | 'muted';
 
@@ -70,12 +71,20 @@ const props = defineProps<{
     };
 }>();
 
+const isRangeLoading = ref(false);
+
 const onRangeChange = (range: RangeOption) => {
     if (range === props.filters.range) return;
     router.visit(route('analytics.index'), {
         data: { range },
         preserveScroll: true,
         preserveState: false,
+        onStart: () => {
+            isRangeLoading.value = true;
+        },
+        onFinish: () => {
+            isRangeLoading.value = false;
+        },
     });
 };
 
@@ -136,8 +145,14 @@ const formatInt = (n: number | null): string =>
 
             <div
                 class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4"
+                :aria-busy="isRangeLoading"
             >
+                <template v-if="isRangeLoading">
+                    <SkeletonCard v-for="n in 8" :key="n" />
+                </template>
+
                 <KpiCard
+                    v-else
                     label="Deployment frequency"
                     :value="formatInt(props.metrics.deployments.frequency.total)"
                     secondary="Completed runs"
@@ -146,6 +161,7 @@ const formatInt = (n: number | null): string =>
                     :sparkline="props.metrics.deployments.frequency.sparkline"
                 />
                 <KpiCard
+                    v-if="!isRangeLoading"
                     label="Deployment success"
                     :value="formatPercent(props.metrics.deployments.success_rate.percent)"
                     secondary="Success / (success + failure)"
@@ -155,6 +171,7 @@ const formatInt = (n: number | null): string =>
                     :status-label="props.metrics.deployments.success_rate.percent === null ? 'No data' : 'Last range'"
                 />
                 <KpiCard
+                    v-if="!isRangeLoading"
                     label="Alert frequency"
                     :value="formatInt(props.metrics.alerts.frequency.total)"
                     secondary="Triggered in range"
@@ -163,6 +180,7 @@ const formatInt = (n: number | null): string =>
                     :sparkline="props.metrics.alerts.frequency.sparkline"
                 />
                 <KpiCard
+                    v-if="!isRangeLoading"
                     label="Mean time to recovery"
                     :value="props.metrics.alerts.mttr.label ?? '—'"
                     secondary="Resolved alerts only"
@@ -172,6 +190,7 @@ const formatInt = (n: number | null): string =>
                     :status-label="props.metrics.alerts.mttr.seconds === null ? 'No data' : 'Avg'"
                 />
                 <KpiCard
+                    v-if="!isRangeLoading"
                     label="Website uptime"
                     :value="formatPercent(props.metrics.websites.uptime.percent)"
                     secondary="Volume-weighted"
@@ -182,6 +201,7 @@ const formatInt = (n: number | null): string =>
                     :sparkline="props.metrics.websites.uptime.sparkline"
                 />
                 <KpiCard
+                    v-if="!isRangeLoading"
                     label="Response time"
                     :value="formatMs(props.metrics.websites.response_time.avg_ms)"
                     secondary="Average over up checks"
@@ -192,6 +212,7 @@ const formatInt = (n: number | null): string =>
                     :sparkline="fillNulls(props.metrics.websites.response_time.sparkline)"
                 />
                 <KpiCard
+                    v-if="!isRangeLoading"
                     label="Container CPU"
                     :value="formatPercent(props.metrics.containers.cpu.percent)"
                     secondary="Across user hosts"
@@ -202,6 +223,7 @@ const formatInt = (n: number | null): string =>
                     :sparkline="fillNulls(props.metrics.containers.cpu.sparkline)"
                 />
                 <KpiCard
+                    v-if="!isRangeLoading"
                     label="Container memory"
                     :value="formatPercent(props.metrics.containers.memory.percent)"
                     secondary="Across user hosts"

--- a/resources/js/Pages/Deployments/Index.vue
+++ b/resources/js/Pages/Deployments/Index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import SkeletonRow from '@/Components/Skeleton/SkeletonRow.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import {
     conclusionLabel,
@@ -92,6 +93,7 @@ const props = defineProps<{
 // Mirror the URL filter shape into reactive locals so dropdowns work
 // against `v-model` without poking the prop directly.
 const filterDraft = ref<FilterState>({ ...props.filters });
+const isTimelineLoading = ref(false);
 
 // Status / conclusion are static enums on the PHP side — hard-coded
 // here is safer than serializing them through Inertia (no type drift
@@ -143,6 +145,12 @@ const applyFilters = () => {
         preserveScroll: true,
         preserveState: true,
         only: ['deployments', 'filters', 'filterOptions'],
+        onStart: () => {
+            isTimelineLoading.value = true;
+        },
+        onFinish: () => {
+            isTimelineLoading.value = false;
+        },
     });
 };
 
@@ -167,6 +175,24 @@ const clearFilters = () => {
 const refresh = () => {
     router.reload({
         only: ['deployments', 'filterOptions'],
+        onStart: () => {
+            isTimelineLoading.value = true;
+        },
+        onFinish: () => {
+            isTimelineLoading.value = false;
+        },
+    });
+};
+
+const refreshTimeline = () => {
+    router.reload({
+        only: ['deployments', 'filterOptions'],
+        onStart: () => {
+            isTimelineLoading.value = true;
+        },
+        onFinish: () => {
+            isTimelineLoading.value = false;
+        },
     });
 };
 
@@ -265,9 +291,7 @@ onMounted(() => {
         // newly-imported repository arrives — without `filterOptions`
         // here, the new repo wouldn't appear in the dropdown until the
         // user navigates away and back.
-        router.reload({
-            only: ['deployments', 'filterOptions'],
-        });
+        refreshTimeline();
     });
 
     const connector = window.Echo.connector;
@@ -353,10 +377,15 @@ onBeforeUnmount(() => {
                     <button
                         type="button"
                         class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/15 px-3 py-2 text-sm font-semibold text-accent-cyan transition hover:border-accent-cyan/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                        :disabled="isTimelineLoading"
                         @click="refresh"
                     >
-                        <RefreshCcw class="h-4 w-4" aria-hidden="true" />
-                        Refresh
+                        <RefreshCcw
+                            class="h-4 w-4"
+                            :class="{ 'animate-spin': isTimelineLoading }"
+                            aria-hidden="true"
+                        />
+                        {{ isTimelineLoading ? 'Refreshing…' : 'Refresh' }}
                     </button>
                 </div>
             </header>
@@ -480,9 +509,19 @@ onBeforeUnmount(() => {
                 </button>
             </section>
 
+            <div
+                v-if="isTimelineLoading"
+                class="flex flex-col gap-2"
+                role="status"
+                aria-label="Loading deployments"
+            >
+                <SkeletonRow v-for="n in 5" :key="n" />
+                <span class="sr-only">Loading deployments</span>
+            </div>
+
             <!-- Empty states -->
             <div
-                v-if="deployments.length === 0 && !hasActiveFilter"
+                v-else-if="deployments.length === 0 && !hasActiveFilter"
                 class="glass-card flex flex-col items-center justify-center gap-3 px-6 py-16 text-center"
             >
                 <span

--- a/resources/js/Pages/Monitoring/Hosts/Show.vue
+++ b/resources/js/Pages/Monitoring/Hosts/Show.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import Sparkline from '@/Components/Dashboard/Sparkline.vue';
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import SkeletonCard from '@/Components/Skeleton/SkeletonCard.vue';
 import AgentTokenPanel from '@/Components/Hosts/AgentTokenPanel.vue';
 import ContainerTable from '@/Components/Hosts/ContainerTable.vue';
 import HostMetricsPanel from '@/Components/Hosts/HostMetricsPanel.vue';
@@ -161,6 +162,7 @@ const currentMemory = computed<number | null>(
 // agent posts telemetry. Filter client-side by host_id and partial-
 // reload host + telemetry props on a match. Mirrors spec 025.
 const realtimeConnected = ref<boolean | null>(null);
+const isTelemetryLoading = ref(false);
 let teardown: (() => void) | null = null;
 
 onMounted(() => {
@@ -183,7 +185,15 @@ onMounted(() => {
         '.HostTelemetryRecorded',
         (payload: { host_id: number }) => {
             if (payload.host_id !== props.host.id) return;
-            router.reload({ only: ['host', 'telemetry'] });
+            router.reload({
+                only: ['host', 'telemetry'],
+                onStart: () => {
+                    isTelemetryLoading.value = true;
+                },
+                onFinish: () => {
+                    isTelemetryLoading.value = false;
+                },
+            });
         },
     );
 
@@ -400,7 +410,18 @@ onBeforeUnmount(() => {
             </section>
 
             <section
-                v-if="telemetry.current === null"
+                v-if="isTelemetryLoading"
+                class="grid gap-4 sm:grid-cols-2"
+                role="status"
+                aria-label="Loading telemetry"
+            >
+                <SkeletonCard />
+                <SkeletonCard />
+                <span class="sr-only">Loading telemetry</span>
+            </section>
+
+            <section
+                v-else-if="telemetry.current === null"
                 class="glass-card flex flex-col items-center gap-3 border-dashed p-8 text-center"
             >
                 <Clock

--- a/resources/js/Pages/Monitoring/Websites/Index.vue
+++ b/resources/js/Pages/Monitoring/Websites/Index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import SkeletonRow from '@/Components/Skeleton/SkeletonRow.vue';
 import { websiteStatusTone as statusTone } from '@/lib/websiteStyles';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import { Head, Link, router } from '@inertiajs/vue3';
@@ -41,6 +42,7 @@ const props = defineProps<{
 // four consumers stay in sync when the WebsiteStatus enum grows.
 
 const statusFilter = ref<string | null>(props.filters.status);
+const isFiltering = ref(false);
 
 // Status lives in the query string so a filtered view is shareable and
 // survives reload — same pattern as the Deployments timeline filters.
@@ -52,6 +54,12 @@ const applyFilter = () => {
             preserveScroll: true,
             preserveState: true,
             only: ['websites', 'filters', 'filterOptions'],
+            onStart: () => {
+                isFiltering.value = true;
+            },
+            onFinish: () => {
+                isFiltering.value = false;
+            },
         },
     );
 };
@@ -137,7 +145,17 @@ const projectAccentClass = (color: string | null) =>
             </header>
 
             <div
-                v-if="websites.length === 0 && !statusFilter"
+                v-if="isFiltering"
+                class="flex flex-col gap-2"
+                role="status"
+                aria-label="Loading website monitors"
+            >
+                <SkeletonRow v-for="n in 4" :key="n" />
+                <span class="sr-only">Loading website monitors</span>
+            </div>
+
+            <div
+                v-else-if="websites.length === 0 && !statusFilter"
                 class="glass-card flex flex-col items-center justify-center gap-3 px-6 py-16 text-center"
             >
                 <span

--- a/resources/js/Pages/Monitoring/Websites/Show.vue
+++ b/resources/js/Pages/Monitoring/Websites/Show.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import Sparkline from '@/Components/Dashboard/Sparkline.vue';
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import SkeletonRow from '@/Components/Skeleton/SkeletonRow.vue';
 import { websiteStatusTone as statusTone } from '@/lib/websiteStyles';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import type { PageProps } from '@/types';
@@ -69,6 +70,7 @@ const props = defineProps<{
 // `onMounted` works today but is idiomatically wrong (Inertia could
 // validate the call site at any release).
 const page = usePage<PageProps>();
+const isProbeLoading = ref(false);
 
 const formatUptime = (rate: number | null): string =>
     rate === null ? '—%' : `${rate}%`;
@@ -93,7 +95,15 @@ const runProbe = () => {
     router.post(
         route('monitoring.websites.probe', props.website.id),
         {},
-        { preserveScroll: true },
+        {
+            preserveScroll: true,
+            onStart: () => {
+                isProbeLoading.value = true;
+            },
+            onFinish: () => {
+                isProbeLoading.value = false;
+            },
+        },
     );
 };
 
@@ -159,7 +169,15 @@ onMounted(() => {
             // Only react to pulses for our own website. Other monitors'
             // pulses arrive on the same channel.
             if (payload.website_id !== props.website.id) return;
-            router.reload({ only: ['website', 'summary', 'checks'] });
+            router.reload({
+                only: ['website', 'summary', 'checks'],
+                onStart: () => {
+                    isProbeLoading.value = true;
+                },
+                onFinish: () => {
+                    isProbeLoading.value = false;
+                },
+            });
         },
     );
 
@@ -272,10 +290,15 @@ onBeforeUnmount(() => {
                             v-if="canProbe"
                             type="button"
                             class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/15 px-3 py-2 text-sm font-semibold text-accent-cyan transition hover:border-accent-cyan/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                            :disabled="isProbeLoading"
                             @click="runProbe"
                         >
-                            <Play class="h-4 w-4" aria-hidden="true" />
-                            Probe now
+                            <Play
+                                class="h-4 w-4"
+                                :class="{ 'animate-pulse': isProbeLoading }"
+                                aria-hidden="true"
+                            />
+                            {{ isProbeLoading ? 'Probing…' : 'Probe now' }}
                         </button>
                         <Link
                             v-if="canUpdate"
@@ -426,7 +449,19 @@ onBeforeUnmount(() => {
                 </p>
 
                 <ul
-                    v-if="checks.length > 0"
+                    v-if="isProbeLoading"
+                    class="mt-4 flex flex-col gap-2"
+                    role="status"
+                    aria-label="Loading recent checks"
+                >
+                    <li v-for="n in 3" :key="n">
+                        <SkeletonRow />
+                    </li>
+                    <span class="sr-only">Loading recent checks</span>
+                </ul>
+
+                <ul
+                    v-else-if="checks.length > 0"
                     class="mt-2 divide-y divide-border-subtle"
                 >
                     <li

--- a/resources/js/Pages/Overview.vue
+++ b/resources/js/Pages/Overview.vue
@@ -4,6 +4,7 @@ import KpiCard from '@/Components/Dashboard/KpiCard.vue';
 import RiskyProjects from '@/Components/Dashboard/RiskyProjects.vue';
 import Sparkline from '@/Components/Dashboard/Sparkline.vue';
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import SkeletonCard from '@/Components/Skeleton/SkeletonCard.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import { hostStatusTone } from '@/lib/hostStyles';
 import type { ActivityHeatmapPayload, DashboardPayload, PageProps } from '@/types';
@@ -19,7 +20,7 @@ import {
     Server,
     ShieldCheck,
 } from 'lucide-vue-next';
-import { onBeforeUnmount, onMounted } from 'vue';
+import { onBeforeUnmount, onMounted, ref } from 'vue';
 
 interface TopWorkItem {
     id: string;
@@ -53,6 +54,7 @@ defineProps<{
 // fires; the visible payoff arrives in 035 when Overview renders the
 // "Risky projects" panel + per-project chips that this reload feeds.
 const page = usePage<PageProps>();
+const isDashboardRefreshing = ref(false);
 let teardown: (() => void) | null = null;
 
 onMounted(() => {
@@ -66,7 +68,15 @@ onMounted(() => {
     const channel = window.Echo.private(channelName);
 
     const refreshDashboard = () => {
-        router.reload({ only: ['dashboard'] });
+        router.reload({
+            only: ['dashboard'],
+            onStart: () => {
+                isDashboardRefreshing.value = true;
+            },
+            onFinish: () => {
+                isDashboardRefreshing.value = false;
+            },
+        });
     };
 
     channel.listen('.HealthScoreUpdated', refreshDashboard);
@@ -121,8 +131,14 @@ const stubServices = [
             <section
                 aria-label="Key metrics"
                 class="grid grid-cols-2 gap-4 md:grid-cols-3 xl:grid-cols-6"
+                :aria-busy="isDashboardRefreshing"
             >
+                <template v-if="isDashboardRefreshing">
+                    <SkeletonCard v-for="n in 6" :key="n" />
+                </template>
+
                 <KpiCard
+                    v-else
                     :icon="FolderKanban"
                     accent="cyan"
                     label="Projects"
@@ -138,6 +154,7 @@ const stubServices = [
                     :sparkline="dashboard.projects.sparkline"
                 />
                 <KpiCard
+                    v-if="!isDashboardRefreshing"
                     :icon="Rocket"
                     accent="blue"
                     label="Deployments (24h)"
@@ -159,6 +176,7 @@ const stubServices = [
                     :sparkline="dashboard.deployments.sparkline"
                 />
                 <KpiCard
+                    v-if="!isDashboardRefreshing"
                     :icon="ShieldCheck"
                     accent="success"
                     label="Services"
@@ -173,6 +191,7 @@ const stubServices = [
                     :sparkline="dashboard.services.sparkline"
                 />
                 <KpiCard
+                    v-if="!isDashboardRefreshing"
                     :icon="Server"
                     accent="purple"
                     label="Hosts"
@@ -191,6 +210,7 @@ const stubServices = [
                     :sparkline="dashboard.hosts.sparkline"
                 />
                 <KpiCard
+                    v-if="!isDashboardRefreshing"
                     :icon="Bell"
                     accent="danger"
                     label="Alerts"
@@ -205,6 +225,7 @@ const stubServices = [
                     :sparkline="dashboard.alerts.sparkline"
                 />
                 <KpiCard
+                    v-if="!isDashboardRefreshing"
                     :icon="HeartPulse"
                     accent="magenta"
                     label="Uptime"

--- a/resources/js/Pages/Repositories/Show.vue
+++ b/resources/js/Pages/Repositories/Show.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import SkeletonRow from '@/Components/Skeleton/SkeletonRow.vue';
 import { projectIcon } from '@/lib/projectIcons';
 import {
     conclusionLabel as workflowConclusionLabel,
@@ -692,7 +693,11 @@ onBeforeUnmount(stopPolling);
                             :disabled="isIssuesSyncing"
                             @click="runIssuesSync"
                         >
-                            <RefreshCcw class="h-4 w-4" aria-hidden="true" />
+                            <RefreshCcw
+                                class="h-4 w-4"
+                                :class="{ 'animate-spin': isIssuesSyncing }"
+                                aria-hidden="true"
+                            />
                             {{ isIssuesSyncing ? 'Syncing…' : 'Run sync' }}
                         </button>
                     </header>
@@ -710,8 +715,18 @@ onBeforeUnmount(stopPolling);
                         </span>
                     </p>
 
+                    <div
+                        v-if="isIssuesSyncing && issues.length === 0"
+                        class="mt-4 flex flex-col gap-2"
+                        role="status"
+                        aria-label="Loading issues"
+                    >
+                        <SkeletonRow v-for="n in 3" :key="n" />
+                        <span class="sr-only">Loading issues</span>
+                    </div>
+
                     <ul
-                        v-if="issues.length > 0"
+                        v-else-if="issues.length > 0"
                         class="mt-2 divide-y divide-border-subtle"
                     >
                         <li
@@ -825,7 +840,11 @@ onBeforeUnmount(stopPolling);
                             :disabled="isPullRequestsSyncing"
                             @click="runPullRequestsSync"
                         >
-                            <RefreshCcw class="h-4 w-4" aria-hidden="true" />
+                            <RefreshCcw
+                                class="h-4 w-4"
+                                :class="{ 'animate-spin': isPullRequestsSyncing }"
+                                aria-hidden="true"
+                            />
                             {{ isPullRequestsSyncing ? 'Syncing…' : 'Run sync' }}
                         </button>
                     </header>
@@ -843,8 +862,18 @@ onBeforeUnmount(stopPolling);
                         </span>
                     </p>
 
+                    <div
+                        v-if="isPullRequestsSyncing && pullRequests.length === 0"
+                        class="mt-4 flex flex-col gap-2"
+                        role="status"
+                        aria-label="Loading pull requests"
+                    >
+                        <SkeletonRow v-for="n in 3" :key="n" />
+                        <span class="sr-only">Loading pull requests</span>
+                    </div>
+
                     <ul
-                        v-if="pullRequests.length > 0"
+                        v-else-if="pullRequests.length > 0"
                         class="mt-2 divide-y divide-border-subtle"
                     >
                         <li
@@ -968,7 +997,11 @@ onBeforeUnmount(stopPolling);
                             :disabled="isWorkflowRunsSyncing"
                             @click="runWorkflowRunsSync"
                         >
-                            <RefreshCcw class="h-4 w-4" aria-hidden="true" />
+                            <RefreshCcw
+                                class="h-4 w-4"
+                                :class="{ 'animate-spin': isWorkflowRunsSyncing }"
+                                aria-hidden="true"
+                            />
                             {{ isWorkflowRunsSyncing ? 'Syncing…' : 'Run sync' }}
                         </button>
                     </header>
@@ -986,8 +1019,18 @@ onBeforeUnmount(stopPolling);
                         </span>
                     </p>
 
+                    <div
+                        v-if="isWorkflowRunsSyncing && workflowRuns.length === 0"
+                        class="mt-4 flex flex-col gap-2"
+                        role="status"
+                        aria-label="Loading workflow runs"
+                    >
+                        <SkeletonRow v-for="n in 3" :key="n" />
+                        <span class="sr-only">Loading workflow runs</span>
+                    </div>
+
                     <ul
-                        v-if="workflowRuns.length > 0"
+                        v-else-if="workflowRuns.length > 0"
                         class="mt-2 divide-y divide-border-subtle"
                     >
                         <li

--- a/resources/js/Pages/WorkItems/Index.vue
+++ b/resources/js/Pages/WorkItems/Index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import StatusBadge from '@/Components/Dashboard/StatusBadge.vue';
+import SkeletonRow from '@/Components/Skeleton/SkeletonRow.vue';
 import AppLayout from '@/Layouts/AppLayout.vue';
 import { Head, router } from '@inertiajs/vue3';
 import {
@@ -11,7 +12,7 @@ import {
     Search,
     Sparkles,
 } from 'lucide-vue-next';
-import { reactive, watch } from 'vue';
+import { reactive, ref, watch } from 'vue';
 
 interface RepositoryRef {
     id: number;
@@ -67,6 +68,9 @@ const local = reactive<Filters>({
     q: props.filters.q,
 });
 
+const isFiltering = ref(false);
+const regeneratingRiskId = ref<string | null>(null);
+
 const itemStateTone = (item: WorkItem) => {
     if (item.kind === 'pull_request') {
         return (
@@ -111,11 +115,17 @@ const riskLabel = (assessment: PullRequestRiskAssessment | null | undefined) => 
 
 const regenerateRisk = (item: WorkItem) => {
     if (item.kind !== 'pull_request' || !props.canRegeneratePrRisk) return;
+    regeneratingRiskId.value = item.id;
 
     router.post(
         route('work-items.pull-requests.risk.regenerate', item.id.replace('pull-', '')),
         {},
-        { preserveScroll: true },
+        {
+            preserveScroll: true,
+            onFinish: () => {
+                regeneratingRiskId.value = null;
+            },
+        },
     );
 };
 
@@ -135,6 +145,12 @@ const applyFilters = () => {
             preserveState: false,
             preserveScroll: true,
             replace: true,
+            onStart: () => {
+                isFiltering.value = true;
+            },
+            onFinish: () => {
+                isFiltering.value = false;
+            },
         },
     );
 };
@@ -276,9 +292,20 @@ watch(
             <section
                 aria-label="Items"
                 class="glass-card p-0"
+                :aria-busy="isFiltering"
             >
+                <div
+                    v-if="isFiltering"
+                    class="flex flex-col gap-2 p-4"
+                    role="status"
+                    aria-label="Loading work items"
+                >
+                    <SkeletonRow v-for="n in 4" :key="n" />
+                    <span class="sr-only">Loading work items</span>
+                </div>
+
                 <ul
-                    v-if="items.length > 0"
+                    v-else-if="items.length > 0"
                     class="divide-y divide-border-subtle"
                 >
                     <li
@@ -410,11 +437,23 @@ watch(
                                     v-if="canRegeneratePrRisk"
                                     type="button"
                                     class="inline-flex items-center gap-2 rounded-lg border border-accent-cyan/40 bg-accent-cyan/15 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-accent-cyan transition hover:border-accent-cyan/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent-cyan/60"
+                                    :disabled="regeneratingRiskId !== null"
                                     @click="regenerateRisk(item)"
                                 >
-                                    <Sparkles class="h-3.5 w-3.5" aria-hidden="true" />
-                                    Regenerate
+                                    <Sparkles
+                                        class="h-3.5 w-3.5"
+                                        :class="{ 'animate-pulse': regeneratingRiskId === item.id }"
+                                        aria-hidden="true"
+                                    />
+                                    {{ regeneratingRiskId === item.id ? 'Regenerating…' : 'Regenerate' }}
                                 </button>
+                            </div>
+                            <div
+                                v-if="regeneratingRiskId === item.id"
+                                class="mt-3 rounded-lg border border-accent-cyan/20 bg-accent-cyan/5 p-3 text-xs text-text-muted"
+                                role="status"
+                            >
+                                Risk regeneration is queued. The panel will update after the request completes.
                             </div>
                             <dl class="mt-3 grid gap-3 sm:grid-cols-3">
                                 <div>


### PR DESCRIPTION
## Summary
- Adds focused skeleton/loading states to real async boundaries across Overview, Work Items, Deployments, Monitoring, Analytics, Alerts, and repository detail views.
- Uses existing skeleton primitives without adding fake loaders to fully-rendered static pages.
- Keeps Projects, Repositories index, and Hosts index unchanged because they do not have useful async/filter loading boundaries yet.

## Test plan
- [x] `npm run build` — passed
- [x] `git diff --check` — passed
- [x] Fresh reliability review completed with no findings

## Self-review notes
- No backend/PHP files changed, so PHP tests and Pint were not run.
- Realtime Echo-triggered states were build-verified but not manually smoke-tested in a live browser session.
